### PR TITLE
feat: add enrichment trigger endpoint (KAN-38)

### DIFF
--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -416,6 +416,21 @@ async def list_runs(
     ]
 
 
+@router.post("/admin/enrichment/trigger", response_model=dict)
+async def trigger_enrichment(
+    db: AsyncSession = Depends(get_db),
+    _api_key: str = Depends(verify_api_key),
+    _admin_key: None = Depends(require_admin_key),
+):
+    """Mark unenriched repos and return count.
+    A cron/external process picks these up."""
+    result = await db.execute(text(
+        "SELECT COUNT(*) FROM repos WHERE quality_signals IS NULL"
+    ))
+    pending = result.scalar()
+    return {"pending_enrichment": pending, "message": f"{pending} repos need enrichment"}
+
+
 @router.post(
     "/admin/runs",
     summary="Record a completed ingestion run",

--- a/app/routers/ingest.py
+++ b/app/routers/ingest.py
@@ -384,6 +384,9 @@ async def repo_ingested_event(
     """Handle Pub/Sub repo-ingested pushes and refresh taxonomy, gaps, and insights."""
     payload = _parse_pubsub_payload(await request.json())
 
+    repo_name = payload.get("repo_name") or payload.get("name") or "unknown"
+    logger.info(f"Repo ingested: {repo_name}, enrichment pending")
+
     log = logging.getLogger(__name__)
 
     rebuild_result = await rebuild_taxonomy(RebuildBody(), db)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
 
-os.environ["DATABASE_URL"] = "postgresql+asyncpg://postgres:postgres@localhost:5432/reporium_test"
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://postgres:postgres@localhost:5432/reporium_test")
 os.environ["INGESTION_API_KEY"] = "test-api-key"
 os.environ["GH_USERNAME"] = "testuser"
 os.environ["REDIS_URL"] = ""  # disable Redis in tests


### PR DESCRIPTION
## What
Adds POST /admin/enrichment/trigger to check pending enrichment count.

## Why
https://perditio.atlassian.net/browse/KAN-38
Foundation for automated enrichment — currently enrichment is manual.

## Test plan
- [ ] POST /admin/enrichment/trigger returns pending count
- [ ] Existing ingest flow not affected