### PR TITLE
fix: resolve pytest FastAPI import mismatch

### DIFF
--- a/app/routers/library_full.py
+++ b/app/routers/library_full.py
@@ -173,6 +173,10 @@ _LIFECYCLE_GROUPS_FALLBACK: dict = {
     "Recommendation Systems": "Applied AI",
 }
 
+# Backwards-compatible export retained for tests and callers that still import
+# the old constant name directly. DB-backed lookup remains the live path.
+LIFECYCLE_GROUPS = _LIFECYCLE_GROUPS_FALLBACK
+
 _lifecycle_groups_cache: dict = {}
 _LIFECYCLE_GROUPS_TTL = 300  # 5 minutes
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 fastapi==0.115.0
+starlette==0.38.6
 uvicorn[standard]==0.30.6
 sqlalchemy[asyncio]==2.0.35
 asyncpg==0.29.0


### PR DESCRIPTION
## Summary\n- pin a FastAPI-compatible Starlette version in requirements\n- restore the exported lifecycle-group constant expected by tests\n- unblock pytest collection past the router import crash\n\n## Validation\n- pytest tests/ -x --tb=short now gets past the previous Router.__init__(on_startup=...) import-time failure\n- the next failure is environmental: local Postgres database eporium_test does not exist in this machine, so full suite execution still needs the test DB\n\n## Notes\nThis fixes the runtime/import mismatch reported in KAN-15. The remaining failure is separate test environment setup, not the original FastAPI issue.