### PR TITLE
fix: add is_private = false guard to GET /search endpoint

### DIFF
--- a/app/routers/search.py
+++ b/app/routers/search.py
@@ -33,11 +33,12 @@ async def search_repos(
     stmt = (
         select(Repo)
         .where(
+            Repo.is_private == False,  # noqa: E712 — SQLAlchemy requires == not `is`
             or_(
                 Repo.name.ilike(search),
                 Repo.description.ilike(search),
                 Repo.readme_summary.ilike(search),
-            )
+            ),
         )
         .options(
             selectinload(Repo.tags),


### PR DESCRIPTION
## Security Fix

**Vulnerability:** `GET /search` (text search) was missing the `is_private = false` WHERE clause, potentially exposing private repo names, descriptions, and readme summaries in public search results.

**All other public endpoints had this guard:**
- `/repos` ✓
- `/repos/{name}` ✓  
- `/library` ✓
- `/library/full` ✓
- `/search/semantic` ✓
- `/graph/edges` ✓
- `/wiki/skills/{skill}` ✓
- `/wiki/categories/{category}` ✓

**Fix:** Added `Repo.is_private == False` as the first WHERE condition in the `/search` query.

## Test plan
- [ ] `GET /search?q=<term>` no longer returns repos with `is_private = true`
- [ ] Public repo search results unchanged
- [ ] Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)