### PR TITLE
fix(library): rewire library_full to read from taxonomy_values instead of empty skill_areas/repo_ai_dev_skills

### DIFF
--- a/app/routers/ingest.py
+++ b/app/routers/ingest.py
@@ -85,15 +85,12 @@ async def _rebuild_gap_analysis(db: AsyncSession) -> dict[str, int]:
         await db.execute(
             text(
                 """
-                SELECT sa.name AS skill,
-                       COUNT(DISTINCT ras.repo_id) AS repo_count,
+                SELECT tv.name AS skill,
+                       COALESCE(tv.repo_count, 0) AS repo_count,
                        COALESCE(tv.trending_score, 0) AS trending_score
-                FROM skill_areas sa
-                LEFT JOIN repo_ai_dev_skills ras ON ras.skill = sa.name
-                LEFT JOIN taxonomy_values tv
-                  ON tv.dimension = 'skill_area' AND tv.name = sa.name
-                GROUP BY sa.name, tv.trending_score
-                ORDER BY repo_count ASC, sa.name ASC
+                FROM taxonomy_values tv
+                WHERE tv.dimension = 'skill_area'
+                ORDER BY tv.repo_count ASC, tv.name ASC
                 """
             )
         )

--- a/app/routers/library_full.py
+++ b/app/routers/library_full.py
@@ -182,27 +182,12 @@ _LIFECYCLE_GROUPS_TTL = 300  # 5 minutes
 
 
 async def _get_lifecycle_groups(db: AsyncSession) -> dict:
-    """Return {skill_area_name: lifecycle_group} from the skill_areas table.
+    """Return {skill_area_name: lifecycle_group}.
 
-    Results are cached in memory for 5 minutes. Falls back to the compile-time
-    dict if the table is unavailable (e.g. migration not yet applied).
+    taxonomy_values does not carry a lifecycle_group column, so this function
+    returns the compile-time fallback dict which encodes the 28-skill taxonomy.
+    The async signature is kept so call sites do not need to change.
     """
-    now = time.time()
-    cached = _lifecycle_groups_cache.get("data")
-    if cached and _lifecycle_groups_cache.get("expires_at", 0) > now:
-        return cached
-
-    try:
-        result = await db.execute(text("SELECT name, lifecycle_group FROM skill_areas"))
-        rows = result.fetchall()
-        if rows:
-            mapping = {row.name: row.lifecycle_group for row in rows}
-            _lifecycle_groups_cache["data"] = mapping
-            _lifecycle_groups_cache["expires_at"] = now + _LIFECYCLE_GROUPS_TTL
-            return mapping
-    except Exception:
-        logger.warning("_get_lifecycle_groups: skill_areas table unavailable, using fallback", exc_info=True)
-
     return _LIFECYCLE_GROUPS_FALLBACK
 
 # Keep a set for O(1) membership checks in _build_ai_dev_skill_stats
@@ -876,7 +861,7 @@ async def _fetch_page_repos(
         await asyncio.gather(
             _fetch_junction("SELECT repo_id, language, bytes, percentage FROM repo_languages WHERE repo_id::text = ANY(:ids)"),
             _fetch_junction("SELECT repo_id, category_name, is_primary FROM repo_categories WHERE repo_id::text = ANY(:ids)"),
-            _fetch_junction("SELECT repo_id, skill FROM repo_ai_dev_skills WHERE repo_id::text = ANY(:ids)"),
+            _fetch_junction("SELECT repo_id, raw_value AS skill FROM repo_taxonomy WHERE dimension = 'skill_area' AND repo_id::text = ANY(:ids)"),
             _fetch_junction("SELECT repo_id, tag FROM repo_tags WHERE repo_id::text = ANY(:ids)"),
             _fetch_junction("SELECT repo_id, skill FROM repo_pm_skills WHERE repo_id::text = ANY(:ids)"),
             _fetch_junction("SELECT repo_id, login, display_name, org_category, is_known_org FROM repo_builders WHERE repo_id::text = ANY(:ids)"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
 
-os.environ["DATABASE_URL"] = "postgresql+asyncpg://postgres:postgres@localhost:5432/reporium_test"
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://postgres:postgres@localhost:5432/reporium_test")
 os.environ["INGESTION_API_KEY"] = "test-api-key"
 os.environ["GH_USERNAME"] = "testuser"
 os.environ["REDIS_URL"] = ""  # disable Redis in tests


### PR DESCRIPTION
## Summary

- **`aiDevSkillStats` / skill junction fetch**: Changed `_fetch_page_repos()` to read `repo_id, raw_value AS skill` from `repo_taxonomy WHERE dimension = 'skill_area'` instead of the empty `repo_ai_dev_skills` table, so per-repo AI dev skill data is actually populated.
- **`_get_lifecycle_groups()`**: Removed the dead `SELECT name, lifecycle_group FROM skill_areas` query. `taxonomy_values` has no `lifecycle_group` column, so the function now returns `_LIFECYCLE_GROUPS_FALLBACK` directly (the compile-time 28-skill mapping), eliminating a DB error on every request.
- **`_rebuild_gap_analysis()` in `ingest.py`**: Replaced the triple-join over `skill_areas` + `repo_ai_dev_skills` + `taxonomy_values` with a direct read from `taxonomy_values WHERE dimension = 'skill_area'`, using the pre-aggregated `repo_count` and `trending_score` columns that the taxonomy rebuild job maintains.

## Test plan

- [x] `python -m pytest tests/ -x -q` — 178 passed, 2 skipped, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)