### PR TITLE
feat: run history API + taxonomy deduplication

### DIFF
--- a/app/models/repo.py
+++ b/app/models/repo.py
@@ -253,3 +253,17 @@ class RepoTaxonomy(Base):
     __table_args__ = (
         UniqueConstraint("repo_id", "dimension", "raw_value", name="uq_repo_taxonomy_repo_dim_val"),
     )
+
+
+class IngestRun(Base):
+    """Stores a record for each ingestion pipeline run."""
+    __tablename__ = "ingest_runs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    run_mode: Mapped[str] = mapped_column(Text, nullable=False)          # quick / weekly / full / fix
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="running")  # running / success / error
+    repos_upserted: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    repos_processed: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    errors: Mapped[dict | None] = mapped_column(JSONB, nullable=True)     # list of error strings
+    started_at: Mapped[datetime] = mapped_column(TIMESTAMP(timezone=True), server_default=func.now())
+    finished_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True), nullable=True)

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -8,7 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth import require_admin_key, verify_api_key
 from app.cache import cache
 from app.database import get_db
-from app.models.repo import Repo, RepoEmbedding, RepoTag
+from app.models.repo import IngestRun, Repo, RepoEmbedding, RepoTag
 from app.routers.library_full import invalidate_library_cache
 
 logger = logging.getLogger(__name__)
@@ -376,3 +376,90 @@ async def bootstrap_taxonomy(
     processed = len(untagged_repos)
     await db.commit()
     return {"processed": processed, "assigned": assigned, "errors": errors}
+
+
+# ---------------------------------------------------------------------------
+# Run history
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/admin/runs",
+    summary="List recent ingestion runs",
+    dependencies=[Depends(require_admin_key)],
+)
+async def list_runs(
+    limit: int = Query(50, ge=1, le=200),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return the most recent *limit* ingestion run records, newest first."""
+    result = await db.execute(
+        select(IngestRun).order_by(IngestRun.started_at.desc()).limit(limit)
+    )
+    runs = result.scalars().all()
+    return [
+        {
+            "id": r.id,
+            "run_mode": r.run_mode,
+            "status": r.status,
+            "repos_upserted": r.repos_upserted,
+            "repos_processed": r.repos_processed,
+            "errors": r.errors or [],
+            "started_at": r.started_at.isoformat() if r.started_at else None,
+            "finished_at": r.finished_at.isoformat() if r.finished_at else None,
+            "duration_seconds": (
+                (r.finished_at - r.started_at).total_seconds()
+                if r.finished_at and r.started_at
+                else None
+            ),
+        }
+        for r in runs
+    ]
+
+
+@router.post(
+    "/admin/runs",
+    summary="Record a completed ingestion run",
+    dependencies=[Depends(require_admin_key)],
+    status_code=201,
+)
+async def record_run(
+    payload: dict,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Called by the ingestion pipeline after each run to persist run metadata.
+
+    Expected payload::
+
+        {
+            "run_mode": "quick",
+            "status": "success",
+            "repos_upserted": 42,
+            "repos_processed": 150,
+            "errors": [],
+            "started_at": "2026-03-24T05:00:00Z",
+            "finished_at": "2026-03-24T05:03:12Z"
+        }
+    """
+    from datetime import datetime, timezone
+
+    def _parse_dt(val):
+        if not val:
+            return None
+        if isinstance(val, datetime):
+            return val
+        return datetime.fromisoformat(str(val).replace("Z", "+00:00"))
+
+    run = IngestRun(
+        run_mode=payload.get("run_mode", "unknown"),
+        status=payload.get("status", "unknown"),
+        repos_upserted=int(payload.get("repos_upserted", 0)),
+        repos_processed=int(payload.get("repos_processed", 0)),
+        errors=payload.get("errors") or None,
+        started_at=_parse_dt(payload.get("started_at")),
+        finished_at=_parse_dt(payload.get("finished_at")),
+    )
+    db.add(run)
+    await db.commit()
+    await db.refresh(run)
+    return {"id": run.id, "status": "recorded"}

--- a/app/routers/taxonomy.py
+++ b/app/routers/taxonomy.py
@@ -325,3 +325,111 @@ async def assign_taxonomy(
 
     await db.commit()
     return {"status": "ok", "assigned": assigned}
+
+
+@router.post(
+    "/admin/taxonomy/deduplicate",
+    response_model=dict,
+    dependencies=[Depends(verify_api_key), Depends(require_admin_key)],
+    summary="Deduplicate near-identical taxonomy values within each dimension",
+)
+async def deduplicate_taxonomy(
+    dry_run: bool = False,
+    similarity_threshold: float = 0.95,
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """
+    Find taxonomy_values within the same dimension that are near-identical by
+    cosine similarity (>= similarity_threshold, default 0.95), then merge the
+    smaller (lower repo_count) into the larger.
+
+    Merging means:
+    1. Repoint all repo_taxonomy rows from the duplicate to the canonical value.
+    2. Update canonical value's repo_count to sum of both.
+    3. Delete the duplicate taxonomy_value.
+
+    Returns a list of merges performed (or that would be performed in dry_run).
+    """
+    # Find pairs of taxonomy values within same dimension with high similarity
+    # Only consider values that have embeddings
+    result = await db.execute(text(
+        """
+        SELECT a.id AS id_a, a.dimension, a.name AS name_a, a.repo_count AS count_a,
+               b.id AS id_b, b.name AS name_b, b.repo_count AS count_b,
+               1 - (a.embedding_vec <=> b.embedding_vec) AS similarity
+        FROM taxonomy_values a
+        JOIN taxonomy_values b
+          ON a.dimension = b.dimension
+          AND a.id < b.id
+          AND a.embedding_vec IS NOT NULL
+          AND b.embedding_vec IS NOT NULL
+          AND 1 - (a.embedding_vec <=> b.embedding_vec) >= :threshold
+        ORDER BY similarity DESC
+        """,
+    ), {"threshold": similarity_threshold})
+    pairs = result.fetchall()
+
+    if not pairs:
+        return {"merged": 0, "dry_run": dry_run, "pairs": []}
+
+    merges = []
+    already_merged: set[int] = set()
+
+    for pair in pairs:
+        id_a, id_b = pair.id_a, pair.id_b
+        if id_a in already_merged or id_b in already_merged:
+            continue
+
+        # Keep the one with higher repo_count as canonical
+        if pair.count_a >= pair.count_b:
+            canonical_id, dup_id = id_a, id_b
+            canonical_name, dup_name = pair.name_a, pair.name_b
+        else:
+            canonical_id, dup_id = id_b, id_a
+            canonical_name, dup_name = pair.name_b, pair.name_a
+
+        merge_info = {
+            "dimension": pair.dimension,
+            "canonical": canonical_name,
+            "duplicate": dup_name,
+            "similarity": round(float(pair.similarity), 4),
+        }
+        merges.append(merge_info)
+        already_merged.add(dup_id)
+
+        if not dry_run:
+            # Repoint repo_taxonomy rows from dup to canonical
+            await db.execute(text(
+                """
+                UPDATE repo_taxonomy
+                SET raw_value = :canonical_name, taxonomy_value_id = :canonical_id
+                WHERE taxonomy_value_id = :dup_id
+                  AND NOT EXISTS (
+                      SELECT 1 FROM repo_taxonomy rt2
+                      WHERE rt2.repo_id = repo_taxonomy.repo_id
+                        AND rt2.dimension = repo_taxonomy.dimension
+                        AND rt2.raw_value = :canonical_name
+                  )
+                """
+            ), {"canonical_name": canonical_name, "canonical_id": canonical_id, "dup_id": dup_id})
+
+            # Delete rows that would conflict (the dup is already in canonical's position)
+            await db.execute(text(
+                "DELETE FROM repo_taxonomy WHERE taxonomy_value_id = :dup_id"
+            ), {"dup_id": dup_id})
+
+            # Update canonical repo_count
+            new_count = max(pair.count_a, pair.count_b)
+            await db.execute(text(
+                "UPDATE taxonomy_values SET repo_count = :count WHERE id = :id"
+            ), {"count": new_count, "id": canonical_id})
+
+            # Delete duplicate taxonomy_value
+            await db.execute(text(
+                "DELETE FROM taxonomy_values WHERE id = :id"
+            ), {"id": dup_id})
+
+    if not dry_run:
+        await db.commit()
+
+    return {"merged": len(merges), "dry_run": dry_run, "pairs": merges}

--- a/migrations/versions/017_add_ingest_runs.py
+++ b/migrations/versions/017_add_ingest_runs.py
@@ -1,0 +1,42 @@
+"""Add ingest_runs table for pipeline run history.
+
+Revision ID: 017
+Revises: 016
+Create Date: 2026-03-24
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "017"
+down_revision = "016"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ingest_runs",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
+        sa.Column("run_mode", sa.Text(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False, server_default="running"),
+        sa.Column("repos_upserted", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("repos_processed", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("errors", JSONB(), nullable=True),
+        sa.Column(
+            "started_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("finished_at", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.create_index("ix_ingest_runs_started_at", "ingest_runs", ["started_at"])
+    op.create_index("ix_ingest_runs_status", "ingest_runs", ["status"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_ingest_runs_status", "ingest_runs")
+    op.drop_index("ix_ingest_runs_started_at", "ingest_runs")
+    op.drop_table("ingest_runs")


### PR DESCRIPTION
## Summary
- **`GET /admin/runs`** — lists recent ingestion runs (newest first, limit up to 200), returns `id, run_mode, status, repos_upserted, repos_processed, errors, started_at, finished_at, duration_seconds`
- **`POST /admin/runs`** — ingestion pipeline calls this after each run to persist run metadata; protected by X-Admin-Key
- **`POST /admin/taxonomy/deduplicate`** — finds pairs of taxonomy_values in the same dimension with cosine similarity ≥ 0.95 and merges duplicates into the canonical (higher repo_count) value; supports `?dry_run=true`
- **Migration 017** — adds `ingest_runs` table with indexes on `started_at` and `status`
- **`IngestRun` model** — added to `app/models/repo.py`

## Test plan
- [ ] `GET /admin/runs` returns empty list when no runs recorded
- [ ] `POST /admin/runs` creates a run record and returns `{"id": N, "status": "recorded"}`
- [ ] `GET /admin/runs` returns the created record with `duration_seconds` computed
- [ ] `POST /admin/taxonomy/deduplicate?dry_run=true` returns pairs without making DB changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)