### PR TITLE
chore: remove Sentry, use Cloud Run monitoring

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -4,10 +4,6 @@ import os
 import time
 from contextlib import asynccontextmanager
 
-import sentry_sdk
-from sentry_sdk.integrations.fastapi import FastApiIntegration
-from sentry_sdk.integrations.starlette import StarletteIntegration
-
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.middleware.gzip import GZipMiddleware
@@ -48,19 +44,6 @@ def _configure_logging() -> None:
 
 _configure_logging()
 logger = logging.getLogger(__name__)
-
-_sentry_dsn = os.environ.get("SENTRY_DSN")
-if _sentry_dsn:
-    sentry_sdk.init(
-        dsn=_sentry_dsn,
-        traces_sample_rate=0.1,
-        environment=os.environ.get("APP_ENV", "production"),
-        integrations=[
-            StarletteIntegration(),
-            FastApiIntegration(),
-        ],
-    )
-
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,4 @@ google-cloud-secret-manager>=2.16
 slowapi>=0.1.9
 anthropic>=0.40.0
 sentence-transformers>=3.0.0
-sentry-sdk[fastapi]>=2.0.0
 numpy>=1.26


### PR DESCRIPTION
## Summary
- Removes `sentry-sdk[fastapi]>=2.0.0` from `requirements.txt`
- Removes all Sentry imports and the `sentry_sdk.init(...)` initialisation block from `app/main.py`

Sentry trial is 14 days only — removed in favour of existing Cloud Run structured logging and Cloud Monitoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)