### PR TITLE
KAN-57: expose repos.primary_category as dbCategory in /library/full

### DIFF
--- a/app/routers/library_full.py
+++ b/app/routers/library_full.py
@@ -863,6 +863,8 @@ def _build_enriched_repo(repo: dict, languages: list, categories: list,
         "licenseSpdx": repo.get("license_spdx"),
         "qualitySignals": repo.get("quality_signals"),
         "securitySignals": repo.get("security_signals"),
+        "dbCategory": repo.get("primary_category"),
+        "dbSecondaryCategories": repo.get("secondary_categories") or [],
         "builders": [
             {
                 "login": b["login"],
@@ -1169,7 +1171,8 @@ async def _fetch_page_repos(
                parent_stars, parent_forks, parent_is_archived, stargazers_count, open_issues_count,
                commits_last_7_days, commits_last_30_days, commits_last_90_days,
                readme_summary, activity_score, ingested_at, updated_at, github_updated_at,
-               problem_solved, license_spdx, quality_signals, has_tests, has_ci, security_signals
+               problem_solved, license_spdx, quality_signals, has_tests, has_ci, security_signals,
+               primary_category, secondary_categories
         FROM repos
         WHERE is_private = false
         ORDER BY COALESCE(parent_stars, stargazers_count, 0) DESC


### PR DESCRIPTION
## Summary
- Adds `primary_category` and `secondary_categories` to the main repos SELECT query
- Surfaces them as `dbCategory` and `dbSecondaryCategories` in the API response
- These are the 16 KAN-41 categories at 100% coverage across 1,544 repos

## Why a new field name
The existing `primaryCategory` field comes from the `repo_categories` junction table (old frontend taxonomy). Using `dbCategory` avoids collision and lets both systems coexist.

## Test plan
- [x] SQL compiles and query returns new fields
- [ ] `/library/full` response includes `dbCategory: "agents"` etc. for each repo
- [ ] Null-safe — repos without primary_category return `dbCategory: null`

🤖 Generated with [Claude Code](https://claude.com/claude-code)