### PR TITLE
fix(trends): invalidate trends:report cache on snapshot ingest (KAN-56)

### DIFF
--- a/app/routers/ingest.py
+++ b/app/routers/ingest.py
@@ -318,6 +318,7 @@ async def ingest_trend_snapshot(
         await db.refresh(row)
 
     await cache.invalidate("trends:latest")
+    await cache.invalidate("trends:report")
     return [TrendSnapshotOut.model_validate(r, from_attributes=True) for r in rows]
 
 


### PR DESCRIPTION
## Summary

- `POST /ingest/trends/snapshot` was only invalidating the `trends:latest` cache key but NOT `trends:report`
- After weekly ingestion populated `trend_snapshots`, `GET /trends/report` kept serving a stale empty response for up to 1 hour (`CACHE_TTL_TRENDS = 3600s`)
- Added `await cache.invalidate("trends:report")` alongside the existing `trends:latest` invalidation

## Root Cause Analysis (KAN-56)

**Primary issue (data pipeline — not a code bug):** `trend_snapshots` are only populated when the ingestion pipeline runs in `--mode weekly` or `--mode full`. Quick mode does not compute trends. The table being empty means no data has been ingested yet in the right mode.

**Secondary issue (code bug — fixed here):** Even after weekly ingestion runs and writes snapshots, the `/trends/report` endpoint caches an empty `TrendReportOut` on first call (when the table was empty), and that stale empty cache entry persists for 1 hour because `POST /ingest/trends/snapshot` was not invalidating the `trends:report` key. This would cause Trend Intelligence to remain empty even after weekly ingestion succeeds.

## Frontend behavior (no crash, graceful empty state)

The frontend handles empty trends correctly:
- `getTrends()` in `dataProvider.ts` catches errors and falls back to the static `trends.json` file
- `HomePageClient.tsx`: `if (!cancelled && t) setTrends(t)` — only sets trends state if truthy
- `MetricsSidebar.tsx`: `{trends && (...)}` — entire Intelligence section is hidden when `trends` is null
- `MetricsSidebar.tsx`: `{(trends.period?.snapshots ?? 0) < 3 ? (<p>Trend data builds up over time...</p>)}` — shows graceful message when fewer than 3 snapshots exist
- No frontend crashes or misleading data; the section simply doesn't appear

## Router registration

`trends.router` is already registered in `app/main.py` (line 223). `POST /ingest/trends/snapshot` is on `ingest.router` (line 226). Both correctly registered.

## Test plan

- [ ] Run ingestion in `--mode weekly` to populate `trend_snapshots`
- [ ] Call `POST /ingest/trends/snapshot` via ingestion pipeline
- [ ] Immediately call `GET /trends/report` — should return non-empty report (not wait up to 1 hour)
- [ ] Verify Trend Intelligence panel shows trending/emerging data in the sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)