### PR TITLE
fix(library): add 5 missing CATEGORY_MAP entries (#19)

### DIFF
--- a/app/routers/library_full.py
+++ b/app/routers/library_full.py
@@ -37,6 +37,11 @@ CATEGORY_MAP = {
     "Other": "Dev Tools & Automation",
     "Data Processing": "MLOps & Infrastructure",
     "Embeddings": "RAG & Retrieval",
+    "Audio": "Industry: Audio & Music",
+    "Fine Tuning": "Model Training",
+    "Deployment": "MLOps & Infrastructure",
+    "Evaluation": "Evals & Benchmarking",
+    "Datasets": "Datasets",
 }
 
 


### PR DESCRIPTION
## Summary
- Adds mappings for `Audio`, `Fine Tuning`, `Deployment`, `Evaluation`, and `Datasets` to `CATEGORY_MAP` in `library_full.py`
- These five DB category names fell through to the default gray color (`#94a3b8`) and box icon on reporium.com

## Test plan
- [ ] Deploy to Cloud Run and verify affected repos render with correct color/icon on reporium.com
- [ ] Confirm `/library/full` response shows mapped display names for these categories

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)