### PR TITLE
feat: add proactive portfolio insights endpoint

### DIFF
--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -27,6 +27,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sentence_transformers import SentenceTransformer
 
 from app.auth import verify_api_key
+from app.cache import CACHE_TTL_STATS, cache
 from app.circuit_breaker import anthropic_breaker
 from app.database import async_session_factory, get_db
 # Rate limiter for the public /ask endpoint (no auth, IP-based)
@@ -221,6 +222,47 @@ class QueryResponse(BaseModel):
     tokens_used: dict
 
 
+class TaxonomyGapSignal(BaseModel):
+    dimension: str
+    value: str
+    repo_count: int
+    trending_score: float
+    description: str | None = None
+
+
+class StaleRepoSignal(BaseModel):
+    repo_name: str
+    owner: str
+    github_url: str
+    parent_stars: int | None = None
+    activity_score: int = 0
+    last_updated_at: str | None = None
+    stale_days: int
+
+
+class VelocityLeaderSignal(BaseModel):
+    repo_name: str
+    owner: str
+    github_url: str
+    commits_last_7_days: int
+    commits_last_30_days: int
+    activity_score: int
+
+
+class DuplicateClusterSignal(BaseModel):
+    similarity: float
+    repos: list[str]
+
+
+class PortfolioInsightsResponse(BaseModel):
+    generated_at: str
+    taxonomy_gaps: list[TaxonomyGapSignal]
+    stale_repos: list[StaleRepoSignal]
+    velocity_leaders: list[VelocityLeaderSignal]
+    near_duplicate_clusters: list[DuplicateClusterSignal]
+    summary: list[str]
+
+
 def _coerce_cached_sources(raw_sources: object) -> list[SourceRepo]:
     if isinstance(raw_sources, str):
         try:
@@ -283,6 +325,179 @@ async def _find_semantic_cache_hit(
     if row is None or not row.answer_full:
         return None
     return row.answer_full, _coerce_cached_sources(row.sources), row.model
+
+
+async def _taxonomy_gap_signals(db: AsyncSession, limit: int = 6) -> list[TaxonomyGapSignal]:
+    result = await db.execute(
+        text("""
+            SELECT dimension, name, repo_count, trending_score, description
+            FROM taxonomy_values
+            WHERE repo_count <= 5
+              AND trending_score > 0
+            ORDER BY trending_score DESC, repo_count ASC, name ASC
+            LIMIT :limit
+        """),
+        {"limit": limit},
+    )
+    return [
+        TaxonomyGapSignal(
+            dimension=row.dimension,
+            value=row.name,
+            repo_count=int(row.repo_count or 0),
+            trending_score=float(row.trending_score or 0.0),
+            description=row.description,
+        )
+        for row in result.fetchall()
+    ]
+
+
+async def _stale_repo_signals(db: AsyncSession, limit: int = 6) -> list[StaleRepoSignal]:
+    result = await db.execute(
+        text("""
+            SELECT name,
+                   owner,
+                   github_url,
+                   parent_stars,
+                   activity_score,
+                   COALESCE(your_last_push_at, upstream_last_push_at, github_updated_at, updated_at) AS last_updated_at,
+                   EXTRACT(DAY FROM (NOW() - COALESCE(your_last_push_at, upstream_last_push_at, github_updated_at, updated_at))) AS stale_days
+            FROM repos
+            WHERE is_private = false
+              AND parent_is_archived = false
+              AND COALESCE(your_last_push_at, upstream_last_push_at, github_updated_at, updated_at) < NOW() - INTERVAL '180 days'
+            ORDER BY stale_days DESC, COALESCE(parent_stars, stargazers_count, 0) DESC
+            LIMIT :limit
+        """),
+        {"limit": limit},
+    )
+    return [
+        StaleRepoSignal(
+            repo_name=row.name,
+            owner=row.owner,
+            github_url=row.github_url,
+            parent_stars=row.parent_stars,
+            activity_score=int(row.activity_score or 0),
+            last_updated_at=row.last_updated_at.isoformat() if row.last_updated_at else None,
+            stale_days=int(float(row.stale_days or 0)),
+        )
+        for row in result.fetchall()
+    ]
+
+
+async def _velocity_leader_signals(db: AsyncSession, limit: int = 6) -> list[VelocityLeaderSignal]:
+    result = await db.execute(
+        text("""
+            SELECT name, owner, github_url, commits_last_7_days, commits_last_30_days, activity_score
+            FROM repos
+            WHERE is_private = false
+              AND commits_last_30_days > 0
+            ORDER BY commits_last_30_days DESC, commits_last_7_days DESC, activity_score DESC
+            LIMIT :limit
+        """),
+        {"limit": limit},
+    )
+    return [
+        VelocityLeaderSignal(
+            repo_name=row.name,
+            owner=row.owner,
+            github_url=row.github_url,
+            commits_last_7_days=int(row.commits_last_7_days or 0),
+            commits_last_30_days=int(row.commits_last_30_days or 0),
+            activity_score=int(row.activity_score or 0),
+        )
+        for row in result.fetchall()
+    ]
+
+
+async def _near_duplicate_signals(db: AsyncSession, limit: int = 4) -> list[DuplicateClusterSignal]:
+    result = await db.execute(
+        text("""
+            SELECT r1.owner AS owner_a,
+                   r1.name AS repo_a,
+                   r2.owner AS owner_b,
+                   r2.name AS repo_b,
+                   1 - (e1.embedding_vec <=> e2.embedding_vec) AS similarity
+            FROM repo_embeddings e1
+            JOIN repo_embeddings e2 ON e1.repo_id < e2.repo_id
+            JOIN repos r1 ON r1.id = e1.repo_id
+            JOIN repos r2 ON r2.id = e2.repo_id
+            WHERE e1.embedding_vec IS NOT NULL
+              AND e2.embedding_vec IS NOT NULL
+              AND r1.is_private = false
+              AND r2.is_private = false
+              AND (1 - (e1.embedding_vec <=> e2.embedding_vec)) >= 0.92
+            ORDER BY similarity DESC
+            LIMIT :limit
+        """),
+        {"limit": limit},
+    )
+    return [
+        DuplicateClusterSignal(
+            similarity=round(float(row.similarity or 0.0), 4),
+            repos=[f"{row.owner_a}/{row.repo_a}", f"{row.owner_b}/{row.repo_b}"],
+        )
+        for row in result.fetchall()
+    ]
+
+
+def _portfolio_summary(
+    taxonomy_gaps: list[TaxonomyGapSignal],
+    stale_repos: list[StaleRepoSignal],
+    velocity_leaders: list[VelocityLeaderSignal],
+    near_duplicate_clusters: list[DuplicateClusterSignal],
+) -> list[str]:
+    summary: list[str] = []
+    if taxonomy_gaps:
+        top_gap = taxonomy_gaps[0]
+        summary.append(
+            f"{top_gap.value} is the sharpest emerging {top_gap.dimension.replace('_', ' ')} gap with a trending score of {top_gap.trending_score:.2f} across only {top_gap.repo_count} repos."
+        )
+    if stale_repos:
+        stalest = stale_repos[0]
+        summary.append(
+            f"{stalest.owner}/{stalest.repo_name} is the stalest high-signal repo in the portfolio at {stalest.stale_days} days since the last observed update."
+        )
+    if velocity_leaders:
+        leader = velocity_leaders[0]
+        summary.append(
+            f"{leader.owner}/{leader.repo_name} is leading portfolio velocity with {leader.commits_last_30_days} commits in the last 30 days."
+        )
+    if near_duplicate_clusters:
+        duplicate = near_duplicate_clusters[0]
+        summary.append(
+            f"{duplicate.repos[0]} and {duplicate.repos[1]} look like the strongest near-duplicate pair at {duplicate.similarity * 100:.1f}% similarity."
+        )
+    return summary
+
+
+async def _portfolio_insights(db: AsyncSession) -> PortfolioInsightsResponse:
+    cache_key = "intelligence:portfolio-insights"
+    cached = await cache.get(cache_key)
+    if cached:
+        return PortfolioInsightsResponse(**cached)
+
+    taxonomy_gaps, stale_repos, velocity_leaders, near_duplicate_clusters = await asyncio.gather(
+        _taxonomy_gap_signals(db),
+        _stale_repo_signals(db),
+        _velocity_leader_signals(db),
+        _near_duplicate_signals(db),
+    )
+
+    response = PortfolioInsightsResponse(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        taxonomy_gaps=taxonomy_gaps,
+        stale_repos=stale_repos,
+        velocity_leaders=velocity_leaders,
+        near_duplicate_clusters=near_duplicate_clusters,
+        summary=_portfolio_summary(
+            taxonomy_gaps,
+            stale_repos,
+            velocity_leaders,
+            near_duplicate_clusters,
+        ),
+    )
+    await cache.set(cache_key, response.model_dump(), ttl=CACHE_TTL_STATS)
+    return response
 
 
 async def _run_query(
@@ -534,3 +749,13 @@ async def intelligence_ask(
     the repo knowledge base. Rate limited to 10/minute and 100/day per IP.
     """
     return await _run_query(req, db, client_ip=get_remote_address(request))
+
+
+@router.get("/portfolio-insights", response_model=PortfolioInsightsResponse)
+@_limiter.limit("12/minute")
+async def portfolio_insights(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    """Curated intelligence feed for the portfolio dashboard."""
+    return await _portfolio_insights(db)

--- a/tests/test_intelligence.py
+++ b/tests/test_intelligence.py
@@ -15,12 +15,19 @@ import pytest
 from httpx import AsyncClient
 
 from app.routers.intelligence import (
+    DuplicateClusterSignal,
+    PortfolioInsightsResponse,
     QueryRequest,
+    StaleRepoSignal,
+    TaxonomyGapSignal,
+    VelocityLeaderSignal,
     _coerce_cached_sources,
     _estimate_cost,
     _find_semantic_cache_hit,
     _hash_ip,
     _log_query,
+    _portfolio_insights,
+    _portfolio_summary,
     _run_query,
 )
 
@@ -331,3 +338,62 @@ async def test_run_query_returns_semantic_cache_hit_without_calling_anthropic():
     assert response.sources[0].owner == "perditioinc"
     anthropic_client.assert_not_called()
     mock_log_query.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_portfolio_insights_uses_cached_payload():
+    cached_payload = PortfolioInsightsResponse(
+        generated_at="2026-03-24T00:00:00+00:00",
+        taxonomy_gaps=[],
+        stale_repos=[],
+        velocity_leaders=[],
+        near_duplicate_clusters=[],
+        summary=[],
+    ).model_dump()
+    db = AsyncMock()
+
+    with patch("app.routers.intelligence.cache.get", new=AsyncMock(return_value=cached_payload)), \
+         patch("app.routers.intelligence.cache.set", new=AsyncMock()) as cache_set:
+        response = await _portfolio_insights(db)
+
+    assert response.generated_at == "2026-03-24T00:00:00+00:00"
+    cache_set.assert_not_awaited()
+    db.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_portfolio_insights_builds_and_caches_response():
+    db = AsyncMock()
+    taxonomy_gaps = [TaxonomyGapSignal(dimension="ai_trend", value="Agent Memory", repo_count=2, trending_score=8.4)]
+    stale_repos = [StaleRepoSignal(repo_name="stale-repo", owner="perditioinc", github_url="https://github.com/perditioinc/stale-repo", stale_days=245)]
+    velocity_leaders = [VelocityLeaderSignal(repo_name="fast-repo", owner="perditioinc", github_url="https://github.com/perditioinc/fast-repo", commits_last_7_days=14, commits_last_30_days=41, activity_score=92)]
+    duplicate_clusters = [DuplicateClusterSignal(similarity=0.9442, repos=["perditioinc/a", "perditioinc/b"])]
+
+    with patch("app.routers.intelligence.cache.get", new=AsyncMock(return_value=None)), \
+         patch("app.routers.intelligence.cache.set", new=AsyncMock()) as cache_set, \
+         patch("app.routers.intelligence._taxonomy_gap_signals", new=AsyncMock(return_value=taxonomy_gaps)), \
+         patch("app.routers.intelligence._stale_repo_signals", new=AsyncMock(return_value=stale_repos)), \
+         patch("app.routers.intelligence._velocity_leader_signals", new=AsyncMock(return_value=velocity_leaders)), \
+         patch("app.routers.intelligence._near_duplicate_signals", new=AsyncMock(return_value=duplicate_clusters)):
+        response = await _portfolio_insights(db)
+
+    assert response.taxonomy_gaps[0].value == "Agent Memory"
+    assert response.stale_repos[0].repo_name == "stale-repo"
+    assert response.velocity_leaders[0].repo_name == "fast-repo"
+    assert response.near_duplicate_clusters[0].repos == ["perditioinc/a", "perditioinc/b"]
+    assert len(response.summary) == 4
+    cache_set.assert_awaited_once()
+
+
+def test_portfolio_summary_formats_signal_highlights():
+    summary = _portfolio_summary(
+        [TaxonomyGapSignal(dimension="use_case", value="Synthetic QA", repo_count=3, trending_score=6.2)],
+        [StaleRepoSignal(repo_name="old-repo", owner="perditioinc", github_url="https://github.com/perditioinc/old-repo", stale_days=210)],
+        [VelocityLeaderSignal(repo_name="hot-repo", owner="perditioinc", github_url="https://github.com/perditioinc/hot-repo", commits_last_7_days=9, commits_last_30_days=28, activity_score=88)],
+        [DuplicateClusterSignal(similarity=0.931, repos=["perditioinc/one", "perditioinc/two"])],
+    )
+
+    assert "Synthetic QA" in summary[0]
+    assert "old-repo" in summary[1]
+    assert "hot-repo" in summary[2]
+    assert "perditioinc/one" in summary[3]


### PR DESCRIPTION
## Changes
- add GET /intelligence/portfolio-insights with taxonomy gap, stale repo, velocity leader, and near-duplicate signals
- cache the computed intelligence feed and expose structured summary highlights
- add focused intelligence tests for cache and summary behavior

## Validation
- python -m py_compile app/routers/intelligence.py tests/test_intelligence.py
- python -m pytest tests/test_intelligence.py -q -k " portfolio_insights or portfolio_summary\