### PR TITLE
KAN-152: fix 2 test failures blocking clean CI on main

### DIFF
--- a/app/models/repo.py
+++ b/app/models/repo.py
@@ -74,6 +74,10 @@ class Repo(Base):
     # Structure: {risk_level, incident_reported, incident_date, incident_url, incident_summary}
     security_signals: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
 
+    # KAN-41 16-category taxonomy (backfilled by backfill_primary_category.py)
+    primary_category: Mapped[str | None] = mapped_column(Text, nullable=True)
+    secondary_categories: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+
     # Relationships
     tags: Mapped[list["RepoTag"]] = relationship(
         back_populates="repo", cascade="all, delete-orphan"

--- a/app/routers/library_full.py
+++ b/app/routers/library_full.py
@@ -1148,7 +1148,7 @@ def _build_builder_stats(repos: list) -> list:
             "topRepos": bd["topRepos"][:5],
             "avatarUrl": bd["avatarUrl"],
         })
-    return stats[:200]  # Top 200 builders by repo count
+    return stats[:50]  # Top 50 builders by repo count
 
 
 async def _fetch_page_repos(


### PR DESCRIPTION
## Summary
- Add `primary_category` and `secondary_categories` to `Repo` ORM model — without these, `Base.metadata.create_all` omits the columns from the test DB, causing `UndefinedColumnError` when `/library/full` runs its raw SQL SELECT. Fixes `test_ingest_with_valid_key`.
- Fix `_build_builder_stats` limit from `[:200]` to `[:50]` — the function was documented as \"Top 50 builders\" but sliced at 200, breaking `TestBuildBuilderStats::test_returns_at_most_50`.

Closes #152.

## Test plan
- [ ] `pytest tests/test_ingest.py::test_ingest_with_valid_key` passes
- [ ] `pytest tests/test_library_full.py::TestBuildBuilderStats::test_returns_at_most_50` passes
- [ ] Full `pytest tests/ -v` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)