### PR TITLE
feat: add pgvector semantic search endpoint

### DIFF
--- a/app/embeddings.py
+++ b/app/embeddings.py
@@ -1,0 +1,16 @@
+import logging
+
+from sentence_transformers import SentenceTransformer
+
+logger = logging.getLogger(__name__)
+
+_model: SentenceTransformer | None = None
+
+
+def get_embedding_model() -> SentenceTransformer:
+    global _model
+    if _model is None:
+        logger.info("Loading sentence-transformers semantic search model...")
+        _model = SentenceTransformer("all-MiniLM-L6-v2")
+        logger.info("Semantic search model loaded")
+    return _model

--- a/app/routers/search.py
+++ b/app/routers/search.py
@@ -1,19 +1,21 @@
 from fastapi import APIRouter, Depends, Query, Request
 from slowapi import Limiter
 from slowapi.util import get_remote_address
-from sqlalchemy import or_, select
+from sqlalchemy import or_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.database import get_db
+from app.embeddings import get_embedding_model
 from app.models.repo import Repo
 from app.routers.library import _repo_to_summary
-from app.schemas.repo import RepoSummary
+from app.schemas.repo import RepoSemanticResult, RepoSummary
 
 router = APIRouter()
 limiter = Limiter(key_func=get_remote_address)
 
 MAX_RESULTS = 20
+MAX_SEMANTIC_RESULTS = 50
 
 
 @router.get("/search", response_model=list[RepoSummary])
@@ -51,3 +53,98 @@ async def search_repos(
     result = await db.execute(stmt)
     repos = result.scalars().all()
     return [_repo_to_summary(r) for r in repos]
+
+
+def _vec_to_pg(arr) -> str:
+    return "[" + ",".join(f"{x:.8f}" for x in arr.tolist()) + "]"
+
+
+async def _semantic_candidate_rows(
+    db: AsyncSession,
+    *,
+    query_embedding,
+    limit: int,
+):
+    vec_str = _vec_to_pg(query_embedding)
+    result = await db.execute(
+        text("""
+            SELECT r.id AS repo_id,
+                   1 - (re.embedding_vec <=> CAST(:vec AS vector)) AS similarity
+            FROM repo_embeddings re
+            JOIN repos r ON r.id = re.repo_id
+            WHERE re.embedding_vec IS NOT NULL
+              AND r.is_private = false
+            ORDER BY re.embedding_vec <=> CAST(:vec AS vector)
+            LIMIT :limit
+        """),
+        {"vec": vec_str, "limit": limit},
+    )
+    return result.fetchall()
+
+
+async def _hydrate_semantic_results(
+    db: AsyncSession,
+    *,
+    candidate_rows,
+) -> list[RepoSemanticResult]:
+    if not candidate_rows:
+        return []
+
+    repo_ids = [row.repo_id for row in candidate_rows]
+    similarity_by_id = {row.repo_id: float(row.similarity) for row in candidate_rows}
+
+    stmt = (
+        select(Repo)
+        .where(Repo.id.in_(repo_ids))
+        .options(
+            selectinload(Repo.tags),
+            selectinload(Repo.categories),
+            selectinload(Repo.builders),
+            selectinload(Repo.ai_dev_skills),
+            selectinload(Repo.pm_skills),
+            selectinload(Repo.languages),
+        )
+    )
+    result = await db.execute(stmt)
+    repo_map = {repo.id: repo for repo in result.scalars().all()}
+
+    ordered_results: list[RepoSemanticResult] = []
+    for repo_id in repo_ids:
+        repo = repo_map.get(repo_id)
+        if repo is None:
+            continue
+        ordered_results.append(
+            RepoSemanticResult(
+                **_repo_to_summary(repo).model_dump(),
+                similarity=round(similarity_by_id[repo_id], 6),
+            )
+        )
+
+    return ordered_results
+
+
+async def _semantic_search(
+    db: AsyncSession,
+    *,
+    query: str,
+    limit: int,
+) -> list[RepoSemanticResult]:
+    model = get_embedding_model()
+    query_embedding = model.encode(query)
+    candidate_rows = await _semantic_candidate_rows(
+        db,
+        query_embedding=query_embedding,
+        limit=limit,
+    )
+    return await _hydrate_semantic_results(db, candidate_rows=candidate_rows)
+
+
+@router.get("/search/semantic", response_model=list[RepoSemanticResult])
+@limiter.limit("10/minute")
+async def semantic_search_repos(
+    request: Request,
+    q: str = Query(..., min_length=1),
+    limit: int = Query(default=10, ge=1, le=MAX_SEMANTIC_RESULTS),
+    db: AsyncSession = Depends(get_db),
+) -> list[RepoSemanticResult]:
+    return await _semantic_search(db, query=q, limit=limit)

--- a/app/schemas/repo.py
+++ b/app/schemas/repo.py
@@ -86,6 +86,10 @@ class RepoDetail(RepoSummary):
     commits: list[CommitRef] = []
 
 
+class RepoSemanticResult(RepoSummary):
+    similarity: float
+
+
 # --- Ingest input schemas ---
 
 class CategoryIngest(BaseModel):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,6 +1,9 @@
 import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 from httpx import AsyncClient
 
+from app.routers.search import _semantic_search
 from tests.conftest import AUTH_HEADERS, TEST_REPO_FIXTURE
 
 
@@ -37,3 +40,105 @@ async def test_search_no_results(client: AsyncClient):
 async def test_search_requires_query(client: AsyncClient):
     response = await client.get("/search")
     assert response.status_code == 422
+
+
+def _fake_repo(*, repo_id: str, name: str, owner: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=repo_id,
+        name=name,
+        owner=owner,
+        description=f"{name} description",
+        is_fork=False,
+        forked_from=None,
+        primary_language="Python",
+        github_url=f"https://github.com/{owner}/{name}",
+        fork_sync_state=None,
+        behind_by=0,
+        ahead_by=0,
+        upstream_created_at=None,
+        forked_at=None,
+        your_last_push_at=None,
+        upstream_last_push_at=None,
+        parent_stars=100,
+        parent_forks=10,
+        parent_is_archived=False,
+        stargazers_count=25,
+        open_issues_count=3,
+        commits_last_7_days=1,
+        commits_last_30_days=2,
+        commits_last_90_days=3,
+        readme_summary=f"{name} summary",
+        activity_score=80,
+        ingested_at="2026-03-24T00:00:00Z",
+        updated_at="2026-03-24T00:00:00Z",
+        github_updated_at=None,
+        tags=[],
+        categories=[],
+        builders=[],
+        ai_dev_skills=[],
+        pm_skills=[],
+        languages=[],
+    )
+
+
+class _FetchAllResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def fetchall(self):
+        return self._rows
+
+
+class _ScalarsResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return self._rows
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_calls_distance_query_and_applies_limit():
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[
+        _FetchAllResult([]),
+    ])
+    fake_model = MagicMock()
+    fake_model.encode.return_value = MagicMock(tolist=lambda: [0.1, 0.2, 0.3])
+
+    with patch("app.routers.search.get_embedding_model", return_value=fake_model):
+        results = await _semantic_search(db, query="vector databases", limit=7)
+
+    assert results == []
+    db.execute.assert_awaited_once()
+    stmt, params = db.execute.await_args.args
+    assert "<=>" in str(stmt)
+    assert params["limit"] == 7
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_returns_results_ordered_by_similarity():
+    candidate_rows = [
+        SimpleNamespace(repo_id="00000000-0000-0000-0000-000000000002", similarity=0.95),
+        SimpleNamespace(repo_id="00000000-0000-0000-0000-000000000001", similarity=0.81),
+    ]
+    repos = [
+        _fake_repo(repo_id="00000000-0000-0000-0000-000000000001", name="second", owner="perditioinc"),
+        _fake_repo(repo_id="00000000-0000-0000-0000-000000000002", name="first", owner="perditioinc"),
+    ]
+    db = AsyncMock()
+    db.execute = AsyncMock(side_effect=[
+        _FetchAllResult(candidate_rows),
+        _ScalarsResult(repos),
+    ])
+    fake_model = MagicMock()
+    fake_model.encode.return_value = MagicMock(tolist=lambda: [0.1, 0.2, 0.3])
+
+    with patch("app.routers.search.get_embedding_model", return_value=fake_model):
+        results = await _semantic_search(db, query="agent orchestration", limit=2)
+
+    assert [result.name for result in results] == ["first", "second"]
+    assert [result.similarity for result in results] == [0.95, 0.81]


### PR DESCRIPTION
## Changes
- add a lazy sentence-transformers singleton in `app/embeddings.py`
- add `GET /search/semantic?q=...&limit=...` backed by `repo_embeddings.embedding_vec`
- use pgvector cosine distance ordering against the existing HNSW index
- hydrate semantic hits back into full repo summaries with an added `similarity` field
- rate limit semantic search to `10/minute`
- add mocked search tests covering the vector distance query, ordering, and limit handling

## Validation
- `python -m py_compile app/embeddings.py app/routers/search.py app/schemas/repo.py tests/test_search.py`
- `python -m pytest tests/test_search.py -q -k "semantic_search"`

## Notes
- This stays on top of the existing `repo_embeddings.embedding_vec vector(384)` index path and does not touch taxonomy re-enrichment work.
