### PR TITLE
fix: security hardening — CORS, admin API key, migration 014, license_spdx

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -1,5 +1,8 @@
+import os
+
 from fastapi import HTTPException, Security, status
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi.security.api_key import APIKeyHeader
 
 from app.config import settings
 
@@ -15,3 +18,38 @@ async def verify_api_key(
             detail="Invalid API key",
         )
     return credentials.credentials
+
+
+# ---------------------------------------------------------------------------
+# Admin key — protects admin-only endpoints (POST /admin/*, /admin/taxonomy/*)
+# ---------------------------------------------------------------------------
+
+_ADMIN_KEY_HEADER = APIKeyHeader(name="X-Admin-Key", auto_error=False)
+
+
+async def require_admin_key(
+    x_admin_key: str | None = Security(_ADMIN_KEY_HEADER),
+) -> None:
+    admin_key = os.getenv("ADMIN_API_KEY")
+    if not admin_key:
+        return  # No key configured — allow (dev mode)
+    if x_admin_key != admin_key:
+        raise HTTPException(status_code=403, detail="Invalid admin key")
+
+
+# ---------------------------------------------------------------------------
+# Ingest key — protects ingest pipeline endpoints (POST /ingest/repos, /enrich)
+# Separate credential from admin key so the ingestion pipeline has its own token.
+# ---------------------------------------------------------------------------
+
+_INGEST_KEY_HEADER = APIKeyHeader(name="X-Admin-Key", auto_error=False)
+
+
+async def require_ingest_key(
+    x_admin_key: str | None = Security(_INGEST_KEY_HEADER),
+) -> None:
+    ingest_key = os.getenv("INGEST_API_KEY")
+    if not ingest_key:
+        return  # No key configured — allow (dev mode)
+    if x_admin_key != ingest_key:
+        raise HTTPException(status_code=403, detail="Invalid ingest key")

--- a/app/models/repo.py
+++ b/app/models/repo.py
@@ -65,6 +65,7 @@ class Repo(Base):
 
     # Enrichment extras
     problem_solved: Mapped[str | None] = mapped_column(Text)
+    license_spdx: Mapped[str | None] = mapped_column(Text)
 
     # Relationships
     tags: Mapped[list["RepoTag"]] = relationship(

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy import delete, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth import verify_api_key
+from app.auth import require_admin_key, verify_api_key
 from app.cache import cache
 from app.database import get_db
 from app.models.repo import RepoTag
@@ -61,6 +61,7 @@ async def _prune_noise_tags(db: AsyncSession, *, dry_run: bool) -> dict:
 async def data_quality(
     db: AsyncSession = Depends(get_db),
     _api_key: str = Depends(verify_api_key),
+    _admin_key: None = Depends(require_admin_key),
 ):
 
     # Query counts
@@ -117,5 +118,6 @@ async def prune_tags(
     dry_run: bool = Query(default=False),
     db: AsyncSession = Depends(get_db),
     _api_key: str = Depends(verify_api_key),
+    _admin_key: None = Depends(require_admin_key),
 ):
     return await _prune_noise_tags(db, dry_run=dry_run)

--- a/app/routers/ingest.py
+++ b/app/routers/ingest.py
@@ -9,7 +9,7 @@ from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth import verify_api_key
+from app.auth import require_ingest_key, verify_api_key
 from app.cache import cache
 from app.database import get_db
 from app.models.repo import (
@@ -30,7 +30,7 @@ from app.schemas.trend import GapAnalysisIn, GapAnalysisOut, IngestionLogIn, Ing
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/ingest", dependencies=[Depends(verify_api_key)])
+router = APIRouter(prefix="/ingest", dependencies=[Depends(verify_api_key), Depends(require_ingest_key)])
 limiter = Limiter(key_func=get_remote_address)
 
 MAX_BATCH = 100

--- a/app/routers/library_full.py
+++ b/app/routers/library_full.py
@@ -536,6 +536,7 @@ def _build_enriched_repo(repo: dict, languages: list, categories: list,
             for t in (taxonomy or [])
         ],
         "problemSolved": repo.get("problem_solved"),
+        "licenseSpdx": repo.get("license_spdx"),
         "builders": [
             {
                 "login": b["login"],

--- a/app/routers/taxonomy.py
+++ b/app/routers/taxonomy.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel
 from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth import verify_api_key
+from app.auth import require_admin_key, verify_api_key
 from app.database import get_db
 from app.models.repo import SkillArea, TaxonomyValue
 
@@ -196,7 +196,7 @@ async def list_taxonomy_values(
     }
 
 
-@router.post("/admin/taxonomy/rebuild", dependencies=[Depends(verify_api_key)])
+@router.post("/admin/taxonomy/rebuild", dependencies=[Depends(verify_api_key), Depends(require_admin_key)])
 async def rebuild_taxonomy(
     body: RebuildBody = RebuildBody(),
     db: AsyncSession = Depends(get_db),
@@ -240,7 +240,7 @@ async def rebuild_taxonomy(
     return {"status": "ok", "upserted": upserted, "dimensions": dimensions}
 
 
-@router.post("/admin/taxonomy/embed", dependencies=[Depends(verify_api_key)])
+@router.post("/admin/taxonomy/embed", dependencies=[Depends(verify_api_key), Depends(require_admin_key)])
 async def embed_taxonomy(db: AsyncSession = Depends(get_db)) -> dict:
     """
     Generate embeddings for taxonomy_values that are missing embedding_vec.
@@ -272,7 +272,7 @@ async def embed_taxonomy(db: AsyncSession = Depends(get_db)) -> dict:
     return {"status": "ok", "embedded": embedded}
 
 
-@router.post("/admin/taxonomy/assign", dependencies=[Depends(verify_api_key)])
+@router.post("/admin/taxonomy/assign", dependencies=[Depends(verify_api_key), Depends(require_admin_key)])
 async def assign_taxonomy(
     body: AssignBody = AssignBody(),
     db: AsyncSession = Depends(get_db),

--- a/app/schemas/repo.py
+++ b/app/schemas/repo.py
@@ -76,6 +76,7 @@ class RepoSummary(BaseModel):
     readme_summary: str | None = None
     activity_score: int = 0
     problem_solved: str | None = None
+    license_spdx: str | None = None
 
     ingested_at: datetime
     updated_at: datetime

--- a/migrations/versions/014_cleanup_hardcoded_seeds_and_dead_columns.py
+++ b/migrations/versions/014_cleanup_hardcoded_seeds_and_dead_columns.py
@@ -1,0 +1,34 @@
+"""Clean up hardcoded seed data, drop dead columns, and add license_spdx.
+
+Revision ID: 014
+Revises: 013
+Create Date: 2026-03-24
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "014"
+down_revision = "013"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Remove the 28 hardcoded seed rows from skill_areas.
+    # The taxonomy rebuild pipeline will repopulate from real data.
+    op.execute("DELETE FROM skill_areas WHERE id > 0")
+
+    # Drop dead columns defined in migration 002 but never populated or used.
+    op.execute("ALTER TABLE repos DROP COLUMN IF EXISTS dependencies")
+    op.execute("ALTER TABLE repos DROP COLUMN IF EXISTS quality_signals")
+
+    # Add license_spdx column to repos table.
+    op.execute("ALTER TABLE repos ADD COLUMN IF NOT EXISTS license_spdx TEXT")
+
+
+def downgrade() -> None:
+    # Seed data cannot be restored — drop the column additions only.
+    op.execute("ALTER TABLE repos DROP COLUMN IF EXISTS license_spdx")
+    op.execute("ALTER TABLE repos ADD COLUMN IF NOT EXISTS dependencies JSONB")
+    op.execute("ALTER TABLE repos ADD COLUMN IF NOT EXISTS quality_signals JSONB")


### PR DESCRIPTION
## Summary

Five security and cleanup items, all on one branch.

### 1. CORS fix
`fix/cors-restrict-origins` was already merged into dev. Verified: `allow_origins` in `app/main.py` is restricted to `https://reporium.com`, `https://www.reporium.com`, `https://perditioinc.github.io` — wildcard `*` removed. CORS tests in `tests/test_cors.py` also already present.

### 2. Admin endpoint authentication
Added `require_admin_key` (checks `ADMIN_API_KEY` env var) and `require_ingest_key` (checks `INGEST_API_KEY` env var) to `app/auth.py` using `APIKeyHeader(name="X-Admin-Key")`.

Applied to:
- `app/routers/admin.py` — `GET /admin/data-quality`, `POST /admin/tags/prune`
- `app/routers/taxonomy.py` — `POST /admin/taxonomy/rebuild`, `/embed`, `/assign`
- `app/routers/ingest.py` — all `/ingest/*` routes (router-level dependency)

Both keys default to allow-all when env var is unset (dev mode).

### 3. Migration 014 — cleanup hardcoded seeds and dead columns
New file: `migrations/versions/014_cleanup_hardcoded_seeds_and_dead_columns.py`
- Deletes 28 hardcoded seed rows from `skill_areas` (taxonomy rebuild repopulates from real data)
- Drops dead `dependencies` and `quality_signals` columns on `repos` (defined in migration 002, never populated)
- Adds `license_spdx TEXT` column to `repos`

### 4. `license_spdx` field
- `app/models/repo.py`: `license_spdx: Mapped[str | None] = mapped_column(Text)` on `Repo`
- `app/schemas/repo.py`: `license_spdx: str | None = None` on `RepoSummary`
- `app/routers/library_full.py`: `"licenseSpdx": repo.get("license_spdx")` in `_build_enriched_repo`

### 5. Stale PR cleanup
- **PR #42** (feature/p0-scale) — closed. All changes (stable UUIDs, full_name/migration 006, pgvector/migration 007, pagination, intelligence enhancements) fully absorbed into dev via commits 14bff81 and later merges.
- **PR #54** (fix/fix-created-at-date) — closed. The single-line createdAt fix is superseded: dev already uses `github_created_at` for built repos and `upstream_created_at` for forks (migration 009, commit 68c6fa1).

## Test plan
- [ ] `python -m py_compile app/auth.py app/routers/admin.py app/routers/taxonomy.py app/routers/ingest.py` — passes
- [ ] `POST /admin/tags/prune` without `X-Admin-Key` returns 403 when `ADMIN_API_KEY` is set
- [ ] `POST /ingest/repos` without `X-Admin-Key` returns 403 when `INGEST_API_KEY` is set
- [ ] Dev mode (no env vars) — all admin routes still accessible
- [ ] Run migration 014 on staging; confirm `skill_areas` is empty, `dependencies`/`quality_signals` columns gone, `license_spdx` column present
- [ ] `GET /library/full` response includes `licenseSpdx` field on each repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)