### PR TITLE
fix(ingest): raise /ingest/repos rate limit to unblock nightly sync (#4)

### DIFF
--- a/app/routers/ingest.py
+++ b/app/routers/ingest.py
@@ -86,7 +86,7 @@ async def _upsert_repo(db: AsyncSession, item: RepoIngestItem) -> Repo:
 
 
 @router.post("/repos", response_model=IngestResponse)
-@limiter.limit("10/minute")
+@limiter.limit("200/minute")
 async def ingest_repos(
     request: Request,
     items: list[RepoIngestItem],


### PR DESCRIPTION
## Summary
- Raises `/ingest/repos` rate limit from `10/minute` to `200/minute`
- The nightly sync sends 20 concurrent batch requests from one GitHub Actions IP — the old 10/min cap caused ~1000/1459 repos to 429 on every run
- Endpoint is already protected by `verify_api_key` so a higher limit is safe

## Root cause
`REPORIUM_API_URL` secret was also empty until today (set to the Cloud Run URL). With an empty URL the script hit the hardcoded fallback. After fixing the secret, the rate limit became the new failure mode.

## Test plan
- [ ] Merge to dev → deploy to Cloud Run
- [ ] Re-run nightly sync workflow and confirm 0 failed repos

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)