### PR TITLE
feat: add open issues count to library payload

### DIFF
--- a/app/models/repo.py
+++ b/app/models/repo.py
@@ -42,6 +42,7 @@ class Repo(Base):
 
     # Own star count (for non-fork / built repos)
     stargazers_count: Mapped[int | None] = mapped_column(Integer)
+    open_issues_count: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
 
     # Activity
     commits_last_7_days: Mapped[int] = mapped_column(Integer, default=0, server_default="0")

--- a/app/routers/library_full.py
+++ b/app/routers/library_full.py
@@ -206,6 +206,9 @@ def sanitize_repo(repo: dict) -> dict:
         repo["readmeSummary"] = repo["description"]
         logger.warning("Contract fallback: %s missing readmeSummary", name)
 
+    if repo.get("openIssuesCount") is None:
+        repo["openIssuesCount"] = 0
+
     if not repo.get("primaryCategory") or repo["primaryCategory"] == "Other":
         repo["primaryCategory"] = "Uncategorized"
 
@@ -367,6 +370,7 @@ def _build_enriched_repo(repo: dict, languages: list, categories: list,
         "enrichedTags": list(dict.fromkeys([s["skill"] for s in ai_skills] + [t["tag"] for t in tags])),
         "stars": repo.get("parent_stars") if repo.get("is_fork") else (repo.get("stargazers_count") or 0),
         "forks": repo.get("parent_forks") if repo.get("is_fork") else 0,
+        "openIssuesCount": repo.get("open_issues_count") or 0,
         "lastUpdated": _iso(repo.get("github_updated_at") or repo.get("updated_at")),
         "url": repo.get("github_url") or f"https://github.com/{owner}/{name}",
         "isArchived": repo.get("parent_is_archived") or False,
@@ -688,7 +692,7 @@ async def _fetch_page_repos(
         SELECT id, name, owner, full_name, description, is_fork, forked_from, primary_language,
                github_url, fork_sync_state, behind_by, ahead_by,
                github_created_at, upstream_created_at, forked_at, your_last_push_at, upstream_last_push_at,
-               parent_stars, parent_forks, parent_is_archived, stargazers_count,
+               parent_stars, parent_forks, parent_is_archived, stargazers_count, open_issues_count,
                commits_last_7_days, commits_last_30_days, commits_last_90_days,
                readme_summary, activity_score, ingested_at, updated_at, github_updated_at,
                problem_solved, integration_tags, dependencies

--- a/app/schemas/repo.py
+++ b/app/schemas/repo.py
@@ -60,6 +60,7 @@ class RepoSummary(BaseModel):
     parent_forks: int | None = None
     parent_is_archived: bool = False
     stargazers_count: int | None = None
+    open_issues_count: int = 0
 
     commits_last_7_days: int = 0
     commits_last_30_days: int = 0
@@ -138,6 +139,7 @@ class RepoIngestItem(BaseModel):
     parent_forks: int | None = None
     parent_is_archived: bool = False
     stargazers_count: int | None = None
+    open_issues_count: int = 0
 
     commits_last_7_days: int = 0
     commits_last_30_days: int = 0

--- a/migrations/versions/010_add_open_issues_count.py
+++ b/migrations/versions/010_add_open_issues_count.py
@@ -1,0 +1,29 @@
+"""add open issues count to repos
+
+Revision ID: 010
+Revises: 009
+Create Date: 2026-03-24 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "010"
+down_revision: Union[str, None] = "009"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "repos",
+        sa.Column("open_issues_count", sa.Integer(), nullable=False, server_default="0"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("repos", "open_issues_count")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,10 +7,10 @@ import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://postgres:postgres@localhost:5432/reporium_test")
-os.environ.setdefault("INGESTION_API_KEY", "test-api-key")
-os.environ.setdefault("GH_USERNAME", "testuser")
-os.environ.setdefault("REDIS_URL", "")  # disable Redis in tests
+os.environ["DATABASE_URL"] = "postgresql+asyncpg://postgres:postgres@localhost:5432/reporium_test"
+os.environ["INGESTION_API_KEY"] = "test-api-key"
+os.environ["GH_USERNAME"] = "testuser"
+os.environ["REDIS_URL"] = ""  # disable Redis in tests
 
 import app.database as db_module
 from app.database import Base, get_db
@@ -65,6 +65,7 @@ TEST_REPO_FIXTURE = {
     "parent_stars": 1000,
     "parent_forks": 200,
     "parent_is_archived": False,
+    "open_issues_count": 42,
     "commits_last_7_days": 3,
     "commits_last_30_days": 12,
     "commits_last_90_days": 40,

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -32,6 +32,10 @@ async def test_ingest_with_valid_key(client: AsyncClient):
     assert data["upserted"] == 1
     assert data["errors"] == []
 
+    library = await client.get("/library/full")
+    assert library.status_code == 200
+    assert library.json()["repos"][0]["openIssuesCount"] == 42
+
 
 @pytest.mark.asyncio
 async def test_ingest_is_idempotent(client: AsyncClient):

--- a/tests/test_library_full.py
+++ b/tests/test_library_full.py
@@ -328,6 +328,7 @@ def _make_db_repo(**kwargs) -> dict:
         "parent_forks": None,
         "parent_is_archived": False,
         "stargazers_count": None,
+        "open_issues_count": 0,
         "commits_last_7_days": 0,
         "commits_last_30_days": 0,
         "commits_last_90_days": 0,
@@ -401,3 +402,13 @@ class TestBuildEnrichedRepoStars:
         )
         enriched = _build_enriched_repo(repo, [], [], [], [], [])
         assert enriched["forks"] == 0
+
+    def test_open_issues_count_round_trips_from_repo_row(self):
+        """Repo open issue counts should be exposed on the frontend contract."""
+        repo = _make_db_repo(
+            is_fork=False,
+            stargazers_count=10,
+            open_issues_count=17,
+        )
+        enriched = _build_enriched_repo(repo, [], [], [], [], [])
+        assert enriched["openIssuesCount"] == 17


### PR DESCRIPTION
## Changes
- add migration 010 for epos.open_issues_count
- expose open_issues_count on ingest and summary schemas
- include openIssuesCount in /library/full repo payloads
- add regression coverage for the library payload contract
- pin test env vars in 	ests/conftest.py so ingest tests do not accidentally use local shell secrets

## Validation
- python -m py_compile migrations/versions/010_add_open_issues_count.py app/models/repo.py app/schemas/repo.py app/routers/library_full.py
- python -m pytest tests/test_library_full.py -q

## Notes
- 	ests/test_ingest.py still requires a local eporium_test Postgres database. This machine does not have that database, so the ingest integration test remains environment-blocked here even though the contract wiring is in place.
- Follow-up release PR: after this lands in dev, open dev -> main to trigger the Cloud Run redeploy.