### PR TITLE
feat: data-driven taxonomy — skill_areas table + /taxonomy API endpoint (#17)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -15,7 +15,7 @@ from slowapi.util import get_remote_address
 
 from app.cache import cache
 from app.database import check_db_connection, engine
-from app.routers import admin, ingest, intelligence, library, library_full, platform, repos, search, trends, wiki
+from app.routers import admin, ingest, intelligence, library, library_full, platform, repos, search, taxonomy, trends, wiki
 
 
 class _JsonFormatter(logging.Formatter):
@@ -224,6 +224,7 @@ app.include_router(platform.router)
 app.include_router(ingest.router)
 app.include_router(intelligence.router)
 app.include_router(library_full.router)
+app.include_router(taxonomy.router, prefix="/taxonomy")
 app.include_router(admin.router)
 
 

--- a/app/models/repo.py
+++ b/app/models/repo.py
@@ -191,3 +191,17 @@ class RepoEmbedding(Base):
     )
 
     repo: Mapped["Repo"] = relationship(back_populates="embedding")
+
+
+class SkillArea(Base):
+    __tablename__ = "skill_areas"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    lifecycle_group: Mapped[str] = mapped_column(Text, nullable=False, index=True)
+    description: Mapped[str | None] = mapped_column(Text)
+    icon: Mapped[str | None] = mapped_column(Text)
+    color: Mapped[str | None] = mapped_column(Text)
+    sort_order: Mapped[int] = mapped_column(Integer, default=0)
+    min_repos_to_display: Mapped[int] = mapped_column(Integer, default=1)
+    created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())

--- a/app/routers/library_full.py
+++ b/app/routers/library_full.py
@@ -139,8 +139,10 @@ _AI_DEV_SKILLS_ORDERED: list = [
     "Recommendation Systems",
 ]
 
-# Mapping from skill area name → lifecycle group name (used in API responses).
-LIFECYCLE_GROUPS: dict = {
+# Lifecycle group lookup is now DB-driven (skill_areas table).
+# _get_lifecycle_groups(db) queries the DB and caches for 5 minutes.
+# This dict is a compile-time fallback used only when the DB is unavailable.
+_LIFECYCLE_GROUPS_FALLBACK: dict = {
     "Foundation Model Architecture": "Foundation & Training",
     "Fine-tuning & Alignment": "Foundation & Training",
     "Data Engineering": "Foundation & Training",
@@ -155,11 +157,11 @@ LIFECYCLE_GROUPS: dict = {
     "Structured Output": "LLM Application Layer",
     "Prompt Engineering": "LLM Application Layer",
     "Knowledge Graphs": "LLM Application Layer",
-    "Evaluation": "Eval/Safety/Ops",
-    "Security & Guardrails": "Eval/Safety/Ops",
-    "Observability": "Eval/Safety/Ops",
-    "MLOps": "Eval/Safety/Ops",
-    "AI Governance": "Eval/Safety/Ops",
+    "Evaluation": "Eval / Safety / Ops",
+    "Security & Guardrails": "Eval / Safety / Ops",
+    "Observability": "Eval / Safety / Ops",
+    "MLOps": "Eval / Safety / Ops",
+    "AI Governance": "Eval / Safety / Ops",
     "Computer Vision": "Modality-Specific",
     "Speech & Audio": "Modality-Specific",
     "Generative Media": "Modality-Specific",
@@ -170,6 +172,34 @@ LIFECYCLE_GROUPS: dict = {
     "AI for Science": "Applied AI",
     "Recommendation Systems": "Applied AI",
 }
+
+_lifecycle_groups_cache: dict = {}
+_LIFECYCLE_GROUPS_TTL = 300  # 5 minutes
+
+
+async def _get_lifecycle_groups(db: AsyncSession) -> dict:
+    """Return {skill_area_name: lifecycle_group} from the skill_areas table.
+
+    Results are cached in memory for 5 minutes. Falls back to the compile-time
+    dict if the table is unavailable (e.g. migration not yet applied).
+    """
+    now = time.time()
+    cached = _lifecycle_groups_cache.get("data")
+    if cached and _lifecycle_groups_cache.get("expires_at", 0) > now:
+        return cached
+
+    try:
+        result = await db.execute(text("SELECT name, lifecycle_group FROM skill_areas"))
+        rows = result.fetchall()
+        if rows:
+            mapping = {row.name: row.lifecycle_group for row in rows}
+            _lifecycle_groups_cache["data"] = mapping
+            _lifecycle_groups_cache["expires_at"] = now + _LIFECYCLE_GROUPS_TTL
+            return mapping
+    except Exception:
+        logger.warning("_get_lifecycle_groups: skill_areas table unavailable, using fallback", exc_info=True)
+
+    return _LIFECYCLE_GROUPS_FALLBACK
 
 # Keep a set for O(1) membership checks in _build_ai_dev_skill_stats
 _AI_DEV_SKILL_SET: set = set(_AI_DEV_SKILLS_ORDERED)
@@ -378,7 +408,8 @@ def _iso(val) -> str:
 
 def _build_enriched_repo(repo: dict, languages: list, categories: list,
                          ai_skills: list, tags: list, pm_skills: list,
-                         builders: list = None, industries: list = None) -> dict:
+                         builders: list = None, industries: list = None,
+                         lifecycle_groups: dict = None) -> dict:
     """Transform a DB repo row + junction data into the frontend EnrichedRepo shape."""
     forked_from = repo.get("forked_from")
     owner = repo.get("owner", "perditioinc")
@@ -484,7 +515,7 @@ def _build_enriched_repo(repo: dict, languages: list, categories: list,
         },
         "latestRelease": None,
         "aiDevSkills": [
-            {"skill": s["skill"], "lifecycleGroup": LIFECYCLE_GROUPS.get(s["skill"], "")}
+            {"skill": s["skill"], "lifecycleGroup": (lifecycle_groups or _LIFECYCLE_GROUPS_FALLBACK).get(s["skill"], "")}
             for s in ai_skills
         ],
         "pmSkills": [s["skill"] for s in pm_skills],
@@ -676,7 +707,7 @@ def _build_skill_stats(repos: list, skill_field: str) -> list:
     return stats
 
 
-def _build_ai_dev_skill_stats(repos: list) -> list:
+def _build_ai_dev_skill_stats(repos: list, lifecycle_groups: dict = None) -> list:
     """Build AI Dev Skill stats for the 28-skill taxonomy.
 
     First checks aiDevSkills for direct matches against the canonical 28 skill names.
@@ -723,7 +754,7 @@ def _build_ai_dev_skill_stats(repos: list) -> list:
         top = sorted(skill_top_repos.get(skill, []), reverse=True)[:5]
         stats.append({
             "skill": skill,
-            "lifecycleGroup": LIFECYCLE_GROUPS.get(skill, ""),
+            "lifecycleGroup": (lifecycle_groups or _LIFECYCLE_GROUPS_FALLBACK).get(skill, ""),
             "repoCount": count,
             "coverage": coverage,
             "topRepos": [name for _, name in top],
@@ -864,6 +895,8 @@ async def _fetch_page_repos(
     for r in industry_rows:
         all_industries[str(r.repo_id)].append({"industry": r.industry})
 
+    lifecycle_groups = await _get_lifecycle_groups(db)
+
     enriched = []
     for repo in repo_dicts:
         rid = str(repo["id"])
@@ -876,6 +909,7 @@ async def _fetch_page_repos(
             pm_skills=all_pm_skills.get(rid, []),
             builders=all_builders.get(rid, []),
             industries=all_industries.get(rid, []),
+            lifecycle_groups=lifecycle_groups,
         )))
 
     return enriched, total
@@ -908,7 +942,7 @@ async def _fetch_aggregates(db: AsyncSession) -> dict:
         "tagMetrics": _build_tag_metrics(all_repos),
         "categories": _build_categories(all_repos),
         "builderStats": _build_builder_stats(all_repos),
-        "aiDevSkillStats": _build_ai_dev_skill_stats(all_repos),
+        "aiDevSkillStats": _build_ai_dev_skill_stats(all_repos, lifecycle_groups=await _get_lifecycle_groups(db)),
         "pmSkillStats": _build_skill_stats(all_repos, "pmSkills"),
     }
     logger.info(f"Aggregates built in {time.monotonic() - t0:.1f}s across {len(all_repos)} repos")

--- a/app/routers/taxonomy.py
+++ b/app/routers/taxonomy.py
@@ -1,0 +1,135 @@
+"""
+GET /taxonomy/skill-areas — Returns all skill areas from DB, grouped by lifecycle_group.
+GET /taxonomy/skill-areas/{name}/repos — Returns repos tagged with a given skill area.
+
+Skill areas are stored in the skill_areas table; adding a new area requires only a DB insert.
+"""
+
+import logging
+import time
+from collections import defaultdict
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import func, select, text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.models.repo import SkillArea
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Taxonomy"])
+
+# In-memory cache for skill-areas list (5 min TTL)
+_taxonomy_cache: dict = {}
+_TAXONOMY_CACHE_TTL = 300  # 5 minutes
+
+
+@router.get("/skill-areas")
+async def list_skill_areas(db: AsyncSession = Depends(get_db)) -> dict:
+    """
+    Return all skill areas from the DB, grouped by lifecycle_group.
+    Each skill area includes a repoCount (repos in repo_ai_dev_skills).
+    Skill areas with repoCount < min_repos_to_display are excluded.
+    """
+    now = time.monotonic()
+    cached = _taxonomy_cache.get("skill_areas")
+    if cached and cached.get("expires_at", 0) > now:
+        return cached["data"]
+
+    # Fetch all skill areas ordered by sort_order
+    stmt = select(SkillArea).order_by(SkillArea.sort_order, SkillArea.name)
+    result = await db.execute(stmt)
+    skill_areas = result.scalars().all()
+
+    # Count repos per skill area from repo_ai_dev_skills
+    count_stmt = text(
+        "SELECT skill, COUNT(DISTINCT repo_id) AS repo_count "
+        "FROM repo_ai_dev_skills "
+        "GROUP BY skill"
+    )
+    count_result = await db.execute(count_stmt)
+    repo_counts: dict[str, int] = {row.skill: row.repo_count for row in count_result}
+
+    grouped: dict[str, list] = defaultdict(list)
+    for sa in skill_areas:
+        count = repo_counts.get(sa.name, 0)
+        if count < sa.min_repos_to_display:
+            continue
+        grouped[sa.lifecycle_group].append({
+            "id": sa.id,
+            "name": sa.name,
+            "lifecycleGroup": sa.lifecycle_group,
+            "description": sa.description,
+            "icon": sa.icon,
+            "color": sa.color,
+            "sortOrder": sa.sort_order,
+            "repoCount": count,
+        })
+
+    response = {
+        "groups": [
+            {
+                "lifecycleGroup": group,
+                "skillAreas": areas,
+            }
+            for group, areas in grouped.items()
+        ],
+        "total": sum(len(areas) for areas in grouped.values()),
+    }
+
+    _taxonomy_cache["skill_areas"] = {"data": response, "expires_at": now + _TAXONOMY_CACHE_TTL}
+    return response
+
+
+@router.get("/skill-areas/{name}/repos")
+async def get_repos_for_skill_area(name: str, db: AsyncSession = Depends(get_db)) -> dict:
+    """
+    Return repos that have this skill area (via repo_ai_dev_skills join).
+    Validates that the skill area exists in the skill_areas table.
+    """
+    # Verify skill area exists
+    sa_stmt = select(SkillArea).where(SkillArea.name == name)
+    sa_result = await db.execute(sa_stmt)
+    skill_area = sa_result.scalar_one_or_none()
+    if skill_area is None:
+        raise HTTPException(status_code=404, detail=f"Skill area '{name}' not found")
+
+    # Fetch repos with this skill
+    repos_stmt = text(
+        "SELECT r.name, r.owner, r.description, r.github_url, r.primary_language, "
+        "       r.stargazers_count, r.parent_stars, r.activity_score, r.readme_summary "
+        "FROM repos r "
+        "JOIN repo_ai_dev_skills s ON s.repo_id = r.id "
+        "WHERE s.skill = :skill "
+        "ORDER BY COALESCE(r.stargazers_count, r.parent_stars, 0) DESC"
+    )
+    repos_result = await db.execute(repos_stmt, {"skill": name})
+    rows = repos_result.mappings().all()
+
+    repos = [
+        {
+            "name": row["name"],
+            "owner": row["owner"],
+            "description": row["description"],
+            "githubUrl": row["github_url"],
+            "primaryLanguage": row["primary_language"],
+            "stars": row["stargazers_count"] or row["parent_stars"] or 0,
+            "activityScore": row["activity_score"],
+            "readmeSummary": row["readme_summary"],
+        }
+        for row in rows
+    ]
+
+    return {
+        "skillArea": {
+            "id": skill_area.id,
+            "name": skill_area.name,
+            "lifecycleGroup": skill_area.lifecycle_group,
+            "description": skill_area.description,
+            "icon": skill_area.icon,
+            "color": skill_area.color,
+        },
+        "repos": repos,
+        "repoCount": len(repos),
+    }

--- a/migrations/versions/010_add_skill_areas_table.py
+++ b/migrations/versions/010_add_skill_areas_table.py
@@ -1,0 +1,189 @@
+"""add skill_areas table with seed data
+
+Revision ID: 010
+Revises: 009
+Create Date: 2026-03-24
+"""
+from alembic import op
+
+revision = '010'
+down_revision = '009'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS skill_areas (
+            id SERIAL PRIMARY KEY,
+            name TEXT NOT NULL UNIQUE,
+            lifecycle_group TEXT NOT NULL,
+            description TEXT,
+            icon TEXT,
+            color TEXT,
+            sort_order INT DEFAULT 0,
+            min_repos_to_display INT DEFAULT 1,
+            created_at TIMESTAMPTZ DEFAULT NOW()
+        )
+    """)
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS ix_skill_areas_lifecycle_group "
+        "ON skill_areas (lifecycle_group)"
+    )
+
+    # Foundation & Training
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('Foundation Model Architecture', 'Foundation & Training', 1) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('Fine-tuning & Alignment', 'Foundation & Training', 2) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('Data Engineering', 'Foundation & Training', 3) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('Synthetic Data', 'Foundation & Training', 4) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+
+    # Inference & Deployment
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('Inference & Serving', 'Inference & Deployment', 5) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('Model Compression', 'Inference & Deployment', 6) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('Edge AI', 'Inference & Deployment', 7) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+
+    # LLM Application Layer
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('Agents & Orchestration', 'LLM Application Layer', 8) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('RAG & Retrieval', 'LLM Application Layer', 9) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('Context Engineering', 'LLM Application Layer', 10) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('Tool Use', 'LLM Application Layer', 11) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('Structured Output', 'LLM Application Layer', 12) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('Prompt Engineering', 'LLM Application Layer', 13) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('Knowledge Graphs', 'LLM Application Layer', 14) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+
+    # Eval / Safety / Ops
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('Evaluation', 'Eval / Safety / Ops', 15) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('Security & Guardrails', 'Eval / Safety / Ops', 16) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('Observability', 'Eval / Safety / Ops', 17) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('MLOps', 'Eval / Safety / Ops', 18) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('AI Governance', 'Eval / Safety / Ops', 19) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+
+    # Modality-Specific
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('Computer Vision', 'Modality-Specific', 20) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('Speech & Audio', 'Modality-Specific', 21) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('Generative Media', 'Modality-Specific', 22) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('NLP', 'Modality-Specific', 23) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('Multimodal', 'Modality-Specific', 24) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+
+    # Applied AI
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('Coding Assistants', 'Applied AI', 25) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('Robotics', 'Applied AI', 26) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('AI for Science', 'Applied AI', 27) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+    op.execute(
+        "INSERT INTO skill_areas (name, lifecycle_group, sort_order) "
+        "VALUES ('Recommendation Systems', 'Applied AI', 28) "
+        "ON CONFLICT (name) DO NOTHING"
+    )
+
+
+def downgrade():
+    op.execute("DROP INDEX IF EXISTS ix_skill_areas_lifecycle_group")
+    op.execute("DROP TABLE IF EXISTS skill_areas")


### PR DESCRIPTION
## Summary

- Adds migration `010_add_skill_areas_table.py` — creates `skill_areas` table and seeds all 28 skill areas with lifecycle groups; each INSERT is a separate `op.execute()` call (asyncpg-safe)
- Adds `SkillArea` SQLAlchemy model to `app/models/repo.py`
- Creates `app/routers/taxonomy.py` with `GET /taxonomy/skill-areas` (grouped + repoCount, filtered by min_repos_to_display) and `GET /taxonomy/skill-areas/{name}/repos`
- Registers `taxonomy.router` with prefix `/taxonomy` in `app/main.py`
- Replaces hardcoded `LIFECYCLE_GROUPS` dict in `library_full.py` with `_get_lifecycle_groups(db)` async helper: queries `skill_areas` table, caches in memory for 5 minutes, falls back to compile-time dict if table unavailable

**Result:** Adding a new skill area = DB insert only. No code change required, no re-enrichment of existing repos.

## Test plan

- [ ] Run `alembic upgrade head` — verify `skill_areas` table created with 28 rows
- [ ] `GET /taxonomy/skill-areas` returns groups: Foundation & Training, Inference & Deployment, LLM Application Layer, Eval / Safety / Ops, Modality-Specific, Applied AI
- [ ] `GET /taxonomy/skill-areas/RAG%20%26%20Retrieval/repos` returns repos list with repoCount
- [ ] `GET /taxonomy/skill-areas/Nonexistent/repos` returns 404
- [ ] `GET /library/full` still returns correct lifecycleGroup values on aiDevSkills and aiDevSkillStats
- [ ] Insert a new row into skill_areas; within 5 minutes it appears in /taxonomy/skill-areas without any code deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)