### PR TITLE
docs: tighten API route metadata

### DIFF
--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -13,7 +13,7 @@ from app.routers.library_full import invalidate_library_cache
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter()
+router = APIRouter(tags=["Admin"])
 
 # Canonical noise-tag list from Reporium taxonomy Phase 4 cleanup rules.
 NOISE_TAGS = frozenset({
@@ -62,12 +62,13 @@ async def _prune_noise_tags(db: AsyncSession, *, dry_run: bool) -> dict:
     }
 
 
-@router.get("/admin/data-quality")
+@router.get("/admin/data-quality", response_model=dict)
 async def data_quality(
     db: AsyncSession = Depends(get_db),
     _api_key: str = Depends(verify_api_key),
     _admin_key: None = Depends(require_admin_key),
 ):
+    """Return aggregate admin-only data quality metrics for the current repo corpus."""
 
     # Query counts
     total = (await db.execute(text("SELECT COUNT(*) FROM repos;"))).scalar()
@@ -118,17 +119,18 @@ async def data_quality(
     }
 
 
-@router.post("/admin/tags/prune")
+@router.post("/admin/tags/prune", response_model=dict)
 async def prune_tags(
     dry_run: bool = Query(default=False),
     db: AsyncSession = Depends(get_db),
     _api_key: str = Depends(verify_api_key),
     _admin_key: None = Depends(require_admin_key),
 ):
+    """Count or delete noise tags from repo_tags. Requires API and admin keys."""
     return await _prune_noise_tags(db, dry_run=dry_run)
 
 
-@router.post("/admin/quality/compute")
+@router.post("/admin/quality/compute", response_model=dict)
 async def compute_quality_signals(
     db: AsyncSession = Depends(get_db),
     _api_key: str = Depends(verify_api_key),
@@ -188,7 +190,7 @@ async def compute_quality_signals(
     return {"computed": computed, "skipped": skipped}
 
 
-@router.post("/admin/embeddings/backfill")
+@router.post("/admin/embeddings/backfill", response_model=dict)
 async def backfill_embeddings(
     db: AsyncSession = Depends(get_db),
     _api_key: str = Depends(verify_api_key),
@@ -269,7 +271,7 @@ async def backfill_embeddings(
     return {"backfilled": backfilled, "errors": errors}
 
 
-@router.post("/admin/taxonomy/bootstrap")
+@router.post("/admin/taxonomy/bootstrap", response_model=dict)
 async def bootstrap_taxonomy(
     limit: int = Query(default=100, ge=1, le=500),
     dimension: str | None = Query(default=None),

--- a/app/routers/ingest.py
+++ b/app/routers/ingest.py
@@ -34,8 +34,16 @@ from app.schemas.trend import GapAnalysisIn, GapAnalysisOut, IngestionLogIn, Ing
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/ingest", dependencies=[Depends(verify_api_key), Depends(require_ingest_key)])
-events_router = APIRouter(prefix="/ingest/events", dependencies=[Depends(require_ingest_key), Depends(require_pubsub_push)])
+router = APIRouter(
+    prefix="/ingest",
+    tags=["Ingest"],
+    dependencies=[Depends(verify_api_key), Depends(require_ingest_key)],
+)
+events_router = APIRouter(
+    prefix="/ingest/events",
+    tags=["Ingest"],
+    dependencies=[Depends(require_ingest_key), Depends(require_pubsub_push)],
+)
 limiter = Limiter(key_func=get_remote_address)
 
 MAX_BATCH = 100
@@ -219,6 +227,7 @@ async def ingest_repos(
     items: list[RepoIngestItem],
     db: AsyncSession = Depends(get_db),
 ) -> IngestResponse:
+    """Upsert a bounded batch of repos from ingestion. Requires API and ingest keys."""
     if len(items) > MAX_BATCH:
         raise HTTPException(status_code=400, detail=f"Max {MAX_BATCH} repos per request")
 
@@ -250,6 +259,7 @@ async def enrich_repo(
     item: RepoEnrichItem,
     db: AsyncSession = Depends(get_db),
 ) -> dict:
+    """Apply enrichment-only fields to an existing repo. Requires API and ingest keys."""
     stmt = select(Repo).where(Repo.name == name)
     result = await db.execute(stmt)
     repo = result.scalar_one_or_none()
@@ -293,6 +303,7 @@ async def ingest_trend_snapshot(
     items: list[TrendSnapshotIn],
     db: AsyncSession = Depends(get_db),
 ) -> list[TrendSnapshotOut]:
+    """Persist trend snapshots produced by ingestion. Requires API and ingest keys."""
     rows = []
     for item in items:
         snap = TrendSnapshot(**item.model_dump())
@@ -312,6 +323,7 @@ async def ingest_gaps(
     items: list[GapAnalysisIn],
     db: AsyncSession = Depends(get_db),
 ) -> list[GapAnalysisOut]:
+    """Persist gap-analysis rows produced by ingestion. Requires API and ingest keys."""
     rows = []
     for item in items:
         gap = GapAnalysis(**item.model_dump())
@@ -331,6 +343,7 @@ async def ingest_log(
     item: IngestionLogIn,
     db: AsyncSession = Depends(get_db),
 ) -> IngestionLogOut:
+    """Persist or update an ingestion run log record. Requires API and ingest keys."""
     # Find the latest running log for this mode, or create a new one
     stmt = (
         select(IngestionLog)
@@ -368,6 +381,7 @@ async def repo_ingested_event(
     request: Request,
     db: AsyncSession = Depends(get_db),
 ) -> dict:
+    """Handle Pub/Sub repo-ingested pushes and refresh taxonomy, gaps, and insights."""
     payload = _parse_pubsub_payload(await request.json())
 
     rebuild_result = await rebuild_taxonomy(RebuildBody(), db)

--- a/app/routers/library.py
+++ b/app/routers/library.py
@@ -12,7 +12,7 @@ from app.models.repo import Repo, RepoCategory, RepoTag
 from app.schemas.library import CategorySummary, LibraryResponse, LibraryStats, TagMetric
 from app.schemas.repo import RepoSummary
 
-router = APIRouter()
+router = APIRouter(tags=["Library"])
 
 
 def _repo_to_summary(repo: Repo) -> RepoSummary:

--- a/app/routers/library_full.py
+++ b/app/routers/library_full.py
@@ -982,7 +982,7 @@ async def _fetch_aggregates(db: AsyncSession) -> dict:
     return aggregates
 
 
-@router.get("/library/full")
+@router.get("/library/full", response_model=dict)
 async def library_full(
     db: AsyncSession = Depends(get_db),
     page: int = Query(default=1, ge=1, description="1-based page number"),
@@ -1044,7 +1044,7 @@ async def library_full(
     return response
 
 
-@router.get("/forks")
+@router.get("/forks", response_model=dict)
 async def list_forks(
     db: AsyncSession = Depends(get_db),
     limit: int = 100,

--- a/app/routers/platform.py
+++ b/app/routers/platform.py
@@ -11,10 +11,10 @@ from app.auth import verify_api_key
 from app.database import get_db
 from app.models.repo import Repo, RepoAIDevSkill, RepoCategory
 
-router = APIRouter()
+router = APIRouter(tags=["Platform"])
 
 
-@router.get("/metrics/latest")
+@router.get("/metrics/latest", response_model=dict)
 async def metrics_latest(db: AsyncSession = Depends(get_db)) -> dict:
     """Platform metrics for reporium-metrics to consume."""
     total = (await db.execute(select(func.count(Repo.id)))).scalar_one()
@@ -53,7 +53,7 @@ async def metrics_latest(db: AsyncSession = Depends(get_db)) -> dict:
     }
 
 
-@router.get("/audit/status")
+@router.get("/audit/status", response_model=dict)
 async def audit_status(db: AsyncSession = Depends(get_db)) -> dict:
     """Platform health for reporium-roadmap to consume."""
     db_ok = False
@@ -81,7 +81,7 @@ async def audit_status(db: AsyncSession = Depends(get_db)) -> dict:
     }
 
 
-@router.post("/events/ingest")
+@router.post("/events/ingest", response_model=dict)
 async def events_ingest(
     payload: dict,
     _api_key: str = Depends(verify_api_key),

--- a/app/routers/repos.py
+++ b/app/routers/repos.py
@@ -20,7 +20,7 @@ from app.models.repo import (
 from app.routers.library import _repo_to_summary
 from app.schemas.repo import RepoDetail, RepoSummary
 
-router = APIRouter()
+router = APIRouter(tags=["Repos"])
 
 VALID_SORT = {"stars", "updated", "behind", "name"}
 VALID_SYNC = {"up-to-date", "behind", "ahead", "diverged"}

--- a/app/routers/search.py
+++ b/app/routers/search.py
@@ -11,7 +11,7 @@ from app.models.repo import Repo
 from app.routers.library import _repo_to_summary
 from app.schemas.repo import RepoSemanticResult, RepoSummary
 
-router = APIRouter()
+router = APIRouter(tags=["Search"])
 limiter = Limiter(key_func=get_remote_address)
 
 MAX_RESULTS = 20

--- a/app/routers/taxonomy.py
+++ b/app/routers/taxonomy.py
@@ -156,7 +156,7 @@ class AssignBody(BaseModel):
     threshold: float = 0.65
 
 
-@router.get("/dimensions")
+@router.get("/dimensions", response_model=dict)
 async def list_dimensions(db: AsyncSession = Depends(get_db)) -> dict:
     """Return distinct dimension strings from repo_taxonomy with repo counts."""
     result = await db.execute(text(
@@ -174,7 +174,7 @@ async def list_dimensions(db: AsyncSession = Depends(get_db)) -> dict:
     }
 
 
-@router.get("/{dimension}")
+@router.get("/{dimension}", response_model=dict)
 async def list_taxonomy_values(
     dimension: str,
     db: AsyncSession = Depends(get_db),
@@ -196,7 +196,7 @@ async def list_taxonomy_values(
     }
 
 
-@router.post("/admin/taxonomy/rebuild", dependencies=[Depends(verify_api_key), Depends(require_admin_key)])
+@router.post("/admin/taxonomy/rebuild", response_model=dict, dependencies=[Depends(verify_api_key), Depends(require_admin_key)])
 async def rebuild_taxonomy(
     body: RebuildBody = RebuildBody(),
     db: AsyncSession = Depends(get_db),
@@ -240,7 +240,7 @@ async def rebuild_taxonomy(
     return {"status": "ok", "upserted": upserted, "dimensions": dimensions}
 
 
-@router.post("/admin/taxonomy/embed", dependencies=[Depends(verify_api_key), Depends(require_admin_key)])
+@router.post("/admin/taxonomy/embed", response_model=dict, dependencies=[Depends(verify_api_key), Depends(require_admin_key)])
 async def embed_taxonomy(db: AsyncSession = Depends(get_db)) -> dict:
     """
     Generate embeddings for taxonomy_values that are missing embedding_vec.
@@ -272,7 +272,7 @@ async def embed_taxonomy(db: AsyncSession = Depends(get_db)) -> dict:
     return {"status": "ok", "embedded": embedded}
 
 
-@router.post("/admin/taxonomy/assign", dependencies=[Depends(verify_api_key), Depends(require_admin_key)])
+@router.post("/admin/taxonomy/assign", response_model=dict, dependencies=[Depends(verify_api_key), Depends(require_admin_key)])
 async def assign_taxonomy(
     body: AssignBody = AssignBody(),
     db: AsyncSession = Depends(get_db),

--- a/app/routers/trends.py
+++ b/app/routers/trends.py
@@ -8,7 +8,7 @@ from app.models.repo import Repo, RepoCategory, RepoTag
 from app.models.trend import GapAnalysis, IngestionLog, TrendSnapshot
 from app.schemas.trend import GapAnalysisOut, IngestionLogOut, StatsResponse, TaxonomyGapItem, TrendSnapshotOut
 
-router = APIRouter()
+router = APIRouter(tags=["Trends"])
 
 
 @router.get("/trends", response_model=list[TrendSnapshotOut])
@@ -33,7 +33,7 @@ async def get_trends(db: AsyncSession = Depends(get_db)) -> list[TrendSnapshotOu
     return out
 
 
-@router.get("/gaps", response_model=list[GapAnalysisOut])
+@router.get("/gaps", response_model=list[GapAnalysisOut], tags=["Trends", "Taxonomy"])
 async def get_gaps(db: AsyncSession = Depends(get_db)) -> list[GapAnalysisOut]:
     cached = await cache.get("gaps:latest")
     if cached:

--- a/app/routers/wiki.py
+++ b/app/routers/wiki.py
@@ -9,7 +9,7 @@ from app.models.repo import Repo, RepoAIDevSkill, RepoCategory, RepoPMSkill
 from app.routers.library import _repo_to_summary
 from app.schemas.repo import RepoSummary
 
-router = APIRouter()
+router = APIRouter(tags=["Wiki"])
 
 
 class SkillWikiResponse(BaseModel):


### PR DESCRIPTION
## Summary
- add missing router tags so Scalar groups endpoints cleanly
- add explicit response models for implicit dict endpoints
- tighten route docstrings on ingest/admin/platform surfaces

## Validation
- `python -m py_compile app/routers/*.py` (targeted router set) passed