### PR TITLE
fix: resolve duplicate revision-010 migration conflict

### DIFF
--- a/migrations/versions/011_add_skill_areas_table.py
+++ b/migrations/versions/011_add_skill_areas_table.py
@@ -1,13 +1,13 @@
 """add skill_areas table with seed data
 
-Revision ID: 010
-Revises: 009
+Revision ID: 011
+Revises: 010
 Create Date: 2026-03-24
 """
 from alembic import op
 
-revision = '010'
-down_revision = '009'
+revision = '011'
+down_revision = '010'
 branch_labels = None
 depends_on = None
 

--- a/migrations/versions/012_add_query_log_semantic_cache_fields.py
+++ b/migrations/versions/012_add_query_log_semantic_cache_fields.py
@@ -1,7 +1,7 @@
 """Add query_log fields needed for semantic caching
 
-Revision ID: 011
-Revises: 010
+Revision ID: 012
+Revises: 011
 Create Date: 2026-03-24
 
 Adds:
@@ -13,8 +13,8 @@ from typing import Sequence, Union
 
 from alembic import op
 
-revision: str = "011"
-down_revision: Union[str, None] = "010"
+revision: str = "012"
+down_revision: Union[str, None] = "011"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary

- Both `010_add_open_issues_count` (Codex PR #62) and `010_add_skill_areas_table` (PR #67) were independently assigned `revision='010'` and `down_revision='009'`
- Alembic throws a **multiple-head error** on startup when two migrations share the same revision ID — this would prevent `alembic upgrade head` from running on deploy
- Renumbers the chain to be linear: 009 → 010 (open_issues) → 011 (skill_areas) → 012 (query_log_semantic_cache)

## Changes
- `010_add_skill_areas_table.py` → renamed `011_add_skill_areas_table.py`, `revision='011'`, `down_revision='010'`
- `011_add_query_log_semantic_cache_fields.py` → renamed `012_add_query_log_semantic_cache_fields.py`, `revision='012'`, `down_revision='011'`

## Test plan
- [ ] `alembic upgrade head` runs without "Multiple head revisions" error
- [ ] All 4 migrations apply cleanly: 009 → 010 → 011 → 012

🤖 Generated with [Claude Code](https://claude.com/claude-code)