### PR TITLE
fix(repos): include taxonomy in repo detail response and stargazers_count in ingestion (KAN-53)

### DIFF
--- a/app/routers/library.py
+++ b/app/routers/library.py
@@ -71,7 +71,7 @@ def _repo_to_summary(repo: Repo) -> RepoSummary:
         ],
         taxonomy=[
             {"dimension": t.dimension, "value": t.raw_value, "similarityScore": t.similarity_score, "assignedBy": t.assigned_by}
-            for t in repo.taxonomy
+            for t in getattr(repo, "taxonomy", [])
         ],
     )
 
@@ -99,6 +99,7 @@ async def get_library(
             selectinload(Repo.ai_dev_skills),
             selectinload(Repo.pm_skills),
             selectinload(Repo.languages),
+            selectinload(Repo.taxonomy),
         )
         .order_by(Repo.updated_at.desc())
         .offset(offset)

--- a/app/routers/library.py
+++ b/app/routers/library.py
@@ -69,6 +69,10 @@ def _repo_to_summary(repo: Repo) -> RepoSummary:
             {"language": l.language, "bytes": l.bytes, "percentage": l.percentage}
             for l in repo.languages
         ],
+        taxonomy=[
+            {"dimension": t.dimension, "value": t.raw_value, "similarityScore": t.similarity_score, "assignedBy": t.assigned_by}
+            for t in repo.taxonomy
+        ],
     )
 
 

--- a/app/routers/repos.py
+++ b/app/routers/repos.py
@@ -16,6 +16,7 @@ from app.models.repo import (
     RepoCommit,
     RepoLanguage,
     RepoTag,
+    RepoTaxonomy,
 )
 from app.routers.library import _repo_to_summary
 from app.schemas.repo import RepoDetail, RepoSummary
@@ -174,6 +175,7 @@ async def get_repo(name: str, db: AsyncSession = Depends(get_db)) -> RepoDetail:
             selectinload(Repo.pm_skills),
             selectinload(Repo.languages),
             selectinload(Repo.commits),
+            selectinload(Repo.taxonomy),
         )
     )
     result = await db.execute(stmt)
@@ -200,6 +202,7 @@ async def get_repo_by_owner(owner: str, repo: str, db: AsyncSession = Depends(ge
             selectinload(Repo.pm_skills),
             selectinload(Repo.languages),
             selectinload(Repo.commits),
+            selectinload(Repo.taxonomy),
         )
     )
     result = await db.execute(stmt)

--- a/app/routers/repos.py
+++ b/app/routers/repos.py
@@ -83,6 +83,7 @@ async def list_repos(
             selectinload(Repo.ai_dev_skills),
             selectinload(Repo.pm_skills),
             selectinload(Repo.languages),
+            selectinload(Repo.taxonomy),
         )
     )
 

--- a/app/routers/search.py
+++ b/app/routers/search.py
@@ -46,6 +46,7 @@ async def search_repos(
             selectinload(Repo.ai_dev_skills),
             selectinload(Repo.pm_skills),
             selectinload(Repo.languages),
+            selectinload(Repo.taxonomy),
         )
         .order_by(Repo.activity_score.desc())
         .limit(MAX_RESULTS)
@@ -103,6 +104,7 @@ async def _hydrate_semantic_results(
             selectinload(Repo.ai_dev_skills),
             selectinload(Repo.pm_skills),
             selectinload(Repo.languages),
+            selectinload(Repo.taxonomy),
         )
     )
     result = await db.execute(stmt)
@@ -147,6 +149,7 @@ async def _full_text_fallback(
             selectinload(Repo.ai_dev_skills),
             selectinload(Repo.pm_skills),
             selectinload(Repo.languages),
+            selectinload(Repo.taxonomy),
         )
         .order_by(Repo.activity_score.desc())
         .limit(limit)

--- a/tests/test_repos.py
+++ b/tests/test_repos.py
@@ -76,3 +76,55 @@ async def test_health(client: AsyncClient):
     data = response.json()
     assert "status" in data
     assert "db" in data
+
+
+# KAN-53: /repos/{name} must include taxonomy dimensions
+@pytest.mark.asyncio
+async def test_repo_detail_includes_taxonomy(client: AsyncClient):
+    """Repo detail endpoint must return taxonomy list (KAN-53)."""
+    fixture_with_taxonomy = {
+        **TEST_REPO_FIXTURE,
+        "name": "taxonomy-test-repo",
+        "skill_areas": ["machine-learning"],
+        "industries": ["fintech"],
+        "use_cases": ["recommendation"],
+        "modalities": [],
+        "ai_trends": [],
+        "deployment_context": [],
+    }
+    await client.post("/ingest/repos", json=[fixture_with_taxonomy], headers=AUTH_HEADERS)
+
+    response = await client.get("/repos/taxonomy-test-repo")
+    assert response.status_code == 200
+    data = response.json()
+    assert "taxonomy" in data, "taxonomy key missing from repo detail response"
+    assert isinstance(data["taxonomy"], list)
+
+    dimensions = {entry["dimension"] for entry in data["taxonomy"]}
+    assert "skill_area" in dimensions, "skill_area dimension missing from taxonomy"
+    assert "industry" in dimensions, "industry dimension missing from taxonomy"
+    assert "use_case" in dimensions, "use_case dimension missing from taxonomy"
+
+    skill_values = [e["value"] for e in data["taxonomy"] if e["dimension"] == "skill_area"]
+    assert "machine-learning" in skill_values
+
+
+# Stargazers: built repos must have stargazers_count in response (schema test)
+@pytest.mark.asyncio
+async def test_repo_detail_includes_stargazers_count(client: AsyncClient):
+    """stargazers_count must be present in the repo detail response."""
+    built_repo = {
+        **TEST_REPO_FIXTURE,
+        "name": "built-repo-stars",
+        "is_fork": False,
+        "forked_from": None,
+        "stargazers_count": 42,
+        "parent_stars": None,
+    }
+    await client.post("/ingest/repos", json=[built_repo], headers=AUTH_HEADERS)
+
+    response = await client.get("/repos/built-repo-stars")
+    assert response.status_code == 200
+    data = response.json()
+    assert "stargazers_count" in data
+    assert data["stargazers_count"] == 42


### PR DESCRIPTION
## Summary

- **KAN-53 (taxonomy omitted):** `_repo_to_summary` never mapped `repo.taxonomy` to the `taxonomy` field in `RepoSummary`. The ORM model had the relationship and the schema had the field, but the builder function simply didn't populate it. Fixed by adding the taxonomy mapping to `_repo_to_summary` in `library.py`. Both `GET /repos/{name}` and `GET /repos/{owner}/{repo}` now also eager-load `Repo.taxonomy` via `selectinload` to avoid N+1 queries.
- **Stargazers bug:** `_to_api_payload` in `reporium-ingestion/ingestion/main.py` never included `stargazers_count` in the dict sent to the API. `GitHubRepo.stars` was fetched from GitHub correctly but silently dropped. Fixed by adding `'stargazers_count': repo.stars` to the payload. This fix is in a companion commit on `reporium-ingestion` branch of the same name.
- **Note on "0 stars" for built repos:** This was a real ingestion bug — the field was never sent, so the DB value remained `NULL` (displayed as 0). It is NOT simply that the repos have 0 GitHub stars.

## Test plan

- [x] `test_repo_detail_includes_taxonomy` — seeds a repo with `skill_areas`, `industries`, `use_cases` via ingest, then asserts `GET /repos/{name}` returns a `taxonomy` list with the correct dimensions and values
- [x] `test_repo_detail_includes_stargazers_count` — seeds a built repo with `stargazers_count: 42`, asserts the detail response includes it correctly
- [x] All 183 existing tests pass (`python -m pytest tests/ -x -q`)

## Related

- reporium-ingestion companion fix: `perditioinc/reporium-ingestion` branch `claude/feature/fix-repo-detail-taxonomy-stargazers`

🤖 Generated with [Claude Code](https://claude.com/claude-code)