### PR TITLE
ci: auto-deploy to Cloud Run on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,7 @@
 name: Deploy to Cloud Run
 on:
+  push:
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -38,7 +40,7 @@ jobs:
                   source="reporium-api",
                   payload={
                       "service": "reporium-api",
-                      "version": "v1.5.1",
+                      "version": os.getenv("GITHUB_SHA", "unknown")[:7],
                       "url": "https://reporium-api-573778300586.us-central1.run.app",
                   },
               )


### PR DESCRIPTION
## Summary
- Adds `push: branches: [main]` trigger to deploy.yml so production deploys are automatic
- Removes manual-only `workflow_dispatch` (kept as fallback)
- Updates hardcoded `v1.5.1` version in event payload to use `GITHUB_SHA[:7]`

## Test plan
- [ ] Merge PR → verify GitHub Actions deploy job triggers automatically
- [ ] Check Cloud Run revision appears within ~5 min of merge
- [ ] Verify api.deployed Pub/Sub event is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)