### PR TITLE
test: add quality signals and taxonomy gap coverage

### DIFF
--- a/tests/test_quality_signals.py
+++ b/tests/test_quality_signals.py
@@ -1,0 +1,164 @@
+"""
+Tests for quality signals and related endpoints.
+
+Covers:
+- POST /admin/quality/compute returns {"computed": N}
+- GET /gaps/taxonomy returns list of TaxonomyGapItems with correct fields
+- GET /library returns repos with quality_signals field (can be None)
+"""
+
+import pytest
+from httpx import AsyncClient
+
+from tests.conftest import AUTH_HEADERS, TEST_REPO_FIXTURE
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+REPO_WITH_QUALITY = {
+    **TEST_REPO_FIXTURE,
+    "name": "quality-test-repo",
+    "github_url": "https://github.com/testuser/quality-test-repo",
+    "commits_last_7_days": 5,
+    "commits_last_30_days": 20,
+    "activity_score": 60,
+    "open_issues_count": 3,
+    # taxonomy so GET /gaps/taxonomy has something to work with
+    "skill_areas": ["RAG & Retrieval"],
+    "industries": ["Healthcare"],
+    "use_cases": ["document-qa"],
+    "modalities": ["text"],
+    "ai_trends": ["chain-of-thought"],
+    "deployment_context": ["cloud"],
+}
+
+
+@pytest.fixture(autouse=True)
+async def seed_repo(client: AsyncClient):
+    """Ingest a repo before each test in this module."""
+    resp = await client.post(
+        "/ingest/repos",
+        json=[REPO_WITH_QUALITY],
+        headers=AUTH_HEADERS,
+    )
+    assert resp.status_code == 200, resp.text
+    yield
+
+
+# ---------------------------------------------------------------------------
+# POST /admin/quality/compute
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_compute_quality_signals_returns_computed_count(client: AsyncClient):
+    """POST /admin/quality/compute should return a dict with 'computed' key."""
+    resp = await client.post(
+        "/admin/quality/compute",
+        headers=AUTH_HEADERS,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "computed" in data
+    assert isinstance(data["computed"], int)
+    assert data["computed"] >= 0
+
+
+@pytest.mark.asyncio
+async def test_compute_quality_signals_requires_auth(client: AsyncClient):
+    """POST /admin/quality/compute without auth should return 403."""
+    resp = await client.post("/admin/quality/compute")
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_compute_quality_signals_updates_repos(client: AsyncClient):
+    """After compute, repos should have quality_signals."""
+    compute_resp = await client.post(
+        "/admin/quality/compute",
+        headers=AUTH_HEADERS,
+    )
+    assert compute_resp.status_code == 200
+    data = compute_resp.json()
+    assert data["computed"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# GET /gaps/taxonomy
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_gaps_taxonomy_returns_list(client: AsyncClient):
+    """GET /gaps/taxonomy should return a list."""
+    resp = await client.get("/gaps/taxonomy")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+
+
+@pytest.mark.asyncio
+async def test_gaps_taxonomy_items_have_correct_fields(client: AsyncClient):
+    """Each TaxonomyGapItem must have dimension, name, repo_count, gap_score, severity."""
+    resp = await client.get("/gaps/taxonomy")
+    assert resp.status_code == 200
+    items = resp.json()
+    for item in items:
+        assert "dimension" in item, f"Missing 'dimension' in {item}"
+        assert "name" in item, f"Missing 'name' in {item}"
+        assert "repo_count" in item, f"Missing 'repo_count' in {item}"
+        assert "gap_score" in item, f"Missing 'gap_score' in {item}"
+        assert "severity" in item, f"Missing 'severity' in {item}"
+        assert isinstance(item["repo_count"], int)
+        assert isinstance(item["gap_score"], float)
+        assert item["severity"] in ("low", "medium", "high"), f"Invalid severity: {item['severity']}"
+
+
+@pytest.mark.asyncio
+async def test_gaps_taxonomy_gap_score_range(client: AsyncClient):
+    """gap_score should be in [0.0, 1.0]."""
+    resp = await client.get("/gaps/taxonomy")
+    assert resp.status_code == 200
+    for item in resp.json():
+        assert 0.0 <= item["gap_score"] <= 1.0, f"gap_score out of range: {item}"
+
+
+@pytest.mark.asyncio
+async def test_gaps_taxonomy_min_max_repos_filter(client: AsyncClient):
+    """min_repos / max_repos params should filter results."""
+    # With max_repos=0, there should be no results (nothing has 0 or fewer repos)
+    resp = await client.get("/gaps/taxonomy", params={"min_repos": 1, "max_repos": 0})
+    assert resp.status_code == 200
+    # empty or valid list — we only care it doesn't crash
+    assert isinstance(resp.json(), list)
+
+
+# ---------------------------------------------------------------------------
+# GET /library — quality_signals field
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_library_includes_quality_signals_field(client: AsyncClient):
+    """GET /library should return repos that include the quality_signals field."""
+    resp = await client.get("/library")
+    assert resp.status_code == 200
+    data = resp.json()
+    repos = data.get("repos") or data.get("items") or []
+    # There must be at least 1 repo (seeded above)
+    assert len(repos) >= 1
+    # Every repo must have the quality_signals key (may be None)
+    for repo in repos:
+        assert "quality_signals" in repo, f"Missing quality_signals in repo: {repo.get('name')}"
+
+
+@pytest.mark.asyncio
+async def test_library_quality_signals_is_dict_or_none(client: AsyncClient):
+    """quality_signals must be either null (None) or a dict."""
+    resp = await client.get("/library")
+    assert resp.status_code == 200
+    data = resp.json()
+    repos = data.get("repos") or data.get("items") or []
+    for repo in repos:
+        qs = repo.get("quality_signals")
+        assert qs is None or isinstance(qs, dict), (
+            f"quality_signals has unexpected type {type(qs)} for repo {repo.get('name')}"
+        )

--- a/tests/test_taxonomy_gaps.py
+++ b/tests/test_taxonomy_gaps.py
@@ -1,0 +1,202 @@
+"""
+Tests for taxonomy gap analysis logic.
+
+Covers:
+- Gap score calculation (0.0 = well covered, 1.0 = absent)
+- Severity classification (low / medium / high)
+- Filtering by min_repos / max_repos params on GET /gaps/taxonomy
+"""
+
+import pytest
+from httpx import AsyncClient
+
+from tests.conftest import AUTH_HEADERS, TEST_REPO_FIXTURE
+
+# ---------------------------------------------------------------------------
+# Helper: inline gap score / severity logic matching what trends.py computes
+# ---------------------------------------------------------------------------
+
+def _compute_gap_score(repo_count: int, max_count: int) -> float:
+    """Mirror the gap score formula from app/routers/trends.py."""
+    if max_count == 0:
+        return 1.0
+    return 1.0 - (repo_count / max_count)
+
+
+def _classify_severity(gap_score: float) -> str:
+    """Mirror the severity classification from app/routers/trends.py."""
+    if gap_score >= 0.8:
+        return "high"
+    if gap_score >= 0.4:
+        return "medium"
+    return "low"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for gap score calculation (no DB required)
+# ---------------------------------------------------------------------------
+
+class TestGapScoreCalculation:
+    def test_zero_repo_count_gives_max_gap(self):
+        score = _compute_gap_score(0, 10)
+        assert score == 1.0
+
+    def test_equal_to_max_gives_zero_gap(self):
+        score = _compute_gap_score(10, 10)
+        assert score == 0.0
+
+    def test_half_of_max_gives_half_gap(self):
+        score = _compute_gap_score(5, 10)
+        assert abs(score - 0.5) < 1e-9
+
+    def test_max_count_zero_returns_one(self):
+        """Edge case: if max is 0, gap should be 1.0 (nothing exists)."""
+        score = _compute_gap_score(0, 0)
+        assert score == 1.0
+
+    def test_score_always_between_zero_and_one(self):
+        for repo_count in range(0, 11):
+            score = _compute_gap_score(repo_count, 10)
+            assert 0.0 <= score <= 1.0, f"Out of range for repo_count={repo_count}"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for severity classification
+# ---------------------------------------------------------------------------
+
+class TestSeverityClassification:
+    def test_gap_score_above_0_8_is_high(self):
+        assert _classify_severity(0.9) == "high"
+        assert _classify_severity(0.8) == "high"
+        assert _classify_severity(1.0) == "high"
+
+    def test_gap_score_between_0_4_and_0_8_is_medium(self):
+        assert _classify_severity(0.6) == "medium"
+        assert _classify_severity(0.4) == "medium"
+        assert _classify_severity(0.79) == "medium"
+
+    def test_gap_score_below_0_4_is_low(self):
+        assert _classify_severity(0.0) == "low"
+        assert _classify_severity(0.2) == "low"
+        assert _classify_severity(0.39) == "low"
+
+    def test_boundary_exactly_0_8_is_high(self):
+        assert _classify_severity(0.8) == "high"
+
+    def test_boundary_exactly_0_4_is_medium(self):
+        assert _classify_severity(0.4) == "medium"
+
+
+# ---------------------------------------------------------------------------
+# Integration: taxonomy-seeded repos and the API endpoint
+# ---------------------------------------------------------------------------
+
+REPO_WITH_MANY_DIMS = {
+    **TEST_REPO_FIXTURE,
+    "name": "gap-test-repo",
+    "github_url": "https://github.com/testuser/gap-test-repo",
+    "skill_areas": ["RAG & Retrieval", "Agents & Orchestration", "Fine-tuning"],
+    "industries": ["Healthcare"],
+    "use_cases": ["document-qa"],
+    "modalities": ["text"],
+    "ai_trends": ["chain-of-thought"],
+    "deployment_context": ["cloud"],
+}
+
+REPO_SINGLE_DIM = {
+    **TEST_REPO_FIXTURE,
+    "name": "gap-single-dim-repo",
+    "github_url": "https://github.com/testuser/gap-single-dim-repo",
+    "skill_areas": ["RAG & Retrieval"],
+    "industries": [],
+    "use_cases": [],
+    "modalities": [],
+    "ai_trends": [],
+    "deployment_context": [],
+}
+
+
+@pytest.fixture(autouse=True)
+async def seed_repos(client: AsyncClient):
+    """Seed repos with taxonomy before each test."""
+    for repo in [REPO_WITH_MANY_DIMS, REPO_SINGLE_DIM]:
+        resp = await client.post(
+            "/ingest/repos",
+            json=[repo],
+            headers=AUTH_HEADERS,
+        )
+        assert resp.status_code == 200, resp.text
+    yield
+
+
+@pytest.mark.asyncio
+async def test_gaps_taxonomy_default_returns_results(client: AsyncClient):
+    """GET /gaps/taxonomy with default params returns a list."""
+    resp = await client.get("/gaps/taxonomy")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert isinstance(data, list)
+
+
+@pytest.mark.asyncio
+async def test_gaps_taxonomy_min_repos_filter(client: AsyncClient):
+    """min_repos param should exclude values below threshold."""
+    # With min_repos=999, no repo-count value should match
+    resp = await client.get("/gaps/taxonomy", params={"min_repos": 999, "max_repos": 10000})
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)
+
+
+@pytest.mark.asyncio
+async def test_gaps_taxonomy_max_repos_filter(client: AsyncClient):
+    """max_repos=1 returns only underrepresented values (1 repo)."""
+    resp = await client.get("/gaps/taxonomy", params={"min_repos": 1, "max_repos": 1})
+    assert resp.status_code == 200
+    items = resp.json()
+    for item in items:
+        assert item["repo_count"] <= 1, f"Expected repo_count<=1, got {item['repo_count']}"
+
+
+@pytest.mark.asyncio
+async def test_gaps_taxonomy_severity_values_are_valid(client: AsyncClient):
+    """All severity values in response must be low/medium/high."""
+    resp = await client.get("/gaps/taxonomy")
+    assert resp.status_code == 200
+    for item in resp.json():
+        assert item["severity"] in ("low", "medium", "high"), (
+            f"Unexpected severity '{item['severity']}' for {item['name']}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_gaps_taxonomy_gap_score_in_range(client: AsyncClient):
+    """gap_score must be in [0.0, 1.0]."""
+    resp = await client.get("/gaps/taxonomy")
+    assert resp.status_code == 200
+    for item in resp.json():
+        score = item["gap_score"]
+        assert 0.0 <= score <= 1.0, f"gap_score={score} out of range for {item['name']}"
+
+
+@pytest.mark.asyncio
+async def test_gaps_taxonomy_high_severity_has_high_gap_score(client: AsyncClient):
+    """Items with severity='high' should have gap_score >= 0.8."""
+    resp = await client.get("/gaps/taxonomy")
+    assert resp.status_code == 200
+    for item in resp.json():
+        if item["severity"] == "high":
+            assert item["gap_score"] >= 0.8, (
+                f"high severity item has gap_score={item['gap_score']}"
+            )
+
+
+@pytest.mark.asyncio
+async def test_gaps_taxonomy_low_severity_has_low_gap_score(client: AsyncClient):
+    """Items with severity='low' should have gap_score < 0.4."""
+    resp = await client.get("/gaps/taxonomy")
+    assert resp.status_code == 200
+    for item in resp.json():
+        if item["severity"] == "low":
+            assert item["gap_score"] < 0.4, (
+                f"low severity item has gap_score={item['gap_score']}"
+            )


### PR DESCRIPTION
## Summary
- Adds `tests/test_quality_signals.py`:
  - Tests POST /admin/quality/compute returns `{computed: N}`
  - Tests GET /gaps/taxonomy returns valid TaxonomyGapItems with correct fields
  - Tests GET /library returns repos with quality_signals field (None or dict)
- Adds `tests/test_taxonomy_gaps.py`:
  - Unit tests for gap score calculation (0.0 to 1.0 range)
  - Unit tests for severity classification (low/medium/high boundaries)
  - Integration tests for min_repos/max_repos filtering params

## Test plan
- [ ] `pytest tests/test_quality_signals.py` passes
- [ ] `pytest tests/test_taxonomy_gaps.py` passes
- [ ] Unit test classes run without DB connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)