### PR TITLE
fix: data quality check URL fallback when env var is empty

### DIFF
--- a/scripts/check_data_quality.py
+++ b/scripts/check_data_quality.py
@@ -14,7 +14,7 @@ import sys
 
 import httpx
 
-API_URL = os.getenv("REPORIUM_API_URL", "https://reporium-api-573778300586.us-central1.run.app")
+API_URL = os.getenv("REPORIUM_API_URL") or "https://reporium-api-573778300586.us-central1.run.app"
 API_KEY = os.getenv("INGESTION_API_KEY", "")
 GH_TOKEN = os.getenv("GH_TOKEN", "")
 


### PR DESCRIPTION
## Summary
- Fixes data quality check failing with `httpx.UnsupportedProtocol`
- Root cause: `REPORIUM_API_URL` secret was an empty string, overriding the hardcoded default
- Fix: use `or` instead of `default=` so empty string triggers fallback

## Test plan
- [ ] Data Quality Check workflow passes after merge
- [ ] `REPORIUM_API_URL` secret now also set correctly in repo settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)