### PR TITLE
fix(docker): CPU-only PyTorch eliminates 20+ min build timeouts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,15 @@ FROM python:3.12-slim
 
 WORKDIR /app
 
+# Install CPU-only PyTorch before the rest of requirements.
+# sentence-transformers brings in full CUDA PyTorch (~2 GB) by default;
+# Cloud Run has no GPU so we only need the CPU wheel (~200 MB).
+# Separating this into its own layer also lets Docker re-use the cached
+# layer across builds where only app code or other deps change.
+RUN pip install --no-cache-dir \
+      torch \
+      --index-url https://download.pytorch.org/whl/cpu
+
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
## Problem

Every Cloud Run deploy has been failing (3+ times today) because:

1. `sentence-transformers` depends on `torch`
2. `pip` resolves `torch` to the full **CUDA wheel** (~2 GB) — even though Cloud Run has no GPU
3. Downloading and installing 2 GB takes 20+ minutes in Cloud Build
4. Cloud Build times out (default 10-min limit, recently extended to 30-min in cloudbuild.yaml — but the issue is the download itself, not just the timeout)

## Fix

Install `torch` from the CPU-only wheel index before the main requirements:

```dockerfile
RUN pip install --no-cache-dir       torch       --index-url https://download.pytorch.org/whl/cpu
```

**CPU wheel**: ~200 MB vs ~2 GB for CUDA — **10× smaller**

This also creates a separate Docker layer for the heavy PyTorch install, so:
- When only app code changes → layer cache hit, build in <1 min
- When only other deps change → PyTorch layer cached, build in ~1-2 min  
- Cold build (no cache at all) → ~3-5 min total

## Expected result

Deploys complete in ~5 min cold / <1 min warm. No more timeouts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)