### PR TITLE
docs: add Reporium API ADR set

### DIFF
--- a/docs/adr/001-embedding-based-taxonomy.md
+++ b/docs/adr/001-embedding-based-taxonomy.md
@@ -1,0 +1,15 @@
+# ADR 001: Embedding-Based Taxonomy Assignment
+
+- Status: Accepted
+
+## Context
+
+Reporium needs taxonomy assignment to scale across an expanding portfolio without repeatedly paying for full Claude re-enrichment runs. The platform already stores repo embeddings in Postgres with pgvector and already performs similarity operations for semantic search. At the same time, the taxonomy itself is becoming more open-ended: new values can appear in multiple dimensions over time, and those values need to be assignable across the existing corpus without resummarizing every repo.
+
+## Decision
+
+Taxonomy assignment is performed through pgvector cosine similarity against precomputed repo embeddings instead of rerunning Claude for every taxonomy change. Each taxonomy value receives its own embedding once, then assignment is handled by SQL similarity queries that write the resulting matches into `repo_taxonomy` with similarity metadata and an `assigned_by` marker. Claude remains responsible for repo-local enrichment tasks such as summary generation, problem framing, and initial open-ended hints, but not for ongoing taxonomy expansion.
+
+## Consequences
+
+Adding a new taxonomy value becomes cheap and fast because it requires one embedding operation plus one batch assignment query. Existing repos can be reclassified across the portfolio without another per-repo model call. The system becomes more deterministic and easier to backfill in production because taxonomy rebuilds are SQL-driven and auditable. The tradeoff is that taxonomy quality now depends on embedding quality and threshold tuning rather than a bespoke prompt for each expansion. That means the platform must retain admin rebuild controls, similarity thresholds, and reviewable outputs so operators can inspect unexpected assignments.

--- a/docs/adr/002-open-taxonomy-design.md
+++ b/docs/adr/002-open-taxonomy-design.md
@@ -1,0 +1,15 @@
+# ADR 002: Open Taxonomy Design
+
+- Status: Accepted
+
+## Context
+
+Early taxonomy work used fixed lists and UI-side mappings for skills and related metadata. That approach created drift between ingestion, API responses, and frontend filters, and it made each new dimension expensive because every repo effectively needed to be reconsidered against a hardcoded catalog. Reporium is now evolving toward a portfolio where industries, use cases, deployment contexts, AI trends, and other dimensions should be able to grow organically as the dataset changes.
+
+## Decision
+
+The taxonomy is treated as open and data-driven rather than fixed and hardcoded. New values originate from enrichment output or admin rebuild flows and are stored in database tables instead of source-code enums. The API exposes those values dynamically for filtering, analytics, and search. Frontend experiences consume live dimensions and values from the API rather than bundling static skill lists as the source of truth.
+
+## Consequences
+
+The product can evolve dimensions without frontend redeploys or one-off migration scripts for every new label. Reporium becomes better suited to emerging AI categories because the system can capture new values as the corpus changes instead of waiting for manual taxonomy curation in code. The tradeoff is that naming quality and duplication management become an operational concern, so admin cleanup tools, pruning, embedding rebuilds, and documentation need to stay strong. This decision also increases the importance of clear analytics and moderation around taxonomy values, because the database is now the contract that every consumer sees.

--- a/docs/adr/003-pubsub-event-flow.md
+++ b/docs/adr/003-pubsub-event-flow.md
@@ -1,0 +1,15 @@
+# ADR 003: Pub/Sub-Driven Taxonomy Refresh
+
+- Status: Accepted
+
+## Context
+
+Ingestion, taxonomy assignment, gap analysis, and portfolio intelligence are tightly related, but manual or scheduled refreshes create stale state between those layers. Reporium already has an event model and Pub/Sub direction in the broader suite. The API now exposes admin-style rebuild endpoints for taxonomy and intelligence refresh, and ingestion can publish completion events when a batch finishes.
+
+## Decision
+
+The platform uses Pub/Sub to trigger taxonomy and intelligence refresh work after ingestion instead of relying only on polling or cron-style periodic rebuilds. Ingestion publishes a repo-ingested event, and the API accepts a protected push callback that can trigger taxonomy embedding, assignment, gap rebuilding, and portfolio insight refresh in response to that event.
+
+## Consequences
+
+Taxonomy coverage and intelligence outputs stay closer to ingestion freshness with fewer manual steps. The operator gets a clearer event boundary for “new corpus state is available,” which also makes it easier to attach future notifications or audit records. This design reduces drift between the repos table, taxonomy tables, and insight surfaces. The tradeoff is that the system now has to defend an additional event-ingest surface and reason about push-auth verification, idempotency, and safe replay behavior. That is still a better fit than polling because refresh cost is tied to actual updates rather than to a blind schedule.

--- a/docs/adr/004-auth-strategy.md
+++ b/docs/adr/004-auth-strategy.md
@@ -1,0 +1,15 @@
+# ADR 004: Header-Based Admin and Ingest Auth
+
+- Status: Accepted
+
+## Context
+
+Reporium exposes public read endpoints as well as operational endpoints for ingest, taxonomy rebuilds, admin maintenance, and event callbacks. Those operational routes are used by sibling repos, scheduled jobs, and internal automation rather than by end-user browsers. The system needs simple credentials that work well in Cloud Run, GitHub Actions, and service-to-service calls without introducing a full OAuth or session stack for internal platform traffic.
+
+## Decision
+
+Operational endpoints use explicit header-based shared-secret auth. Admin actions require `X-Admin-Key` backed by `ADMIN_API_KEY`, ingest actions require `X-Ingest-Key` backed by `INGEST_API_KEY`, and Pub/Sub push requests may additionally validate a signed bearer token when `PUBSUB_AUDIENCE` is configured. Development remains dev-safe by allowing clearly documented passthrough behavior where appropriate, but production paths are expected to set the real secrets explicitly.
+
+## Consequences
+
+The platform gets a small, understandable auth surface that is easy to wire from automation and easy to inspect during incident response. This fits the current internal-platform use case and keeps ingress/auth complexity low while the product is still moving fast. The tradeoff is that key rotation and secret distribution need to be handled carefully through environment management and CI/CD configuration. This decision also means documentation and `.env.example` files matter, because operators need a reliable record of which headers and env vars are required for each class of operational endpoint.

--- a/docs/adr/005-mcp-ai-native.md
+++ b/docs/adr/005-mcp-ai-native.md
@@ -1,0 +1,15 @@
+# ADR 005: MCP as the Agent-Facing Interface
+
+- Status: Accepted
+
+## Context
+
+Reporium already has a REST API for application and automation use, but agent workflows benefit from a smaller, task-oriented interface instead of raw endpoint discovery. The suite now includes `reporium-mcp`, which wraps live API capabilities such as repo search, taxonomy browsing, portfolio questioning, and analytics. Agents are a first-class consumer of Reporium, not just a secondary integration.
+
+## Decision
+
+Reporium exposes an MCP server as the preferred agent-facing layer while keeping the REST API as the underlying system contract. MCP tools map to high-value portfolio actions such as semantic search, repo lookup, taxonomy exploration, portfolio insights, gap analysis, and quality lookup. The REST API remains the implementation backbone, but MCP becomes the interface optimized for AI-native reasoning and tool use.
+
+## Consequences
+
+Agents can query the portfolio in fewer steps and with less brittle prompt logic because the tool layer is curated around portfolio tasks rather than around raw transport concerns. This makes the system more AI-native: an agent can ask for gaps, trends, similar repos, or cross-dimension counts directly instead of composing multiple low-level requests. The tradeoff is that the MCP surface must be kept current as new API capabilities land. That creates a maintenance obligation, but it is acceptable because it gives the project a clearer separation between backend data contracts and agent ergonomics.


### PR DESCRIPTION
## Summary
- add ADRs for embedding-based taxonomy assignment, open taxonomy design, Pub/Sub refresh flow, header-based auth, and MCP as the agent-facing surface
- capture the rationale behind the recent architecture shift in durable docs