### PR TITLE
fix: revert min-instances to 0 + scheduled warmup ping (KAN-37)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
           flags: >-
             --memory=1Gi
             --cpu=1
-            --min-instances=1
+            --min-instances=0
             --max-instances=10
             --concurrency=20
             --timeout=60

--- a/.github/workflows/warmup.yml
+++ b/.github/workflows/warmup.yml
@@ -1,0 +1,23 @@
+name: Keep Cloud Run warm
+
+on:
+  schedule:
+    # Every 10 minutes during active hours (06:00–02:00 UTC, covers US/EU daytime)
+    - cron: '*/10 6-23 * * *'
+    - cron: '*/10 0-2 * * *'
+  workflow_dispatch:
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping health endpoint
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            "https://reporium-api-573778300586.us-central1.run.app/health" \
+            --max-time 10)
+          echo "Health status: $STATUS"
+          if [ "$STATUS" != "200" ]; then
+            echo "Warning: health returned $STATUS"
+            exit 1
+          fi

--- a/deploy/service.yaml
+++ b/deploy/service.yaml
@@ -6,7 +6,7 @@ spec:
   template:
     metadata:
       annotations:
-        autoscaling.knative.dev/minScale: "1"
+        autoscaling.knative.dev/minScale: "0"
         autoscaling.knative.dev/maxScale: "10"
     spec:
       containerConcurrency: 20


### PR DESCRIPTION
## Summary
- `min-instances=1` was added in #50 to eliminate 220s cold starts — but costs **~\$28/month in idle Cloud Run compute** with zero users
- Reverts to `min-instances=0` in both `deploy.yml` and `service.yaml`
- Adds `warmup.yml`: scheduled GitHub Action that pings `/health` every 10 minutes during active hours (06:00–02:00 UTC) — keeps the instance alive at effectively **\$0** (free GHA minutes on public repo)
- `memory=1Gi` and `cpu=1` unchanged — still needed to prevent sentence-transformer OOM

## Cost delta
**−\$28/month** in idle Cloud Run compute

## Trade-off
If the instance does go cold (e.g. outside warmup window or warmup misses), cold start is ~15–30s. Acceptable for a pre-launch product.

## Test plan
- [ ] Deploy merges cleanly to Cloud Run
- [ ] `/health` returns 200 after deploy
- [ ] Warmup workflow fires on schedule and shows 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)