### PR TITLE
feat(observability): add Sentry SDK for error tracking + performance (#24)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,6 +4,10 @@ import os
 import time
 from contextlib import asynccontextmanager
 
+import sentry_sdk
+from sentry_sdk.integrations.fastapi import FastApiIntegration
+from sentry_sdk.integrations.starlette import StarletteIntegration
+
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
@@ -44,6 +48,18 @@ def _configure_logging() -> None:
 
 _configure_logging()
 logger = logging.getLogger(__name__)
+
+_sentry_dsn = os.environ.get("SENTRY_DSN")
+if _sentry_dsn:
+    sentry_sdk.init(
+        dsn=_sentry_dsn,
+        traces_sample_rate=0.1,
+        environment=os.environ.get("APP_ENV", "production"),
+        integrations=[
+            StarletteIntegration(),
+            FastApiIntegration(),
+        ],
+    )
 
 
 @asynccontextmanager

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,4 +15,5 @@ google-cloud-secret-manager>=2.16
 slowapi>=0.1.9
 anthropic>=0.40.0
 sentence-transformers>=3.0.0
+sentry-sdk[fastapi]>=2.0.0
 numpy>=1.26


### PR DESCRIPTION
## Summary
- Adds `sentry-sdk[fastapi]>=2.0.0` to `requirements.txt`
- Initializes Sentry in `app/main.py` before `FastAPI()` is created, guarded by `SENTRY_DSN` env var (skips init if unset — no crash)
- `traces_sample_rate=0.1` (10% of requests sampled for performance)
- `environment` read from `APP_ENV` env var, defaulting to `"production"`
- Includes `StarletteIntegration` and `FastApiIntegration` for automatic unhandled exception capture

## Test plan
- [ ] Deploy with `SENTRY_DSN` unset — confirm app starts normally
- [ ] Deploy with `SENTRY_DSN` set — confirm events appear in Sentry dashboard
- [ ] Trigger a 500 error — confirm it is captured in Sentry
- [ ] Confirm `traces_sample_rate` produces ~10% transaction traces

🤖 Generated with [Claude Code](https://claude.com/claude-code)