### PR TITLE
feat(admin): add /admin/health/data integrity check endpoint (KAN-51)

### DIFF
--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -379,6 +379,104 @@ async def bootstrap_taxonomy(
 
 
 # ---------------------------------------------------------------------------
+# Data integrity health check
+# ---------------------------------------------------------------------------
+
+@router.get("/admin/health/data", response_model=dict)
+async def data_integrity_health(
+    db: AsyncSession = Depends(get_db),
+    _admin_key: None = Depends(require_admin_key),
+):
+    """
+    Monitor junction table row counts and coverage ratios to detect data
+    regressions immediately after ingestion runs.
+
+    Status thresholds:
+    - ``critical``  — repo_tags has < 100 rows total
+    - ``degraded``  — repo_tags coverage < 50 % of repos
+    - ``healthy``   — all checks pass
+    """
+    # --- raw counts (fast COUNT queries, no JOINs) ---
+    tables = [
+        "repos",
+        "repo_tags",
+        "repo_categories",
+        "repo_taxonomy",
+        "taxonomy_values",
+        "repo_ai_dev_skills",
+        "repo_pm_skills",
+        "repo_languages",
+    ]
+    counts: dict[str, int] = {}
+    for table in tables:
+        row = await db.execute(text(f"SELECT COUNT(*) FROM {table}"))  # noqa: S608
+        counts[table] = row.scalar() or 0
+
+    total_repos = counts["repos"]
+
+    # --- coverage: repos that have at least 1 row in each junction table ---
+    def _pct(n: int) -> float:
+        if total_repos == 0:
+            return 0.0
+        return round(n / total_repos * 100, 1)
+
+    tags_covered = (
+        await db.execute(
+            text("SELECT COUNT(DISTINCT repo_id) FROM repo_tags")
+        )
+    ).scalar() or 0
+
+    cats_covered = (
+        await db.execute(
+            text("SELECT COUNT(DISTINCT repo_id) FROM repo_categories")
+        )
+    ).scalar() or 0
+
+    langs_covered = (
+        await db.execute(
+            text("SELECT COUNT(DISTINCT repo_id) FROM repo_languages")
+        )
+    ).scalar() or 0
+
+    coverage = {
+        "tags_pct": _pct(tags_covered),
+        "categories_pct": _pct(cats_covered),
+        "languages_pct": _pct(langs_covered),
+    }
+
+    # --- alerts & status ---
+    alerts: list[str] = []
+    status = "healthy"
+
+    tag_total = counts["repo_tags"]
+    tags_pct = coverage["tags_pct"]
+
+    if tag_total < 100:
+        status = "critical"
+        alerts.append(
+            f"repo_tags critically low: {tag_total} rows for {total_repos} repos"
+        )
+    elif tags_pct < 50.0:
+        status = "degraded"
+        alerts.append(
+            f"repo_tags coverage degraded: {tags_pct}% of repos have a tag"
+        )
+
+    thresholds = {
+        "repo_tags_min_rows": 100,
+        "tags_coverage_min_pct": 50.0,
+    }
+
+    return {
+        "status": status,
+        "counts": counts,
+        "coverage": coverage,
+        "thresholds": thresholds,
+        "alerts": alerts,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Run history
 # ---------------------------------------------------------------------------
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
 
-os.environ["DATABASE_URL"] = "postgresql+asyncpg://postgres:postgres@localhost:5432/reporium_test"
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://postgres:postgres@localhost:5432/reporium_test")
 os.environ["INGESTION_API_KEY"] = "test-api-key"
 os.environ["GH_USERNAME"] = "testuser"
 os.environ["REDIS_URL"] = ""  # disable Redis in tests

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -3,7 +3,7 @@ from httpx import AsyncClient
 from unittest.mock import AsyncMock, patch
 
 from app.routers.admin import _prune_noise_tags
-from tests.conftest import TEST_API_KEY
+from tests.conftest import AUTH_HEADERS, TEST_API_KEY
 
 
 @pytest.mark.asyncio
@@ -47,6 +47,174 @@ class _ScalarResult:
     def fetchall(self):
         return self._rows
 
+
+# ---------------------------------------------------------------------------
+# /admin/health/data
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_data_integrity_health_requires_admin_key(client: AsyncClient):
+    """Endpoint should be accessible without an admin key when ADMIN_API_KEY is unset."""
+    # conftest does not set ADMIN_API_KEY, so require_admin_key allows all requests.
+    response = await client.get("/admin/health/data")
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_data_integrity_health_returns_correct_shape(client: AsyncClient):
+    response = await client.get("/admin/health/data")
+    assert response.status_code == 200
+    data = response.json()
+
+    assert set(data.keys()) == {"status", "counts", "coverage", "thresholds", "alerts"}
+
+    # status must be one of the three sentinel strings
+    assert data["status"] in {"healthy", "degraded", "critical"}
+
+    # counts must include every monitored table
+    expected_tables = {
+        "repos",
+        "repo_tags",
+        "repo_categories",
+        "repo_taxonomy",
+        "taxonomy_values",
+        "repo_ai_dev_skills",
+        "repo_pm_skills",
+        "repo_languages",
+    }
+    assert expected_tables == set(data["counts"].keys())
+    for v in data["counts"].values():
+        assert isinstance(v, int)
+
+    # coverage must contain the three ratio keys
+    assert set(data["coverage"].keys()) == {"tags_pct", "categories_pct", "languages_pct"}
+    for v in data["coverage"].values():
+        assert isinstance(v, float)
+        assert 0.0 <= v <= 100.0
+
+    # thresholds present
+    assert "repo_tags_min_rows" in data["thresholds"]
+    assert "tags_coverage_min_pct" in data["thresholds"]
+
+    # alerts is a list
+    assert isinstance(data["alerts"], list)
+
+
+@pytest.mark.asyncio
+async def test_data_integrity_health_status_critical_when_no_tags(client: AsyncClient):
+    """With an empty database the tag count is 0 → status must be critical."""
+    response = await client.get("/admin/health/data")
+    assert response.status_code == 200
+    data = response.json()
+    # Empty DB → repo_tags = 0 which is < 100 → critical
+    if data["counts"]["repo_tags"] < 100:
+        assert data["status"] == "critical"
+        assert len(data["alerts"]) >= 1
+
+
+@pytest.mark.asyncio
+async def test_data_integrity_health_healthy_status_logic():
+    """Unit-test the status logic directly by mocking the DB."""
+    from app.routers.admin import data_integrity_health
+    from unittest.mock import MagicMock
+
+    # Build a mock DB that returns high counts and good coverage
+    call_count = 0
+    table_counts = {
+        "repos": 500,
+        "repo_tags": 3000,
+        "repo_categories": 450,
+        "repo_taxonomy": 2000,
+        "taxonomy_values": 800,
+        "repo_ai_dev_skills": 300,
+        "repo_pm_skills": 200,
+        "repo_languages": 480,
+        # DISTINCT coverage queries
+        "tags_distinct": 490,
+        "cats_distinct": 460,
+        "langs_distinct": 475,
+    }
+
+    scalar_values = [
+        # 8 table COUNTs (order matches the `tables` list in the handler)
+        table_counts["repos"],
+        table_counts["repo_tags"],
+        table_counts["repo_categories"],
+        table_counts["repo_taxonomy"],
+        table_counts["taxonomy_values"],
+        table_counts["repo_ai_dev_skills"],
+        table_counts["repo_pm_skills"],
+        table_counts["repo_languages"],
+        # 3 DISTINCT coverage queries
+        table_counts["tags_distinct"],
+        table_counts["cats_distinct"],
+        table_counts["langs_distinct"],
+    ]
+
+    idx = 0
+
+    async def fake_execute(stmt):
+        nonlocal idx
+        mock_result = MagicMock()
+        mock_result.scalar.return_value = scalar_values[idx]
+        idx += 1
+        return mock_result
+
+    db = AsyncMock()
+    db.execute = fake_execute
+
+    result = await data_integrity_health(db=db, _admin_key=None)
+
+    assert result["status"] == "healthy"
+    assert result["counts"]["repos"] == 500
+    assert result["counts"]["repo_tags"] == 3000
+    assert result["coverage"]["tags_pct"] == round(490 / 500 * 100, 1)
+    assert result["alerts"] == []
+
+
+@pytest.mark.asyncio
+async def test_data_integrity_health_degraded_status_logic():
+    """Status is degraded when tag count >= 100 but coverage < 50 %."""
+    from app.routers.admin import data_integrity_health
+    from unittest.mock import MagicMock
+
+    # 1000 repos, 150 tags total (>= 100), but only 40 % covered
+    scalar_values = [
+        1000,  # repos
+        150,   # repo_tags
+        800,   # repo_categories
+        500,   # repo_taxonomy
+        200,   # taxonomy_values
+        100,   # repo_ai_dev_skills
+        80,    # repo_pm_skills
+        950,   # repo_languages
+        400,   # DISTINCT tags (40 %)
+        700,   # DISTINCT categories
+        900,   # DISTINCT languages
+    ]
+
+    idx = 0
+
+    async def fake_execute(stmt):
+        nonlocal idx
+        mock_result = MagicMock()
+        mock_result.scalar.return_value = scalar_values[idx]
+        idx += 1
+        return mock_result
+
+    db = AsyncMock()
+    db.execute = fake_execute
+
+    result = await data_integrity_health(db=db, _admin_key=None)
+
+    assert result["status"] == "degraded"
+    assert len(result["alerts"]) == 1
+    assert "degraded" in result["alerts"][0]
+
+
+# ---------------------------------------------------------------------------
+# _prune_noise_tags (existing helpers — kept below)
+# ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
 async def test_prune_noise_tags_dry_run_returns_counts_without_commit():


### PR DESCRIPTION
## Summary

- Adds `GET /admin/health/data` to `app/routers/admin.py`, protected by `require_admin_key`
- Runs fast COUNT-only queries against all 8 critical tables (`repos`, `repo_tags`, `repo_categories`, `repo_taxonomy`, `taxonomy_values`, `repo_ai_dev_skills`, `repo_pm_skills`, `repo_languages`)
- Computes `DISTINCT repo_id` coverage ratios for tags, categories, and languages
- Returns `status: healthy | degraded | critical` based on thresholds (critical < 100 tag rows; degraded < 50% tag coverage), plus `counts`, `coverage`, `thresholds`, and `alerts` arrays

## Test plan

- [ ] `tests/test_admin.py::test_data_integrity_health_requires_admin_key` — endpoint accessible without key in dev mode
- [ ] `tests/test_admin.py::test_data_integrity_health_returns_correct_shape` — validates all keys and types in the response
- [ ] `tests/test_admin.py::test_data_integrity_health_status_critical_when_no_tags` — empty DB → critical status
- [ ] `tests/test_admin.py::test_data_integrity_health_healthy_status_logic` — unit test with mocked DB returning healthy counts
- [ ] `tests/test_admin.py::test_data_integrity_health_degraded_status_logic` — unit test confirming degraded alert fires at <50% tag coverage
- [ ] All 9 admin tests pass (`python -m pytest tests/test_admin.py -x -q`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)