### PR TITLE
fix: embed_taxonomy try/except — repo-ingested event no longer 500s (KAN-34)

### DIFF
--- a/app/routers/ingest.py
+++ b/app/routers/ingest.py
@@ -387,16 +387,11 @@ async def repo_ingested_event(
     log = logging.getLogger(__name__)
 
     rebuild_result = await rebuild_taxonomy(RebuildBody(), db)
-
-    # embed_taxonomy loads a sentence-transformer model (~90 MB) at runtime.
-    # Wrap in try/except so a model-load failure (OOM, network policy on Cloud Run)
-    # does not 500 the entire event handler — taxonomy rebuild and assign still run.
     try:
         embed_result = await embed_taxonomy(db)
     except Exception as exc:
-        log.error("embed_taxonomy failed (non-fatal): %s", exc)
+        log.exception("embed_taxonomy failed during repo-ingested refresh")
         embed_result = {"status": "skipped", "error": str(exc), "embedded": 0}
-
     assign_result = await assign_taxonomy(AssignBody(), db)
     gap_result = await _rebuild_gap_analysis(db)
 

--- a/app/routers/ingest.py
+++ b/app/routers/ingest.py
@@ -384,8 +384,19 @@ async def repo_ingested_event(
     """Handle Pub/Sub repo-ingested pushes and refresh taxonomy, gaps, and insights."""
     payload = _parse_pubsub_payload(await request.json())
 
+    log = logging.getLogger(__name__)
+
     rebuild_result = await rebuild_taxonomy(RebuildBody(), db)
-    embed_result = await embed_taxonomy(db)
+
+    # embed_taxonomy loads a sentence-transformer model (~90 MB) at runtime.
+    # Wrap in try/except so a model-load failure (OOM, network policy on Cloud Run)
+    # does not 500 the entire event handler — taxonomy rebuild and assign still run.
+    try:
+        embed_result = await embed_taxonomy(db)
+    except Exception as exc:
+        log.error("embed_taxonomy failed (non-fatal): %s", exc)
+        embed_result = {"status": "skipped", "error": str(exc), "embedded": 0}
+
     assign_result = await assign_taxonomy(AssignBody(), db)
     gap_result = await _rebuild_gap_analysis(db)
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -13,11 +13,44 @@ ENVIRONMENT=production GCP_PROJECT=perditio-platform alembic upgrade head
 
 ## Health Probes
 
-The Cloud Run service manifest in [deploy/service.yaml](/C:/DEV/PERDITIO_PLATFORM/reporium-api/deploy/service.yaml) points the startup probe at `GET /health`.
+The Cloud Run service manifest should point startup or readiness probes at `GET /health`.
 
 - `200` means the service and database are reachable.
 - `503` means the API is up but the database check failed.
 
-## GitHub Actions
+## Ingestion Recovery Runbook
 
-The deploy workflow now runs `alembic upgrade head` before the Cloud Run deploy step so new code does not boot against an older schema.
+Use this when the live API is returning repos with empty `enrichedTags`, `aiDevSkills`, or `taxonomy` data.
+
+1. Run a full ingestion against production with a fresh cache database so unchanged repos are re-fetched instead of skipped.
+2. Wait for the ingestion run to complete. The production API is updated near the end of the run, not incrementally.
+3. Verify the enrichment tables are populated:
+
+```sql
+SELECT COUNT(*) FROM repo_tags;
+SELECT COUNT(*) FROM repo_ai_dev_skills;
+SELECT COUNT(*) FROM repo_pm_skills;
+SELECT COUNT(*) FROM repo_taxonomy;
+```
+
+4. If taxonomy or gap data is still stale, run the admin refresh sequence manually:
+
+```bash
+curl -X POST https://reporium-api-573778300586.us-central1.run.app/taxonomy/admin/taxonomy/rebuild \
+  -H "Authorization: Bearer $REPORIUM_API_KEY"
+
+curl -X POST https://reporium-api-573778300586.us-central1.run.app/taxonomy/admin/taxonomy/embed \
+  -H "Authorization: Bearer $REPORIUM_API_KEY"
+
+curl -X POST https://reporium-api-573778300586.us-central1.run.app/taxonomy/admin/taxonomy/assign \
+  -H "Authorization: Bearer $REPORIUM_API_KEY"
+
+curl -X POST https://reporium-api-573778300586.us-central1.run.app/admin/gaps/rebuild \
+  -H "Authorization: Bearer $REPORIUM_API_KEY"
+```
+
+5. Trigger a frontend redeploy so the static snapshot artifacts pick up the refreshed enrichment data.
+
+## Current Limitation
+
+The Pub/Sub recovery route at `POST /ingest/events/repo-ingested` can still encounter model-load failures when `embed_taxonomy()` tries to load the sentence-transformers model at runtime. The handler should continue with partial success instead of failing the entire event, but manual recovery remains the safest operational path until model loading is fully hardened in production.

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -180,3 +180,35 @@ async def test_repo_ingested_event_decodes_pubsub_envelope(client: AsyncClient):
 
     assert response.status_code == 200
     assert response.json()["received"] == {"batch": "nightly", "repos": 25}
+
+
+@pytest.mark.asyncio
+async def test_repo_ingested_event_skips_embed_failure_and_still_returns_200(client: AsyncClient, monkeypatch):
+    monkeypatch.setenv("INGEST_API_KEY", "secret-ingest")
+
+    with patch("app.routers.ingest.rebuild_taxonomy", new=AsyncMock(return_value={"status": "ok", "upserted": 3})), \
+         patch("app.routers.ingest.embed_taxonomy", new=AsyncMock(side_effect=RuntimeError("model load failed"))), \
+         patch("app.routers.ingest.assign_taxonomy", new=AsyncMock(return_value={"status": "ok", "assigned": 11})), \
+         patch("app.routers.ingest._rebuild_gap_analysis", new=AsyncMock(return_value={"gap_rows": 8})), \
+         patch("app.routers.ingest._refresh_portfolio_intelligence", new=AsyncMock(return_value={"taxonomy_gap_count": 4, "stale_repo_count": 2, "velocity_leader_count": 3, "near_duplicate_cluster_count": 1})), \
+         patch("app.routers.ingest.cache.invalidate", new=AsyncMock()) as invalidate_cache, \
+         patch("app.routers.ingest.invalidate_library_cache") as invalidate_memory:
+        response = await client.post(
+            "/ingest/events/repo-ingested",
+            json={"source": "pubsub-test"},
+            headers={"X-Ingest-Key": "secret-ingest"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok"
+    assert data["received"]["source"] == "pubsub-test"
+    assert data["taxonomy_rebuild"]["upserted"] == 3
+    assert data["taxonomy_embed"]["status"] == "skipped"
+    assert data["taxonomy_embed"]["embedded"] == 0
+    assert "model load failed" in data["taxonomy_embed"]["error"]
+    assert data["taxonomy_assign"]["assigned"] == 11
+    assert data["gap_rebuild"]["gap_rows"] == 8
+    assert data["portfolio_insights"]["taxonomy_gap_count"] == 4
+    assert invalidate_cache.await_count == 3
+    invalidate_memory.assert_called_once()


### PR DESCRIPTION
## Summary
`POST /ingest/events/repo-ingested` was returning 500 because `embed_taxonomy()` calls `SentenceTransformer('all-MiniLM-L6-v2')` which downloads ~90 MB from HuggingFace at runtime. On Cloud Run this fails (OOM or network policy), crashing the entire handler before `assign_taxonomy`, `gap_rebuild`, or cache invalidation can run.

**Fix:** wrap `embed_taxonomy(db)` in `try/except`. On failure:
- Logs the error at ERROR level
- Returns `{"status": "skipped", "error": "...", "embedded": 0}` in the response
- Remaining pipeline steps (assign, gap rebuild, cache invalidation, portfolio refresh) all complete

## Test plan
- [ ] `POST /ingest/events/repo-ingested` with `{}` body returns 200 (not 500)
- [ ] Response includes `taxonomy_embed.status == "skipped"` when model fails to load
- [ ] Response includes `taxonomy_embed.status == "ok"` when model loads successfully
- [ ] taxonomy rebuild + assign + gap rebuild still execute regardless

🤖 Generated with [Claude Code](https://claude.com/claude-code)