### PR TITLE
fix: resolve test suite failures — UniqueConstraint, Redis, rate limit bypass

### DIFF
--- a/app/cache_redis.py
+++ b/app/cache_redis.py
@@ -26,11 +26,12 @@ class RedisCache:
     """Async Redis wrapper with graceful degradation when REDIS_URL is unset."""
 
     def __init__(self) -> None:
-        self._url: str | None = os.environ.get("REDIS_URL")
+        url = os.environ.get("REDIS_URL", "")
+        self._url: str | None = url if url.strip() else None
         self._client = None  # lazy-initialised on first use
 
     async def _get_client(self):
-        """Return a connected async Redis client, or None if REDIS_URL is unset."""
+        """Return a connected async Redis client, or None if REDIS_URL is unset/empty."""
         if self._url is None:
             return None
         if self._client is None:

--- a/app/main.py
+++ b/app/main.py
@@ -54,9 +54,10 @@ async def lifespan(app: FastAPI):
     await engine.dispose()
 
 
+_rate_limits = [] if os.environ.get("RATELIMIT_ENABLED", "1") == "0" else ["200 per hour", "30 per minute"]
 limiter = Limiter(
     key_func=get_remote_address,
-    default_limits=["200 per hour", "30 per minute"],
+    default_limits=_rate_limits,
     storage_uri="memory://",
 )
 

--- a/app/models/repo.py
+++ b/app/models/repo.py
@@ -2,7 +2,7 @@ import uuid as _uuid_mod
 from datetime import datetime
 from uuid import UUID, uuid4
 
-from sqlalchemy import Boolean, Float, ForeignKey, Integer, Text, TIMESTAMP
+from sqlalchemy import Boolean, Float, ForeignKey, Integer, Text, TIMESTAMP, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -249,3 +249,7 @@ class RepoTaxonomy(Base):
     similarity_score: Mapped[float | None] = mapped_column(Float)
     assigned_by: Mapped[str] = mapped_column(Text, default="enrichment")
     created_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
+
+    __table_args__ = (
+        UniqueConstraint("repo_id", "dimension", "raw_value", name="uq_repo_taxonomy_repo_dim_val"),
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,7 @@ os.environ["DATABASE_URL"] = "postgresql+asyncpg://postgres:postgres@localhost:5
 os.environ["INGESTION_API_KEY"] = "test-api-key"
 os.environ["GH_USERNAME"] = "testuser"
 os.environ["REDIS_URL"] = ""  # disable Redis in tests
+os.environ["RATELIMIT_ENABLED"] = "0"  # disable rate limiting in tests
 
 import app.database as db_module
 from app.database import Base, get_db
@@ -40,6 +41,10 @@ async def _setup_db(event_loop):
     async with db_module.engine.begin() as conn:
         await conn.run_sync(Base.metadata.create_all)
     yield
+    # Dispose engine first to drain connection pool before loop teardown
+    await db_module.engine.dispose()
+    # Recreate for drop_all, then dispose again
+    db_module.engine = create_async_engine(TEST_DB_URL, echo=False, pool_pre_ping=True)
     async with db_module.engine.begin() as conn:
         await conn.run_sync(Base.metadata.drop_all)
     await db_module.engine.dispose()


### PR DESCRIPTION
## Summary
- Adds missing `UniqueConstraint(repo_id, dimension, raw_value)` to `RepoTaxonomy` model so `Base.metadata.create_all()` generates the correct schema in the test DB (was only in Alembic migration, not the model)
- Treats `REDIS_URL=""` as unset in `cache_redis.py` to prevent `ValueError` when tests set it to empty string
- Respects `RATELIMIT_ENABLED=0` env var in `app/main.py` to bypass slowapi rate limits during testing
- Fixes conftest teardown order to dispose engine before `drop_all`, eliminating asyncpg event-loop-closed teardown noise

## Result
All 26 tests in `test_quality_signals.py` + `test_taxonomy_gaps.py` pass cleanly (was: 2 pass, 7+ errors/failures).

## Test plan
- [x] `python -m pytest tests/test_quality_signals.py tests/test_taxonomy_gaps.py` → 26 passed, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)