### PR TITLE
fix: reliable Cloud Run builds, full tag cloud, populate repo_categories

### DIFF
--- a/app/routers/library.py
+++ b/app/routers/library.py
@@ -112,17 +112,28 @@ async def get_library(
     total_result = await db.execute(total_stmt)
     total = total_result.scalar_one()
 
-    # Build stats
+    # Build per-page stats (language distribution uses the current page only)
     lang_counts: dict[str, int] = {}
-    tag_commit_map: dict[str, dict] = {}
+    page_tag_commit_map: dict[str, dict] = {}
     for repo in repos:
         if repo.primary_language:
             lang_counts[repo.primary_language] = lang_counts.get(repo.primary_language, 0) + 1
         for t in repo.tags:
-            if t.tag not in tag_commit_map:
-                tag_commit_map[t.tag] = {"count": 0, "commits": 0}
-            tag_commit_map[t.tag]["count"] += 1
-            tag_commit_map[t.tag]["commits"] += repo.commits_last_7_days
+            if t.tag not in page_tag_commit_map:
+                page_tag_commit_map[t.tag] = {"count": 0, "commits": 0}
+            page_tag_commit_map[t.tag]["count"] += 1
+            page_tag_commit_map[t.tag]["commits"] += repo.commits_last_7_days
+
+    # Top tags — query across ALL repo_tags so the tag cloud reflects the
+    # full corpus, not just the current page's 100 repos.
+    global_tags_stmt = (
+        select(RepoTag.tag, func.count(RepoTag.repo_id).label("cnt"))
+        .group_by(RepoTag.tag)
+        .order_by(func.count(RepoTag.repo_id).desc())
+        .limit(50)
+    )
+    global_tags_result = await db.execute(global_tags_stmt)
+    global_top_tags = [row.tag for row in global_tags_result.all()]
 
     # Categories
     cat_stmt = (
@@ -142,7 +153,7 @@ async def get_library(
             count=data["count"],
             commit_velocity=data["commits"] / max(data["count"], 1),
         )
-        for tag, data in sorted(tag_commit_map.items(), key=lambda x: x[1]["count"], reverse=True)
+        for tag, data in sorted(page_tag_commit_map.items(), key=lambda x: x[1]["count"], reverse=True)
     ]
 
     stats = LibraryStats(
@@ -150,7 +161,7 @@ async def get_library(
         total_forks=sum(1 for r in repos if r.is_fork),
         total_non_forks=sum(1 for r in repos if not r.is_fork),
         languages=lang_counts,
-        top_tags=[t.tag for t in sorted(tag_metrics, key=lambda x: x.count, reverse=True)][:20],
+        top_tags=global_top_tags,
     )
 
     response = LibraryResponse(

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,9 +2,27 @@ steps:
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'build'
+      - '--cache-from'
+      - 'gcr.io/$PROJECT_ID/reporium-api:deps-cache'
+      - '--build-arg'
+      - 'BUILDKIT_INLINE_CACHE=1'
       - '-t'
-      - 'gcr.io/$PROJECT_ID/reporium-api'
+      - 'gcr.io/$PROJECT_ID/reporium-api:deps-cache'
+      - '-t'
+      - 'gcr.io/$PROJECT_ID/reporium-api:$COMMIT_SHA'
+      - '-t'
+      - 'gcr.io/$PROJECT_ID/reporium-api:latest'
       - '.'
+    env:
+      - 'DOCKER_BUILDKIT=1'
 
 images:
-  - 'gcr.io/$PROJECT_ID/reporium-api'
+  - 'gcr.io/$PROJECT_ID/reporium-api:$COMMIT_SHA'
+  - 'gcr.io/$PROJECT_ID/reporium-api:latest'
+  - 'gcr.io/$PROJECT_ID/reporium-api:deps-cache'
+
+# sentence-transformers pulls in PyTorch (~2 GB); cold pip installs take
+# 15-20+ minutes and exceed the default 10-minute Cloud Build timeout.
+# 30 minutes is sufficient even on a cold build, and cached builds finish
+# in under 2 minutes.
+timeout: 1800s

--- a/migrations/versions/019_backfill_repo_categories.py
+++ b/migrations/versions/019_backfill_repo_categories.py
@@ -1,0 +1,192 @@
+"""Backfill repo_categories from repo_tags.
+
+Migration 018 restored repo_tags from repo_taxonomy.  This migration
+derives repo_categories from those tags using the same 21-category
+keyword-matching rules as the ingestion pipeline
+(ingestion/enrichment/taxonomy.py).
+
+Idempotent: INSERT … ON CONFLICT DO UPDATE so safe to re-run.
+
+Revision ID: 019
+Revises: 018
+"""
+
+from alembic import op
+from sqlalchemy import text
+
+revision = "019"
+down_revision = "018"
+branch_labels = None
+depends_on = None
+
+# ── 21 categories (mirrors ingestion/enrichment/taxonomy.py) ─────────────────
+# Each entry: (category_id, category_name, [keywords]).
+# A repo wins a category when ANY keyword is a case-insensitive substring of
+# ANY of its tags.  The category with the most keyword hits becomes primary.
+_CATEGORIES = [
+    ("foundation-models", "Foundation Models", [
+        "large language model", "transformer", "openai", "anthropic", "claude",
+        "google ai", "huggingface", "long context", "multimodal", "quantization",
+        "llama", "gguf", "gpt", "llm", "foundational model",
+    ]),
+    ("ai-agents", "AI Agents", [
+        "ai agent", "multi-agent", "autonomous", "agent memory", "planning",
+        "chain-of-thought", "tool use", "langchain", "langgraph", "crewai",
+        "autogen", "mcp", "prompt engineering", "context engineering",
+        "structured output", "function calling", "agentic",
+    ]),
+    ("rag-retrieval", "RAG & Retrieval", [
+        "rag", "vector database", "embedding", "knowledge graph",
+        "semantic search", "hybrid search", "reranking", "llamaindex",
+        "document processing", "chunking", "retrieval",
+    ]),
+    ("model-training", "Model Training", [
+        "fine-tuning", "reinforcement learning", "lora", "peft", "rlhf",
+        "synthetic data", "dataset", "training", "unsloth", "axolotl",
+        "trl", "deepspeed", "fsdp", "pytorch", "tensorflow", "keras", "jax",
+    ]),
+    ("evals-benchmarking", "Evals & Benchmarking", [
+        "eval", "benchmark", "model evaluation", "llm testing", "red teaming",
+        "safety evaluation", "mmlu", "humaneval", "code evaluation", "alignment",
+    ]),
+    ("observability", "Observability & Monitoring", [
+        "observability", "tracing", "monitoring", "llm monitoring", "logging",
+        "debugging", "langsmith", "phoenix", "mlflow", "weights & biases",
+        "experiment tracking",
+    ]),
+    ("inference-serving", "Inference & Serving", [
+        "inference", "llm serving", "model optimization", "vllm", "tensorrt",
+        "triton", "ollama", "tgi", "batching", "gpu", "cuda",
+        "real-time", "streaming", "deployment",
+    ]),
+    ("generative-media", "Generative Media", [
+        "image generation", "video generation", "text to speech", "speech to text",
+        "music generation", "audio ai", "comfyui", "diffusion", "controlnet",
+        "stable diffusion", "generative",
+    ]),
+    ("computer-vision", "Computer Vision", [
+        "computer vision", "point cloud", "3d vision", "object detection",
+        "segmentation", "depth estimation", "slam", "optical flow",
+        "3d reconstruction", "pose estimation", "vision",
+    ]),
+    ("robotics", "Robotics", [
+        "robotics", "robot", "humanoid", "simulation", "ros", "motion planning",
+        "grasping", "manipulation", "navigation", "control systems",
+    ]),
+    ("nlp-text", "NLP & Text", [
+        "nlp", "natural language", "text classification", "named entity",
+        "sentiment", "summarization", "translation", "question answering",
+        "information extraction", "parsing", "tokenization",
+    ]),
+    ("mlops-infrastructure", "MLOps & Infrastructure", [
+        "mlops", "docker", "kubernetes", "ci/cd", "pipeline",
+        "feature store", "model registry", "data versioning",
+        "dvc", "zenml", "prefect", "airflow", "ray",
+        "distributed computing", "devops",
+    ]),
+    ("dev-tools", "Dev Tools & Automation", [
+        "cli tool", "automation", "sdk", "developer tools",
+        "code generation", "coding assistant", "systems", "security",
+        "database", "backend", "frontend", "full stack",
+    ]),
+    ("cloud-platforms", "Cloud & Platforms", [
+        "google cloud", "aws", "azure", "vertex ai", "sagemaker", "bedrock",
+    ]),
+    ("learning-resources", "Learning Resources", [
+        "tutorial", "course", "roadmap", "cheat sheet", "curated list",
+        "interview prep", "research", "open source", "workshop",
+    ]),
+    ("industry-healthcare", "Industry: Healthcare", [
+        "healthcare ai", "medical imaging", "drug discovery",
+        "clinical nlp", "bioinformatics", "genomics",
+    ]),
+    ("industry-fintech", "Industry: FinTech", [
+        "fintech", "trading ai", "risk modeling", "fraud detection",
+        "financial nlp",
+    ]),
+    ("spatial-xr", "Spatial & XR", [
+        "xr", "virtual reality", "augmented reality", "spatial ai",
+        "arkit", "arcore", "meta quest", "apple vision",
+    ]),
+    ("data-science", "Data Science & Analytics", [
+        "data science", "analytics", "visualization", "pandas", "numpy",
+        "scikit-learn", "sklearn", "statistical", "jupyter",
+    ]),
+    ("safety-alignment", "Safety & Alignment", [
+        "safety", "alignment", "fairness", "bias", "interpretability",
+        "explainability", "robustness", "adversarial", "guardrail",
+    ]),
+    ("other", "Other AI / ML", [
+        "machine learning", "deep learning", "neural network", "artificial intelligence",
+    ]),
+]
+
+
+def _assign(tags_lower: list[str]) -> list[tuple[str, str, bool]]:
+    """Return (cat_id, cat_name, is_primary) tuples for matching categories."""
+    scores: dict[str, int] = {}
+    for cat_id, _cat_name, keywords in _CATEGORIES:
+        for kw in keywords:
+            kw_l = kw.lower()
+            if any(kw_l in tl for tl in tags_lower):
+                scores[cat_id] = scores.get(cat_id, 0) + 1
+
+    if not scores:
+        return []
+
+    max_score = max(scores.values())
+    primary_assigned = False
+    result = []
+    for cat_id, cat_name, _ in _CATEGORIES:
+        if cat_id not in scores:
+            continue
+        is_primary = scores[cat_id] == max_score and not primary_assigned
+        if is_primary:
+            primary_assigned = True
+        result.append((cat_id, cat_name, is_primary))
+    return result
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # Fetch all repo_id → [tag, ...] mappings in one query
+    rows = conn.execute(text(
+        "SELECT repo_id::text, tag FROM repo_tags ORDER BY repo_id"
+    )).fetchall()
+
+    tags_by_repo: dict[str, list[str]] = {}
+    for repo_id, tag in rows:
+        tags_by_repo.setdefault(repo_id, []).append(tag)
+
+    # Assign categories and bulk-insert
+    batch: list[dict] = []
+    for repo_id, tags in tags_by_repo.items():
+        tags_lower = [t.lower() for t in tags]
+        for cat_id, cat_name, is_primary in _assign(tags_lower):
+            batch.append({
+                "repo_id": repo_id,
+                "cat_id": cat_id,
+                "cat_name": cat_name,
+                "is_primary": is_primary,
+            })
+
+    if not batch:
+        return
+
+    # Insert in chunks of 500 to stay within parameter limits
+    CHUNK = 500
+    for i in range(0, len(batch), CHUNK):
+        chunk = batch[i: i + CHUNK]
+        conn.execute(text("""
+            INSERT INTO repo_categories (repo_id, category_id, category_name, is_primary)
+            VALUES (:repo_id, :cat_id, :cat_name, :is_primary)
+            ON CONFLICT (repo_id, category_id) DO UPDATE
+                SET category_name = EXCLUDED.category_name,
+                    is_primary     = EXCLUDED.is_primary
+        """), chunk)
+
+
+def downgrade() -> None:
+    # Cannot distinguish migrated rows from pre-existing ones — no-op.
+    pass


### PR DESCRIPTION
## Three fixes

### 1. `cloudbuild.yaml` — Stop recurring deploy failures

**Problem**: `sentence-transformers` pulls in PyTorch (~2 GB). Cold pip installs take 15-20+ minutes, exceeding Cloud Build's default 10-minute timeout. This caused 3 consecutive deploy failures today.

**Fix**:
- Set `timeout: 1800s` (30 minutes) — enough for a cold build
- Add `--cache-from deps-cache` so warm builds finish in <2 minutes
- Tag the deps layer as `deps-cache` so it's reused across builds

### 2. `library.py` — Tag cloud shows 50 tags across all 1,460 repos

**Problem**: `top_tags` was computed from the 100 repos on the current page only → max 20 unique tags shown. With 34,489 rows in `repo_tags`, the tag cloud should be rich.

**Fix**: Added a separate `SELECT tag, COUNT(*) FROM repo_tags GROUP BY tag ORDER BY COUNT(*) DESC LIMIT 50` query that runs across the full corpus. The tag cloud now reflects all repos.

### 3. `migrations/019` — Populate `repo_categories` without re-ingestion

**Problem**: `repo_categories` has only 2 rows (wiped pre-PR #126). The post-deploy category backfill has been silently failing due to wrong secret name (fixed in PR #139). Even with the fix, categories won't be populated until the next deploy runs successfully.

**Fix**: Python Alembic migration that applies the 21-category keyword rules inline (mirrors `ingestion/enrichment/taxonomy.py`). Runs automatically during `alembic upgrade head` on deploy. Idempotent.

## Test plan
- [x] 187 tests pass
- [x] `_assign(['machine learning', 'computer vision', 'pytorch', 'rag', 'llm'])` → computer-vision primary ✓
- [x] `_assign(['robotics', 'motion planning', 'ros', 'simulation'])` → robotics primary ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)