### PR TITLE
fix: restrict CORS allow_origins from wildcard to reporium.com (#7)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -134,9 +134,15 @@ async def redoc_redirect() -> HTMLResponse:
     )
 
 
+_ALLOWED_ORIGINS = [
+    "https://reporium.com",
+    "https://www.reporium.com",
+    "https://perditioinc.github.io",
+]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=_ALLOWED_ORIGINS,
     allow_methods=["GET", "POST"],
     allow_headers=["*"],
 )

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -1,0 +1,32 @@
+"""Tests for CORS middleware — verifies allowed and blocked origins."""
+
+import pytest
+from httpx import AsyncClient
+
+
+@pytest.mark.asyncio
+async def test_cors_allowed_origin_reporium(client: AsyncClient):
+    """reporium.com must be allowed."""
+    response = await client.get("/health", headers={"Origin": "https://reporium.com"})
+    assert response.headers.get("access-control-allow-origin") == "https://reporium.com"
+
+
+@pytest.mark.asyncio
+async def test_cors_allowed_origin_www(client: AsyncClient):
+    """www.reporium.com must be allowed."""
+    response = await client.get("/health", headers={"Origin": "https://www.reporium.com"})
+    assert response.headers.get("access-control-allow-origin") == "https://www.reporium.com"
+
+
+@pytest.mark.asyncio
+async def test_cors_allowed_origin_github_pages(client: AsyncClient):
+    """perditioinc.github.io must be allowed."""
+    response = await client.get("/health", headers={"Origin": "https://perditioinc.github.io"})
+    assert response.headers.get("access-control-allow-origin") == "https://perditioinc.github.io"
+
+
+@pytest.mark.asyncio
+async def test_cors_blocked_unknown_origin(client: AsyncClient):
+    """Unknown origins must not receive allow-origin header."""
+    response = await client.get("/health", headers={"Origin": "https://evil.example.com"})
+    assert response.headers.get("access-control-allow-origin") is None


### PR DESCRIPTION
## Summary
- Closes #7: `allow_origins=['*']` allowed any origin to call the API
- Restricted to `reporium.com`, `www.reporium.com`, `perditioinc.github.io`
- Added 4 CORS unit tests for allowed and blocked origins

## Test plan
- [ ] 4 new CORS tests pass in CI
- [ ] reporium.com still loads data from API after deploy
- [ ] Unknown origin requests receive no `access-control-allow-origin` header

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)