### PR TITLE
feat(library): remove tag cloud cap — return all unique tags

### DIFF
--- a/app/routers/library.py
+++ b/app/routers/library.py
@@ -126,12 +126,11 @@ async def get_library(
 
     # Top tags — query across ALL repo_tags so the tag cloud reflects the
     # full corpus, not just the current page's 100 repos.
-    # 200 tags gives a rich cloud; the frontend can truncate if desired.
+    # No LIMIT: return every unique tag; the frontend can truncate as desired.
     global_tags_stmt = (
         select(RepoTag.tag, func.count(RepoTag.repo_id).label("cnt"))
         .group_by(RepoTag.tag)
         .order_by(func.count(RepoTag.repo_id).desc())
-        .limit(200)
     )
     global_tags_result = await db.execute(global_tags_stmt)
     global_top_tags = [row.tag for row in global_tags_result.all()]
@@ -169,7 +168,7 @@ async def get_library(
         repos=[_repo_to_summary(r) for r in repos],
         stats=stats,
         categories=categories,
-        tag_metrics=tag_metrics[:200],
+        tag_metrics=tag_metrics,
         total=total,
         page=page,
         limit=limit,


### PR DESCRIPTION
## Summary

- Removes the `.limit(200)` from the global `repo_tags` SQL query in `/library`
- Removes the `[:200]` slice on `tag_metrics`
- Every unique tag in `repo_tags` is now returned (~12 k+ distinct tags after the migration-018 backfill), giving the frontend a fully rich tag cloud

## Why

The tag cloud was capped at 200 entries which still felt too sparse. The corpus has ~12 k+ unique taxonomy values — there's no reason to truncate server-side; the frontend can filter/paginate as needed.

## Test plan

- [ ] Hit `GET /library` and confirm `stats.top_tags` length equals the total distinct tag count in `repo_tags` (no 200-row ceiling)
- [ ] Confirm tag cloud on reporium.com shows the full breadth of tags (langchain, huggingface, wsl, etc. all visible)
- [ ] Response time stays acceptable (query is a simple GROUP BY + ORDER BY on an indexed column)

🤖 Generated with [Claude Code](https://claude.com/claude-code)