### PR TITLE
fix(deploy): use correct secret name INGESTION_API_KEY in post-deploy step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -72,7 +72,7 @@ jobs:
         continue-on-error: true
         env:
           API_URL: https://reporium-api-573778300586.us-central1.run.app
-          INGEST_API_KEY: ${{ secrets.INGEST_API_KEY }}
+          INGEST_API_KEY: ${{ secrets.INGESTION_API_KEY }}
           ADMIN_API_KEY: ${{ secrets.ADMIN_API_KEY }}
         run: |
           # Wait for Cloud Run to be healthy


### PR DESCRIPTION
## Bug

The post-deploy taxonomy rebuild and category backfill have been silently skipping since PR #122 added the step. The step mapped:

```yaml
INGEST_API_KEY: ${{ secrets.INGEST_API_KEY }}
```

But the actual GitHub secret is named `INGESTION_API_KEY` (with "TION"). Since the secret name was wrong, `${INGEST_API_KEY}` was empty, every curl returned 401, and the `|| echo "skipped"` branch fired. Neither taxonomy rebuild nor category backfill ever ran post-deploy.

## Fix

Single character change: `secrets.INGEST_API_KEY` → `secrets.INGESTION_API_KEY`

The shell variable stays as `INGEST_API_KEY` (no curl changes needed).

## Effect after merge

Every deploy will now:
1. ✅ Actually call `POST /admin/taxonomy/rebuild` (populates taxonomy_values)
2. ✅ Actually call `POST /admin/backfill/categories` (populates repo_categories)

This fixes the empty category filter on reporium.com for every future deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)