### PR TITLE
feat: security risk signals + MCP/Claude Plugin identification (backend)

### DIFF
--- a/app/models/repo.py
+++ b/app/models/repo.py
@@ -70,6 +70,10 @@ class Repo(Base):
     has_tests: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     has_ci: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
 
+    # Security risk — curated manually or via admin API
+    # Structure: {risk_level, incident_reported, incident_date, incident_url, incident_summary}
+    security_signals: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
     # Relationships
     tags: Mapped[list["RepoTag"]] = relationship(
         back_populates="repo", cascade="all, delete-orphan"

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -1,7 +1,8 @@
 import json
 import logging
 
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
 from sqlalchemy import delete, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -767,3 +768,86 @@ async def backfill_categories(
     invalidate_library_cache()
 
     return {"processed": processed, "assigned": assigned, "skipped": skipped}
+
+
+# ── Security signal models ──────────────────────────────────────────────────
+
+class SecuritySignalsPatch(BaseModel):
+    """Payload for manually setting a repo's security risk signals."""
+    risk_level: str | None = None        # 'critical' | 'high' | 'medium' | 'low'
+    incident_reported: bool = False
+    incident_date: str | None = None     # ISO date, e.g. "2024-05-20"
+    incident_url: str | None = None      # link to advisory / blog post / CVE
+    incident_summary: str | None = None  # one-sentence human-readable summary
+
+
+@router.patch(
+    "/admin/repos/{repo_name}/security",
+    dependencies=[Depends(require_admin_key)],
+    summary="Set security risk signals for a repo",
+)
+async def set_repo_security_signals(
+    repo_name: str,
+    payload: SecuritySignalsPatch,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Manually mark a repo with security risk metadata.
+    Creates or replaces the security_signals JSONB on the matching repo row.
+
+    Example body for LiteLLM-style supply-chain incident:
+        {
+          "risk_level": "critical",
+          "incident_reported": true,
+          "incident_date": "2024-05-20",
+          "incident_url": "https://github.com/BerriAI/litellm/issues/3668",
+          "incident_summary": "Malicious PyPI package published; credentials at risk"
+        }
+    """
+    result = await db.execute(
+        select(Repo).where(Repo.name == repo_name)
+    )
+    repo = result.scalar_one_or_none()
+    if repo is None:
+        raise HTTPException(status_code=404, detail=f"Repo '{repo_name}' not found")
+
+    repo.security_signals = {
+        "risk_level": payload.risk_level,
+        "incident_reported": payload.incident_reported,
+        "incident_date": payload.incident_date,
+        "incident_url": payload.incident_url,
+        "incident_summary": payload.incident_summary,
+    }
+    await db.commit()
+
+    # Bust all library caches so the next page load reflects the update
+    await cache.invalidate("library:full*")
+    await cache.invalidate("repos:list:*")
+    invalidate_library_cache()
+
+    return {
+        "repo": repo_name,
+        "security_signals": repo.security_signals,
+    }
+
+
+@router.delete(
+    "/admin/repos/{repo_name}/security",
+    dependencies=[Depends(require_admin_key)],
+    summary="Clear security risk signals for a repo",
+)
+async def clear_repo_security_signals(
+    repo_name: str,
+    db: AsyncSession = Depends(get_db),
+):
+    """Remove all security signals from a repo (set to NULL)."""
+    result = await db.execute(select(Repo).where(Repo.name == repo_name))
+    repo = result.scalar_one_or_none()
+    if repo is None:
+        raise HTTPException(status_code=404, detail=f"Repo '{repo_name}' not found")
+
+    repo.security_signals = None
+    await db.commit()
+    invalidate_library_cache()
+
+    return {"repo": repo_name, "security_signals": None}

--- a/app/routers/library.py
+++ b/app/routers/library.py
@@ -73,6 +73,7 @@ def _repo_to_summary(repo: Repo) -> RepoSummary:
             {"dimension": t.dimension, "value": t.raw_value, "similarityScore": t.similarity_score, "assignedBy": t.assigned_by}
             for t in getattr(repo, "taxonomy", [])
         ],
+        security_signals=repo.security_signals,
     )
 
 

--- a/app/routers/library_full.py
+++ b/app/routers/library_full.py
@@ -796,6 +796,8 @@ def _build_enriched_repo(repo: dict, languages: list, categories: list,
         ],
         "problemSolved": repo.get("problem_solved"),
         "licenseSpdx": repo.get("license_spdx"),
+        "qualitySignals": repo.get("quality_signals"),
+        "securitySignals": repo.get("security_signals"),
         "builders": [
             {
                 "login": b["login"],
@@ -1102,7 +1104,7 @@ async def _fetch_page_repos(
                parent_stars, parent_forks, parent_is_archived, stargazers_count, open_issues_count,
                commits_last_7_days, commits_last_30_days, commits_last_90_days,
                readme_summary, activity_score, ingested_at, updated_at, github_updated_at,
-               problem_solved, license_spdx, quality_signals, has_tests, has_ci
+               problem_solved, license_spdx, quality_signals, has_tests, has_ci, security_signals
         FROM repos
         WHERE is_private = false
         ORDER BY COALESCE(parent_stars, stargazers_count, 0) DESC

--- a/app/schemas/repo.py
+++ b/app/schemas/repo.py
@@ -6,6 +6,15 @@ from pydantic import BaseModel, ConfigDict
 
 # --- Sub-schemas ---
 
+class SecuritySignals(BaseModel):
+    """Security risk metadata — manually curated or auto-detected."""
+    risk_level: str | None = None  # 'critical' | 'high' | 'medium' | 'low'
+    incident_reported: bool = False
+    incident_date: str | None = None   # ISO date string, e.g. "2024-05-20"
+    incident_url: str | None = None    # link to CVE / advisory / blog post
+    incident_summary: str | None = None
+
+
 class TaxonomyEntry(BaseModel):
     dimension: str
     value: str
@@ -79,6 +88,7 @@ class RepoSummary(BaseModel):
     quality_signals: dict | None = None
     problem_solved: str | None = None
     license_spdx: str | None = None
+    security_signals: dict | None = None
 
     ingested_at: datetime
     updated_at: datetime
@@ -178,6 +188,9 @@ class RepoIngestItem(BaseModel):
     license_spdx: str | None = None
     has_tests: bool | None = None
     has_ci: bool | None = None
+
+    # Security risk — can be set by ingestion or via admin API
+    security_signals: dict | None = None
 
     # Dynamic taxonomy dimensions
     skill_areas: list[str] = []

--- a/migrations/versions/020_add_security_signals.py
+++ b/migrations/versions/020_add_security_signals.py
@@ -1,0 +1,30 @@
+"""Add security_signals JSONB column to repos.
+
+Stores manually-curated and auto-detected security risk metadata per repo:
+  - risk_level: 'critical' | 'high' | 'medium' | 'low' | null
+  - incident_reported: bool (publicly disclosed security incident)
+  - incident_date: ISO date string
+  - incident_url: link to CVE / blog post / GitHub advisory
+  - incident_summary: one-sentence description
+
+Revision ID: 020
+Revises: 019
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+revision = "020"
+down_revision = "019"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("repos", sa.Column("security_signals", JSONB, nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("repos", "security_signals")


### PR DESCRIPTION
## Summary

- **Migration 020** — adds `security_signals` JSONB column to `repos`
- **Repo model** — `security_signals` field mapped via SQLAlchemy
- **Schemas** — `SecuritySignals` Pydantic model; `security_signals` in `RepoSummary` and `RepoIngestItem`
- **library.py** — `_repo_to_summary()` includes `security_signals`
- **library_full.py** — SQL SELECT + `_build_enriched_repo()` include `security_signals`; also adds missing `qualitySignals` to the full-library response
- **admin.py** — two new endpoints:
  - `PATCH /admin/repos/{name}/security` — set risk_level, incident_reported, incident_date, incident_url, incident_summary
  - `DELETE /admin/repos/{name}/security` — clear all signals

## Security signal shape
```json
{
  "risk_level": "critical",
  "incident_reported": true,
  "incident_date": "2024-05-20",
  "incident_url": "https://github.com/BerriAI/litellm/issues/3668",
  "incident_summary": "Malicious PyPI package published; credentials at risk"
}
```

## Test plan
- [ ] `alembic upgrade head` succeeds on staging DB
- [ ] `PATCH /admin/repos/litellm/security` returns 200 with signals
- [ ] `GET /library/full` response includes `securitySignals` on affected repo
- [ ] `DELETE /admin/repos/litellm/security` clears the field

🤖 Generated with [Claude Code](https://claude.com/claude-code)