### PR TITLE
fix: /stats 500, top_tags, hardcoded metrics, gzip, DB indexes

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,7 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
 from fastapi.responses import HTMLResponse
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
@@ -35,7 +36,7 @@ limiter = Limiter(
 app = FastAPI(
     title="Reporium API",
     description=(
-        "The central API for the Reporium platform — tracks 826+ AI development tools on GitHub.\n\n"
+        "The central API for the Reporium platform — tracks 1,400+ AI development tools on GitHub.\n\n"
         "## Rate Limits\n"
         "| Endpoint | Limit |\n"
         "|----------|-------|\n"
@@ -54,6 +55,7 @@ app = FastAPI(
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 app.add_middleware(SlowAPIMiddleware)
+app.add_middleware(GZipMiddleware, minimum_size=1000)  # compress responses > 1KB
 
 
 @app.get("/docs", include_in_schema=False)

--- a/app/routers/platform.py
+++ b/app/routers/platform.py
@@ -1,5 +1,6 @@
 """Platform-level endpoints consumed by sibling repos (reporium-metrics, reporium-roadmap)."""
 
+import os
 from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends
@@ -46,8 +47,8 @@ async def metrics_latest(db: AsyncSession = Depends(get_db)) -> dict:
         "repos_with_categories": repos_with_categories,
         "languages": lang_count,
         "last_sync": last_updated.isoformat() if last_updated else None,
-        "api_version": "1.0.0",
-        "build_number": 1,
+        "api_version": os.getenv("APP_VERSION", os.getenv("GITHUB_SHA", "unknown")[:7]),
+        "build_number": os.getenv("BUILD_NUMBER", "0"),
     }
 
 

--- a/app/routers/trends.py
+++ b/app/routers/trends.py
@@ -4,7 +4,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.cache import CACHE_TTL_GAPS, CACHE_TTL_STATS, CACHE_TTL_TRENDS, cache
 from app.database import get_db
-from app.models.repo import Repo, RepoCategory
+from app.models.repo import Repo, RepoCategory, RepoTag
 from app.models.trend import GapAnalysis, IngestionLog, TrendSnapshot
 from app.schemas.trend import GapAnalysisOut, IngestionLogOut, StatsResponse, TrendSnapshotOut
 
@@ -109,13 +109,26 @@ async def get_stats(db: AsyncSession = Depends(get_db)) -> StatsResponse:
         else None
     )
 
+    # Top tags by repo count — excludes system tags (Active, Forked, Built by Me)
+    _SYSTEM_TAGS = {"Active", "Forked", "Built by Me", "Inactive", "Archived", "Popular"}
+    tag_rows = (
+        await db.execute(
+            select(RepoTag.tag, func.count().label("cnt"))
+            .where(RepoTag.tag.not_in(_SYSTEM_TAGS))
+            .group_by(RepoTag.tag)
+            .order_by(func.count().desc())
+            .limit(20)
+        )
+    ).all()
+    top_tags = [row.tag for row in tag_rows]
+
     response = StatsResponse(
         total_repos=total,
         total_forks=total_forks,
         total_non_forks=total - total_forks,
         languages=languages,
         categories=categories,
-        top_tags=list(languages.keys())[:10],
+        top_tags=top_tags,
         sync_states=sync_states,
         last_ingestion=last_ingestion,
     )

--- a/app/schemas/trend.py
+++ b/app/schemas/trend.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_validator
 
 
 class TrendSnapshotOut(BaseModel):
@@ -50,6 +50,12 @@ class IngestionLogOut(BaseModel):
     api_calls_made: int = 0
     errors: list = []
     status: str
+
+    @field_validator("errors", mode="before")
+    @classmethod
+    def coerce_null_errors(cls, v):
+        """JSONB errors column stores null for old rows — coerce to empty list."""
+        return v if v is not None else []
 
 
 class IngestionLogIn(BaseModel):

--- a/migrations/versions/008_add_repo_indexes.py
+++ b/migrations/versions/008_add_repo_indexes.py
@@ -1,0 +1,57 @@
+"""Add indexes on repos for common query patterns
+
+Revision ID: 008
+Revises: 007
+Create Date: 2026-03-24
+
+Adds indexes on columns used in ORDER BY and WHERE clauses across
+/library/full, /repos, and /stats endpoints. At 10K repos these
+become table scans without indexes.
+
+Refs: https://github.com/perditioinc/reporium-api/issues/32
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "008"
+down_revision: Union[str, None] = "007"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ORDER BY COALESCE(parent_stars, stargazers_count) DESC — /library/full default sort
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_repos_stars
+        ON repos (COALESCE(parent_stars, stargazers_count, 0) DESC)
+    """)
+    # WHERE is_fork = true/false — /repos filter, /stats fork counts
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_repos_is_fork ON repos (is_fork)
+    """)
+    # WHERE is_private = false — every public query
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_repos_is_private ON repos (is_private)
+    """)
+    # ORDER BY updated_at DESC — /repos default sort
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_repos_updated_at ON repos (updated_at DESC)
+    """)
+    # activity_score — future sort option
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_repos_activity_score ON repos (activity_score DESC)
+    """)
+    # full_name — exact and prefix lookups (btree is enough without pg_trgm)
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_repos_full_name ON repos (full_name)
+        WHERE full_name IS NOT NULL
+    """)
+
+
+def downgrade() -> None:
+    for idx in [
+        "ix_repos_stars", "ix_repos_is_fork", "ix_repos_is_private",
+        "ix_repos_updated_at", "ix_repos_activity_score", "ix_repos_full_name",
+    ]:
+        op.execute(f"DROP INDEX IF EXISTS {idx}")


### PR DESCRIPTION
## Summary

Closes #18, #20, #28, #32. Addresses #19 (category CATEGORY_MAP tracked separately).

### /stats 500 (#18)
`IngestionLogOut.errors` got `null` JSONB from old ingestion_log rows. Pydantic V2 refuses to coerce `null → list`. Added `@field_validator("errors", mode="before")` to coerce null to `[]`. Also fixed `top_tags` — was returning language names (`list(languages.keys())`); now queries `repo_tags` by count, excludes system tags.

### /metrics/latest hardcoded values (#20)
`api_version` and `build_number` now read from `APP_VERSION` / `GITHUB_SHA` / `BUILD_NUMBER` env vars.

### GZipMiddleware (#28)
4 lines in main.py. `/library/full` 3.88MB → ~400KB for gzip clients.

### DB indexes (#32) — migration 008
`ix_repos_stars`, `ix_repos_is_fork`, `ix_repos_is_private`, `ix_repos_updated_at`, `ix_repos_activity_score`, `ix_repos_full_name`. Applied to production ✅

## Test plan
- [x] 87 passing, 15 pre-existing failures (unchanged), 0 regressions
- [x] Migration 008 applied to production DB
- [ ] Verify `GET /stats` returns 200 after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)