### PR TITLE
fix(library): increase tag cloud from 50 to 200 tags

### DIFF
--- a/app/routers/library.py
+++ b/app/routers/library.py
@@ -126,11 +126,12 @@ async def get_library(
 
     # Top tags — query across ALL repo_tags so the tag cloud reflects the
     # full corpus, not just the current page's 100 repos.
+    # 200 tags gives a rich cloud; the frontend can truncate if desired.
     global_tags_stmt = (
         select(RepoTag.tag, func.count(RepoTag.repo_id).label("cnt"))
         .group_by(RepoTag.tag)
         .order_by(func.count(RepoTag.repo_id).desc())
-        .limit(50)
+        .limit(200)
     )
     global_tags_result = await db.execute(global_tags_stmt)
     global_top_tags = [row.tag for row in global_tags_result.all()]
@@ -168,7 +169,7 @@ async def get_library(
         repos=[_repo_to_summary(r) for r in repos],
         stats=stats,
         categories=categories,
-        tag_metrics=tag_metrics[:50],
+        tag_metrics=tag_metrics[:200],
         total=total,
         page=page,
         limit=limit,


### PR DESCRIPTION
## Problem

The tag cloud was capped at 50 entries. With taxonomy-derived tags (broad semantic labels like "Self-hosted", "Machine Learning"), the top 50 by frequency were all generic — masking the hundreds of more specific tags that exist in the corpus.

## Fix

Raise `LIMIT 50` → `LIMIT 200` in the global `repo_tags` query. Also raise `tag_metrics[:50]` → `[:200]`.

The frontend can further truncate/paginate if needed, but 200 gives a much richer view of what's in the library.

## Note

This is a temporary improvement while the full ingestion run (#30 in reporium-ingestion) restores real GitHub topic tags (specific tech names like "langchain", "huggingface", "wsl", etc.). After that run, the tag cloud will automatically show the granular pre-regression tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)