### PR TITLE
fix: show own stars for built repos instead of 0

### DIFF
--- a/app/models/repo.py
+++ b/app/models/repo.py
@@ -34,10 +34,13 @@ class Repo(Base):
     your_last_push_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
     upstream_last_push_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True))
 
-    # Parent stats
+    # Parent stats (for forks — points to upstream repo)
     parent_stars: Mapped[int | None] = mapped_column(Integer)
     parent_forks: Mapped[int | None] = mapped_column(Integer)
     parent_is_archived: Mapped[bool] = mapped_column(Boolean, default=False, server_default="false")
+
+    # Own star count (for non-fork / built repos)
+    stargazers_count: Mapped[int | None] = mapped_column(Integer)
 
     # Activity
     commits_last_7_days: Mapped[int] = mapped_column(Integer, default=0, server_default="0")

--- a/app/routers/library_full.py
+++ b/app/routers/library_full.py
@@ -345,8 +345,8 @@ def _build_enriched_repo(repo: dict, languages: list, categories: list,
         "language": repo.get("primary_language"),
         "topics": [t["tag"] for t in tags],
         "enrichedTags": list(dict.fromkeys([s["skill"] for s in ai_skills] + [t["tag"] for t in tags])),
-        "stars": repo.get("parent_stars") or 0,
-        "forks": repo.get("parent_forks") or 0,
+        "stars": repo.get("parent_stars") if repo.get("is_fork") else (repo.get("stargazers_count") or 0),
+        "forks": repo.get("parent_forks") if repo.get("is_fork") else 0,
         "lastUpdated": _iso(repo.get("github_updated_at") or repo.get("updated_at")),
         "url": repo.get("github_url") or f"https://github.com/{owner}/{name}",
         "isArchived": repo.get("parent_is_archived") or False,
@@ -673,13 +673,13 @@ async def library_full(db: AsyncSession = Depends(get_db)):
         SELECT id, name, owner, description, is_fork, forked_from, primary_language,
                github_url, fork_sync_state, behind_by, ahead_by,
                upstream_created_at, forked_at, your_last_push_at, upstream_last_push_at,
-               parent_stars, parent_forks, parent_is_archived,
+               parent_stars, parent_forks, parent_is_archived, stargazers_count,
                commits_last_7_days, commits_last_30_days, commits_last_90_days,
                readme_summary, activity_score, ingested_at, updated_at, github_updated_at,
                problem_solved, integration_tags, dependencies
         FROM repos
         WHERE is_private = false
-        ORDER BY parent_stars DESC NULLS LAST;
+        ORDER BY COALESCE(parent_stars, stargazers_count, 0) DESC;
     """))
     rows = result.fetchall()
     columns = result.keys()

--- a/app/schemas/repo.py
+++ b/app/schemas/repo.py
@@ -59,6 +59,7 @@ class RepoSummary(BaseModel):
     parent_stars: int | None = None
     parent_forks: int | None = None
     parent_is_archived: bool = False
+    stargazers_count: int | None = None
 
     commits_last_7_days: int = 0
     commits_last_30_days: int = 0
@@ -135,6 +136,7 @@ class RepoIngestItem(BaseModel):
     parent_stars: int | None = None
     parent_forks: int | None = None
     parent_is_archived: bool = False
+    stargazers_count: int | None = None
 
     commits_last_7_days: int = 0
     commits_last_30_days: int = 0

--- a/migrations/versions/004_add_stargazers_count.py
+++ b/migrations/versions/004_add_stargazers_count.py
@@ -1,0 +1,42 @@
+"""Add stargazers_count to repos for non-fork (built) repos
+
+Revision ID: 004
+Revises: 003
+Create Date: 2026-03-23
+
+parent_stars stores the upstream star count for forks.
+For built (non-fork) repos parent_stars is NULL, so their own star count
+was never stored — they showed 0 on reporium.com.
+
+This column holds the repo's own GitHub stargazers count and is populated
+by the ingestion pipeline for non-fork repos.
+
+Fixes: https://github.com/perditioinc/reporium-api/issues/13
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "004"
+down_revision: Union[str, None] = "003"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'repos' AND column_name = 'stargazers_count'
+            ) THEN
+                ALTER TABLE repos ADD COLUMN stargazers_count INTEGER;
+            END IF;
+        END $$;
+    """)
+
+
+def downgrade() -> None:
+    op.drop_column("repos", "stargazers_count")

--- a/scripts/populate_from_reporium_db.py
+++ b/scripts/populate_from_reporium_db.py
@@ -45,6 +45,7 @@ def map_repo(raw: dict) -> dict:
         "github_url": f"https://github.com/{name_with_owner}",
         "parent_stars": raw.get("parentStars"),
         "parent_forks": raw.get("parentForks"),
+        "stargazers_count": raw.get("stargazersCount"),
         "parent_is_archived": bool(raw.get("isArchived", False)),
         "tags": raw.get("topics", []),
         "github_updated_at": raw.get("pushedAt"),

--- a/tests/test_library_full.py
+++ b/tests/test_library_full.py
@@ -15,6 +15,7 @@ from app.routers.library_full import (
     _SKILL_TAG_TO_GROUP,
     _build_ai_dev_skill_stats,
     _build_builder_stats,
+    _build_enriched_repo,
     _build_tag_metrics,
     sanitize_repo,
 )
@@ -299,3 +300,104 @@ class TestSanitizeRepoDateFallback:
         }
         result = sanitize_repo(repo)
         assert result["upstreamLastPushAt"] == "2024-06-01T00:00:00"
+
+
+# ---------------------------------------------------------------------------
+# _build_enriched_repo — stars/forks for fork vs built repos  (issue #13)
+# ---------------------------------------------------------------------------
+
+def _make_db_repo(**kwargs) -> dict:
+    """Minimal DB row dict for _build_enriched_repo."""
+    defaults = {
+        "id": "00000000-0000-0000-0000-000000000001",
+        "name": "test-repo",
+        "owner": "perditioinc",
+        "description": "A test repo",
+        "is_fork": False,
+        "forked_from": None,
+        "primary_language": "Python",
+        "github_url": "https://github.com/perditioinc/test-repo",
+        "fork_sync_state": None,
+        "behind_by": 0,
+        "ahead_by": 0,
+        "upstream_created_at": None,
+        "forked_at": None,
+        "your_last_push_at": None,
+        "upstream_last_push_at": None,
+        "parent_stars": None,
+        "parent_forks": None,
+        "parent_is_archived": False,
+        "stargazers_count": None,
+        "commits_last_7_days": 0,
+        "commits_last_30_days": 0,
+        "commits_last_90_days": 0,
+        "readme_summary": None,
+        "activity_score": 0,
+        "ingested_at": None,
+        "updated_at": None,
+        "github_updated_at": None,
+    }
+    defaults.update(kwargs)
+    return defaults
+
+
+class TestBuildEnrichedRepoStars:
+
+    def test_fork_uses_parent_stars(self):
+        """Fork repos must show the upstream repo's star count."""
+        repo = _make_db_repo(
+            is_fork=True,
+            forked_from="openai/openai-cookbook",
+            parent_stars=45000,
+            parent_forks=7000,
+            stargazers_count=3,
+        )
+        enriched = _build_enriched_repo(repo, [], [], [], [], [])
+        assert enriched["stars"] == 45000
+        assert enriched["forks"] == 7000
+
+    def test_built_repo_uses_own_stargazers_count(self):
+        """Non-fork (built) repos must show their own star count, not parent_stars."""
+        repo = _make_db_repo(
+            is_fork=False,
+            forked_from=None,
+            parent_stars=None,
+            parent_forks=None,
+            stargazers_count=42,
+        )
+        enriched = _build_enriched_repo(repo, [], [], [], [], [])
+        assert enriched["stars"] == 42
+
+    def test_built_repo_with_null_stargazers_count_shows_zero(self):
+        """Built repo with no star data must show 0, not None."""
+        repo = _make_db_repo(
+            is_fork=False,
+            forked_from=None,
+            parent_stars=None,
+            parent_forks=None,
+            stargazers_count=None,
+        )
+        enriched = _build_enriched_repo(repo, [], [], [], [], [])
+        assert enriched["stars"] == 0
+
+    def test_fork_with_null_parent_stars_uses_none_not_own_stars(self):
+        """Fork repos should not fall back to their own stargazers_count."""
+        repo = _make_db_repo(
+            is_fork=True,
+            forked_from="some-org/some-repo",
+            parent_stars=None,
+            stargazers_count=99,
+        )
+        enriched = _build_enriched_repo(repo, [], [], [], [], [])
+        # parent_stars is None — stays None (frontend renders parentStats.stars)
+        assert enriched["stars"] is None
+
+    def test_built_repo_forks_always_zero(self):
+        """Built repos show 0 for forks (we don't track how many times our own repos are forked)."""
+        repo = _make_db_repo(
+            is_fork=False,
+            parent_forks=None,
+            stargazers_count=10,
+        )
+        enriched = _build_enriched_repo(repo, [], [], [], [], [])
+        assert enriched["forks"] == 0


### PR DESCRIPTION
## Summary

- Built (non-fork) repos showed 0 stars because `library_full.py` used `parent_stars`, which is NULL for non-forks
- Added `stargazers_count` column to store each repo's own GitHub star count
- `_build_enriched_repo` now uses `parent_stars` for forks and `stargazers_count` for built repos
- `ORDER BY` updated to `COALESCE(parent_stars, stargazers_count, 0)` so built repos sort correctly

## Changes

| File | Change |
|------|--------|
| `migrations/versions/004_add_stargazers_count.py` | New column `stargazers_count INTEGER` on `repos` table |
| `app/models/repo.py` | Add `stargazers_count` mapped column |
| `app/schemas/repo.py` | Expose `stargazers_count` on `RepoIngestItem` + `RepoSummary` |
| `app/routers/library_full.py` | Conditional stars/forks logic + updated SELECT + ORDER BY |
| `scripts/populate_from_reporium_db.py` | Map `raw.stargazersCount` → `stargazers_count` |
| `tests/test_library_full.py` | 5 new tests for fork vs built repo star behaviour |

## Test plan

- [x] All 37 unit tests pass (`pytest tests/test_library_full.py -v`)
- [ ] After merging, run `alembic upgrade head` in prod to apply migration 004
- [ ] Re-ingest built repos (or manually `UPDATE repos SET stargazers_count = X WHERE is_fork = false`) to populate the new column

Fixes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)