### PR TITLE
fix: stale API docs, /events/ingest auth (#21 #43 #44 #26)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -40,13 +40,17 @@ app = FastAPI(
         "## Rate Limits\n"
         "| Endpoint | Limit |\n"
         "|----------|-------|\n"
-        "| `GET /repos`, `/stats`, `/library` | 100 requests/minute |\n"
-        "| `GET /search` | 30 requests/minute |\n"
-        "| `POST /ingest/*` | 10 requests/minute |\n"
+        "| `GET /repos`, `/stats`, `/library`, `/library/full` | 200/hour, 30/minute |\n"
+        "| `GET /search` | 200/hour, 30/minute |\n"
+        "| `POST /intelligence/ask`, `/intelligence/query` | 200/hour, 30/minute |\n"
+        "| `POST /ingest/*` | 200/hour, 30/minute |\n"
         "| `GET /health` | No limit |\n\n"
-        "Rate limit headers are included in every response."
+        "Rate limit headers are included in every response.\n\n"
+        "## Repo Lookups\n"
+        "All repo endpoints use `owner/name` (e.g. `perditioinc/reporium-api`). "
+        "Bare-name lookups are not supported."
     ),
-    version="1.0.0",
+    version="1.1.0",
     docs_url=None,      # disable default — we serve Scalar
     redoc_url=None,     # disable default — Scalar replaces both
     lifespan=lifespan,

--- a/app/routers/platform.py
+++ b/app/routers/platform.py
@@ -7,6 +7,7 @@ from fastapi import APIRouter, Depends
 from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.auth import verify_api_key
 from app.database import get_db
 from app.models.repo import Repo, RepoAIDevSkill, RepoCategory
 
@@ -81,7 +82,10 @@ async def audit_status(db: AsyncSession = Depends(get_db)) -> dict:
 
 
 @router.post("/events/ingest")
-async def events_ingest(payload: dict) -> dict:
-    """Receive Pub/Sub push events (placeholder for future reporium-events integration)."""
+async def events_ingest(
+    payload: dict,
+    _api_key: str = Depends(verify_api_key),
+) -> dict:
+    """Receive Pub/Sub push events. Requires Authorization: Bearer {REPORIUM_API_KEY} header."""
     # For now, acknowledge receipt without processing
     return {"status": "accepted", "message": "Event received (processing not yet implemented)"}


### PR DESCRIPTION
## Summary
- Corrects rate limits table in OpenAPI description to match actual global limits (200/hour, 30/minute)
- Adds `/intelligence/ask`, `/intelligence/query`, `/library/full` to the rate limits table
- Adds Repo Lookups section clarifying `owner/name` format (no bare-name lookups)
- Bumps API version string to `1.1.0`
- Adds `verify_api_key` dependency to `POST /events/ingest` — was previously unauthenticated

## Test plan
- [ ] `GET /docs` shows updated rate limits and repo lookup guidance
- [ ] `POST /events/ingest` without auth returns 401
- [ ] `POST /events/ingest` with valid Bearer token returns 200

Closes #21 #43 #44 #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)