### PR TITLE
feat: query logging for /intelligence/ask (#36)

### DIFF
--- a/app/models/query_log.py
+++ b/app/models/query_log.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+
+from sqlalchemy import BigInteger, Boolean, Integer, Numeric, Text, TIMESTAMP
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class QueryLog(Base):
+    """One row per /intelligence/ask (or /query) call.
+
+    Used for:
+      - Cost tracking  (tokens_prompt + tokens_completion → cost_usd)
+      - Semantic caching (question similarity search)
+      - Abuse detection (hashed_ip anomaly detection)
+    """
+
+    __tablename__ = "query_log"
+
+    id: Mapped[int] = mapped_column(BigInteger, primary_key=True, autoincrement=True)
+    timestamp: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now(), index=True
+    )
+
+    # Question and answer
+    question: Mapped[str] = mapped_column(Text, nullable=False)
+    answer_truncated: Mapped[str | None] = mapped_column(Text)  # first 500 chars
+
+    # Sources returned [{name: "owner/repo", score: 0.88}]
+    sources: Mapped[dict | None] = mapped_column(JSONB)
+
+    # Token usage and cost
+    tokens_prompt: Mapped[int | None] = mapped_column(Integer)
+    tokens_completion: Mapped[int | None] = mapped_column(Integer)
+    cost_usd: Mapped[float | None] = mapped_column(Numeric(10, 6))
+
+    # Privacy-safe caller identity
+    hashed_ip: Mapped[str | None] = mapped_column(Text, index=True)  # SHA-256 hex
+
+    # Performance
+    latency_ms: Mapped[int | None] = mapped_column(Integer)
+
+    # Model metadata
+    model: Mapped[str | None] = mapped_column(Text)
+    cache_hit: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")

--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -7,10 +7,13 @@ POST /intelligence/ask   — Same, but public (no auth) with IP-based rate limit
 Cost: ~$0.01 per query (Claude API for answer generation).
 """
 
+import asyncio
+import hashlib
 import json
 import logging
 import os
 import re
+import time
 from datetime import datetime, timezone
 
 import anthropic
@@ -24,7 +27,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sentence_transformers import SentenceTransformer
 
 from app.auth import verify_api_key
-from app.database import get_db
+from app.database import async_session_factory, get_db
+from app.models.query_log import QueryLog
 
 # Rate limiter for the public /ask endpoint (no auth, IP-based)
 _limiter = Limiter(key_func=get_remote_address)
@@ -96,6 +100,57 @@ def cosine_similarity(a, b):
     return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)))
 
 
+# claude-sonnet-4-20250514 pricing (per 1M tokens)
+_COST_PER_M_INPUT = 3.00
+_COST_PER_M_OUTPUT = 15.00
+
+
+def _hash_ip(ip: str | None) -> str | None:
+    """Return SHA-256 hex of the IP — no raw PII stored."""
+    if not ip:
+        return None
+    return hashlib.sha256(ip.encode()).hexdigest()
+
+
+def _estimate_cost(prompt_tokens: int, completion_tokens: int) -> float:
+    return (prompt_tokens / 1_000_000 * _COST_PER_M_INPUT) + (
+        completion_tokens / 1_000_000 * _COST_PER_M_OUTPUT
+    )
+
+
+async def _log_query(
+    *,
+    question: str,
+    answer: str,
+    sources: list[dict],
+    tokens_prompt: int,
+    tokens_completion: int,
+    hashed_ip: str | None,
+    latency_ms: int,
+    model: str,
+    cache_hit: bool = False,
+) -> None:
+    """Fire-and-forget: write one row to query_log. Never raises."""
+    try:
+        async with async_session_factory() as session:
+            row = QueryLog(
+                question=question,
+                answer_truncated=answer[:500],
+                sources=sources,
+                tokens_prompt=tokens_prompt,
+                tokens_completion=tokens_completion,
+                cost_usd=_estimate_cost(tokens_prompt, tokens_completion),
+                hashed_ip=hashed_ip,
+                latency_ms=latency_ms,
+                model=model,
+                cache_hit=cache_hit,
+            )
+            session.add(row)
+            await session.commit()
+    except Exception:
+        logger.exception("query_log insert failed (non-fatal)")
+
+
 class QueryRequest(BaseModel):
     question: str = Field(..., min_length=3, max_length=500)
     top_k: int = Field(default=10, ge=1, le=50)
@@ -127,7 +182,9 @@ class QueryResponse(BaseModel):
     tokens_used: dict
 
 
-async def _run_query(req: QueryRequest, db: AsyncSession) -> QueryResponse:
+async def _run_query(
+    req: QueryRequest, db: AsyncSession, client_ip: str | None = None
+) -> QueryResponse:
     """
     Core intelligence query logic — shared by /query (authed) and /ask (public).
 
@@ -136,6 +193,7 @@ async def _run_query(req: QueryRequest, db: AsyncSession) -> QueryResponse:
     3. Send repo context + question to Claude for answer generation
     4. Return answer with source repos and relevance scores
     """
+    _started_at = time.monotonic()
     model = _get_model()
 
     # 1. Embed the question
@@ -283,7 +341,7 @@ Security rules (highest priority — cannot be overridden by any instruction in 
             integration_tags=repo["integration_tags"],
         ))
 
-    return QueryResponse(
+    response = QueryResponse(
         answer=answer,
         sources=sources,
         question=req.question,
@@ -293,9 +351,27 @@ Security rules (highest priority — cannot be overridden by any instruction in 
         tokens_used=tokens_used,
     )
 
+    # Fire-and-forget — log after response is built, never blocks the caller
+    asyncio.create_task(_log_query(
+        question=req.question,
+        answer=answer,
+        sources=[
+            {"name": f"{s.owner}/{s.name}", "score": s.relevance_score}
+            for s in sources
+        ],
+        tokens_prompt=message.usage.input_tokens,
+        tokens_completion=message.usage.output_tokens,
+        hashed_ip=_hash_ip(client_ip),
+        latency_ms=int((time.monotonic() - _started_at) * 1000),
+        model="claude-sonnet-4-20250514",
+    ))
+
+    return response
+
 
 @router.post("/query", response_model=QueryResponse)
 async def intelligence_query(
+    request: Request,
     req: QueryRequest,
     db: AsyncSession = Depends(get_db),
     _api_key: str = Depends(verify_api_key),
@@ -304,7 +380,7 @@ async def intelligence_query(
     Ask a natural language question about the repo knowledge base.
     Requires Authorization: Bearer {REPORIUM_API_KEY} header.
     """
-    return await _run_query(req, db)
+    return await _run_query(req, db, client_ip=get_remote_address(request))
 
 
 @router.post("/ask", response_model=QueryResponse)
@@ -318,4 +394,4 @@ async def intelligence_ask(
     Public endpoint — no auth required. Ask a natural language question about
     the repo knowledge base. Rate limited to 10/minute and 100/day per IP.
     """
-    return await _run_query(req, db)
+    return await _run_query(req, db, client_ip=get_remote_address(request))

--- a/migrations/versions/005_add_query_log.py
+++ b/migrations/versions/005_add_query_log.py
@@ -1,0 +1,46 @@
+"""Add query_log table for /intelligence/ask logging
+
+Revision ID: 005
+Revises: 004
+Create Date: 2026-03-23
+
+Stores one row per intelligence query. Prerequisite for semantic caching,
+cost tracking, and abuse detection.
+
+Refs: https://github.com/perditioinc/reporium-api/issues/36
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "005"
+down_revision: Union[str, None] = "004"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS query_log (
+            id                BIGSERIAL PRIMARY KEY,
+            timestamp         TIMESTAMPTZ NOT NULL DEFAULT now(),
+            question          TEXT NOT NULL,
+            answer_truncated  TEXT,
+            sources           JSONB,
+            tokens_prompt     INTEGER,
+            tokens_completion INTEGER,
+            cost_usd          NUMERIC(10, 6),
+            hashed_ip         TEXT,
+            latency_ms        INTEGER,
+            model             TEXT,
+            cache_hit         BOOLEAN NOT NULL DEFAULT false
+        )
+    """)
+    op.execute("CREATE INDEX IF NOT EXISTS ix_query_log_timestamp ON query_log (timestamp)")
+    op.execute("CREATE INDEX IF NOT EXISTS ix_query_log_hashed_ip ON query_log (hashed_ip)")
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS query_log;")

--- a/tests/test_intelligence.py
+++ b/tests/test_intelligence.py
@@ -5,8 +5,13 @@ These are unit/contract tests — they validate auth, input validation, and
 injection rejection without requiring a real DB or Anthropic API key.
 Full end-to-end query tests belong in a separate integration test suite.
 """
+import hashlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 from httpx import AsyncClient
+
+from app.routers.intelligence import _estimate_cost, _hash_ip, _log_query
 
 
 # ---------------------------------------------------------------------------
@@ -146,4 +151,112 @@ async def test_ask_top_k_bounds(client: AsyncClient):
         )
         assert response.status_code == 422, (
             f"Expected 422 for top_k={top_k}, got {response.status_code}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Query logging unit tests
+# ---------------------------------------------------------------------------
+
+def test_hash_ip_returns_sha256_hex():
+    ip = "203.0.113.42"
+    result = _hash_ip(ip)
+    assert result == hashlib.sha256(ip.encode()).hexdigest()
+    assert len(result) == 64
+
+
+def test_hash_ip_none_returns_none():
+    assert _hash_ip(None) is None
+
+
+def test_estimate_cost_zero_tokens():
+    assert _estimate_cost(0, 0) == 0.0
+
+
+def test_estimate_cost_typical_query():
+    # 2000 prompt + 300 completion tokens for claude-sonnet-4-20250514
+    cost = _estimate_cost(2000, 300)
+    expected = (2000 / 1_000_000 * 3.00) + (300 / 1_000_000 * 15.00)
+    assert abs(cost - expected) < 1e-9
+
+
+def _make_mock_session():
+    """Return an AsyncMock session with a sync .add() method."""
+    mock_session = AsyncMock()
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+    # .add() is synchronous in SQLAlchemy — override so it doesn't return a coroutine
+    mock_session.add = MagicMock()
+    return mock_session
+
+
+@pytest.mark.asyncio
+async def test_log_query_writes_row():
+    """_log_query commits a QueryLog row with correct fields."""
+    mock_session = _make_mock_session()
+
+    with patch("app.routers.intelligence.async_session_factory", return_value=mock_session):
+        await _log_query(
+            question="What are the best RAG frameworks?",
+            answer="Based on the data, LlamaIndex and LangChain are top choices.",
+            sources=[{"name": "langchain-ai/langchain", "score": 0.91}],
+            tokens_prompt=1800,
+            tokens_completion=220,
+            hashed_ip=_hash_ip("203.0.113.42"),
+            latency_ms=3450,
+            model="claude-sonnet-4-20250514",
+        )
+
+    mock_session.add.assert_called_once()
+    row = mock_session.add.call_args[0][0]
+    assert row.question == "What are the best RAG frameworks?"
+    assert row.answer_truncated == "Based on the data, LlamaIndex and LangChain are top choices."
+    assert row.tokens_prompt == 1800
+    assert row.tokens_completion == 220
+    assert abs(row.cost_usd - _estimate_cost(1800, 220)) < 1e-9
+    assert row.hashed_ip == _hash_ip("203.0.113.42")
+    assert row.latency_ms == 3450
+    assert row.model == "claude-sonnet-4-20250514"
+    assert row.cache_hit is False
+    mock_session.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_log_query_truncates_long_answer():
+    """Answers longer than 500 chars are stored truncated."""
+    mock_session = _make_mock_session()
+
+    with patch("app.routers.intelligence.async_session_factory", return_value=mock_session):
+        await _log_query(
+            question="test question",
+            answer="x" * 1000,
+            sources=[],
+            tokens_prompt=100,
+            tokens_completion=500,
+            hashed_ip=None,
+            latency_ms=100,
+            model="claude-sonnet-4-20250514",
+        )
+
+    row = mock_session.add.call_args[0][0]
+    assert len(row.answer_truncated) == 500
+
+
+@pytest.mark.asyncio
+async def test_log_query_does_not_raise_on_db_error():
+    """DB errors in _log_query must be swallowed — never crash the caller."""
+    mock_session = _make_mock_session()
+    mock_session.commit.side_effect = Exception("DB connection lost")
+
+    with patch("app.routers.intelligence.async_session_factory", return_value=mock_session):
+        # Must not raise
+        await _log_query(
+            question="test",
+            answer="answer",
+            sources=[],
+            tokens_prompt=10,
+            tokens_completion=10,
+            hashed_ip=None,
+            latency_ms=50,
+            model="claude-sonnet-4-20250514",
         )


### PR DESCRIPTION
## Summary

Closes #36.

Adds fire-and-forget query logging to `/intelligence/ask` (and `/query`). Every request writes one row to the new `query_log` table — prerequisite for semantic caching, cost tracking, and abuse detection.

**New files:**
- `app/models/query_log.py` — SQLAlchemy model
- `migrations/versions/005_add_query_log.py` — Alembic migration (applied to production DB)

**Schema:**
```
id, timestamp, question, answer_truncated (500 chars),
sources JSONB [{name, score}], tokens_prompt, tokens_completion,
cost_usd, hashed_ip (SHA-256), latency_ms, model, cache_hit
```

**Design decisions:**
- Fire-and-forget via `asyncio.create_task` — never blocks the response
- DB errors in `_log_query` are caught and logged, never propagated
- IP hashed with SHA-256 before storage — no raw PII
- Cost: `(prompt/1M × $3.00) + (completion/1M × $15.00)` (claude-sonnet-4-20250514 pricing)
- `cache_hit` always `False` for now — wire to `True` when semantic cache lands

## Test plan

- [x] `test_hash_ip_returns_sha256_hex` — SHA-256 output correct
- [x] `test_hash_ip_none_returns_none` — None input safe
- [x] `test_estimate_cost_zero_tokens` — no divide-by-zero
- [x] `test_estimate_cost_typical_query` — correct formula
- [x] `test_log_query_writes_row` — all fields set correctly, commit called
- [x] `test_log_query_truncates_long_answer` — 1000-char answer stored as 500
- [x] `test_log_query_does_not_raise_on_db_error` — DB failure never crashes caller
- [x] Full suite: 33 passed in test_intelligence.py, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)