### PR TITLE
KAN-154: add quality_gates.py to nightly CI

### DIFF
--- a/.github/workflows/data-quality.yml
+++ b/.github/workflows/data-quality.yml
@@ -14,13 +14,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-python@v5
         with:
           python-version: "3.11"
-      - run: pip install httpx
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
+      - name: Install dependencies
+        run: pip install httpx psycopg2-binary google-cloud-secret-manager
+
       - name: Run data quality check
         env:
           REPORIUM_API_URL: ${{ secrets.REPORIUM_API_URL }}
           INGESTION_API_KEY: ${{ secrets.INGESTION_API_KEY }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: python scripts/check_data_quality.py
+
+      - name: Run quality gates
+        env:
+          REPORIUM_API_URL: ${{ secrets.REPORIUM_API_URL }}
+          GCP_PROJECT: perditio-platform
+        run: python scripts/quality_gates.py


### PR DESCRIPTION
## Summary

- Adds `quality_gates.py` as a second step in the nightly `data-quality.yml` workflow
- Adds GCP auth so Secret Manager can resolve the DB URL (reuses existing `GCP_SA_KEY` secret, no new secrets required)
- Installs `psycopg2-binary` + `google-cloud-secret-manager` alongside `httpx`
- Gates exit with code 1 on failure → CI blocks regressions automatically

## Gates covered

| Gate | Threshold |
|------|-----------|
| `primary_category_coverage` | ≥ 95% |
| `embeddings_coverage` | ≥ 95% |
| `null_is_private` | = 0 |
| `readme_summary_coverage` | ≥ 80% |
| `no_private_repos_in_api` | = 0 |

## Context

All 5 gates are currently **green** (100% coverage across the board after the readme_summary backfill that closed issue #165). This workflow change ensures they stay green.

## Test plan

- [ ] Trigger workflow via `workflow_dispatch` and confirm both steps pass
- [ ] Verify GCP auth resolves DB URL via Secret Manager (no `DATABASE_URL` secret needed)
- [ ] Confirm workflow exits 0 when all gates pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)