### PR TITLE
feat: add cross-dimension analytics endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -15,7 +15,7 @@ from slowapi.util import get_remote_address
 
 from app.cache import cache
 from app.database import check_db_connection, engine
-from app.routers import admin, ingest, intelligence, library, library_full, platform, repos, search, taxonomy, trends, wiki
+from app.routers import admin, analytics, ingest, intelligence, library, library_full, platform, repos, search, taxonomy, trends, wiki
 
 
 class _JsonFormatter(logging.Formatter):
@@ -218,6 +218,7 @@ async def add_security_headers(request: Request, call_next):
 app.include_router(library.router)
 app.include_router(repos.router)
 app.include_router(search.router)
+app.include_router(analytics.router)
 app.include_router(trends.router)
 app.include_router(wiki.router)
 app.include_router(platform.router)

--- a/app/routers/analytics.py
+++ b/app/routers/analytics.py
@@ -1,0 +1,64 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.schemas.analytics import CrossDimensionCell, CrossDimensionResponse
+
+router = APIRouter(tags=["Analytics"])
+
+
+@router.get("/analytics/cross-dimension", response_model=CrossDimensionResponse)
+async def cross_dimension_analytics(
+    dim1: str = Query(..., min_length=1),
+    dim2: str = Query(..., min_length=1),
+    limit: int = Query(default=10, ge=1, le=50),
+    db: AsyncSession = Depends(get_db),
+) -> CrossDimensionResponse:
+    if dim1 == dim2:
+        raise HTTPException(status_code=400, detail="dim1 and dim2 must be different")
+
+    result = await db.execute(
+        text(
+            """
+            WITH dim1_values AS (
+                SELECT DISTINCT rt.repo_id,
+                       COALESCE(tv.name, rt.raw_value) AS dim1_value
+                FROM repo_taxonomy rt
+                LEFT JOIN taxonomy_values tv ON tv.id = rt.taxonomy_value_id
+                WHERE rt.dimension = :dim1
+            ),
+            dim2_values AS (
+                SELECT DISTINCT rt.repo_id,
+                       COALESCE(tv.name, rt.raw_value) AS dim2_value
+                FROM repo_taxonomy rt
+                LEFT JOIN taxonomy_values tv ON tv.id = rt.taxonomy_value_id
+                WHERE rt.dimension = :dim2
+            )
+            SELECT d1.dim1_value,
+                   d2.dim2_value,
+                   COUNT(DISTINCT d1.repo_id) AS repo_count
+            FROM dim1_values d1
+            JOIN dim2_values d2 ON d2.repo_id = d1.repo_id
+            GROUP BY d1.dim1_value, d2.dim2_value
+            ORDER BY repo_count DESC, d1.dim1_value ASC, d2.dim2_value ASC
+            LIMIT :limit
+            """
+        ),
+        {"dim1": dim1, "dim2": dim2, "limit": limit},
+    )
+    rows = result.fetchall()
+
+    return CrossDimensionResponse(
+        dim1=dim1,
+        dim2=dim2,
+        limit=limit,
+        pairs=[
+            CrossDimensionCell(
+                dim1_value=row.dim1_value,
+                dim2_value=row.dim2_value,
+                repo_count=row.repo_count,
+            )
+            for row in rows
+        ],
+    )

--- a/app/schemas/analytics.py
+++ b/app/schemas/analytics.py
@@ -1,0 +1,14 @@
+from pydantic import BaseModel
+
+
+class CrossDimensionCell(BaseModel):
+    dim1_value: str
+    dim2_value: str
+    repo_count: int
+
+
+class CrossDimensionResponse(BaseModel):
+    dim1: str
+    dim2: str
+    limit: int
+    pairs: list[CrossDimensionCell]

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.routers.analytics import cross_dimension_analytics
+
+
+class _FetchAllResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def fetchall(self):
+        return self._rows
+
+
+@pytest.mark.asyncio
+async def test_cross_dimension_analytics_orders_pairs_from_query():
+    db = AsyncMock()
+    db.execute = AsyncMock(
+        return_value=_FetchAllResult(
+            [
+                SimpleNamespace(dim1_value="DevTools", dim2_value="Agentic AI", repo_count=31),
+                SimpleNamespace(dim1_value="Healthcare", dim2_value="Agentic AI", repo_count=12),
+            ]
+        )
+    )
+
+    response = await cross_dimension_analytics(dim1="industry", dim2="ai_trend", limit=2, db=db)
+
+    assert response.dim1 == "industry"
+    assert response.dim2 == "ai_trend"
+    assert response.limit == 2
+    assert [(pair.dim1_value, pair.dim2_value, pair.repo_count) for pair in response.pairs] == [
+        ("DevTools", "Agentic AI", 31),
+        ("Healthcare", "Agentic AI", 12),
+    ]
+    stmt, params = db.execute.await_args.args
+    assert "repo_taxonomy" in str(stmt)
+    assert params["dim1"] == "industry"
+    assert params["dim2"] == "ai_trend"
+    assert params["limit"] == 2
+
+
+@pytest.mark.asyncio
+async def test_cross_dimension_analytics_rejects_same_dimension():
+    db = AsyncMock()
+
+    with pytest.raises(HTTPException) as exc:
+        await cross_dimension_analytics(dim1="industry", dim2="industry", limit=10, db=db)
+
+    assert exc.value.status_code == 400
+    assert "must be different" in exc.value.detail


### PR DESCRIPTION
## Changes
- add GET /analytics/cross-dimension
- return top (dim1_value, dim2_value) repo-count pairings from epo_taxonomy
- register analytics schemas and route wiring in pp.main
- add focused unit coverage for ordering and same-dimension rejection

## Validation
- python -m py_compile app/main.py app/routers/analytics.py app/schemas/analytics.py tests/test_analytics.py
- pytest tests/test_analytics.py --noconftest -q is blocked by the repo's current FastAPI/runtime mismatch (APIRouter(... tags=...) fails during import before route tests execute)

## Notes
- endpoint is SQL-first and uses existing taxonomy assignments without adding a new aggregation layer