### PR TITLE
KAN-155 + KAN-156: NL filter endpoint + pgvector recommendation engine

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -15,7 +15,7 @@ from slowapi.util import get_remote_address
 
 from app.cache import cache
 from app.database import async_session_factory, check_db_connection, engine
-from app.routers import admin, analytics, graph, ingest, intelligence, library, library_full, platform, repos, search, taxonomy, trends, webhooks, wiki
+from app.routers import admin, analytics, graph, ingest, intelligence, library, library_full, nl_filter, platform, recommendations, repos, search, taxonomy, trends, webhooks, wiki
 
 
 class _JsonFormatter(logging.Formatter):
@@ -235,6 +235,8 @@ app.include_router(platform.router)
 app.include_router(ingest.router)
 app.include_router(ingest.events_router)
 app.include_router(intelligence.router)
+app.include_router(nl_filter.router)
+app.include_router(recommendations.router)
 app.include_router(library_full.router)
 app.include_router(taxonomy.router, prefix="/taxonomy")
 app.include_router(admin.router)

--- a/app/routers/nl_filter.py
+++ b/app/routers/nl_filter.py
@@ -1,0 +1,193 @@
+"""
+KAN-155: POST /intelligence/nl-filter
+
+Translates a natural language query into structured filter params for the
+/repos and /library/full endpoints. Single Haiku call per request — ~$0.0005.
+
+Example input:  "actively maintained Python RAG repos with over 1000 stars"
+Example output: {
+    "language": "python",
+    "category": "rag-retrieval",
+    "min_stars": 1000,
+    "sort": "stars",
+    "tags": ["rag", "retrieval"],
+    "quality": "high",
+    "interpretation": "Python · RAG & Retrieval · 1,000+ stars · sorted by stars"
+}
+
+The structured output maps directly to existing query params on GET /repos.
+"""
+
+import json
+import logging
+import os
+
+import anthropic
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+from app.cache import cache
+from app.circuit_breaker import anthropic_breaker
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/intelligence", tags=["Intelligence"])
+_limiter = Limiter(key_func=get_remote_address)
+
+# Valid categories in the Reporium taxonomy
+_VALID_CATEGORIES = [
+    "agents", "rag-retrieval", "llm-serving", "fine-tuning", "evaluation",
+    "orchestration", "vector-databases", "observability", "security-safety",
+    "code-generation", "data-processing", "computer-vision", "nlp-text",
+    "speech-audio", "generative-media", "infrastructure",
+]
+
+_NL_FILTER_PROMPT = """You are a search query parser for Reporium — a curated library of AI/ML GitHub repositories.
+
+Convert the following natural language search into structured filter parameters.
+
+Natural language query: {query}
+
+Valid categories (pick the single best match, or null if not applicable):
+{categories}
+
+Return ONLY valid JSON matching this schema — no markdown, no explanation:
+{{
+  "language": "<lowercase language name or null>",
+  "category": "<one of the valid categories above, or null>",
+  "min_stars": <integer >= 0 or null>,
+  "max_stars": <integer or null>,
+  "sort": "<one of: stars | updated | name, or null>",
+  "tags": ["<relevant tag keywords — lowercase, specific>"],
+  "quality": "<high | medium | low | null — only set if explicitly mentioned>",
+  "maturity": "<production | beta | prototype | research | null — only if mentioned>",
+  "exclude_archived": <true if user wants active repos, false otherwise>,
+  "interpretation": "<short human-readable summary: what filters were applied, e.g. 'Python · RAG & Retrieval · 1,000+ stars'>"
+}}
+
+Rules:
+- Only set fields that are clearly implied by the query — don't guess
+- min_stars: "popular" → 500, "widely used" → 1000, "very popular" → 5000
+- sort: default to "stars" if popularity is mentioned, "updated" if recency is mentioned
+- tags: extract meaningful keywords (e.g. "rag", "langchain", "fine-tuning") — max 5
+- exclude_archived: true if query mentions "active", "maintained", "recent", "working"
+- interpretation: be concise, use · as separator"""
+
+
+def _get_anthropic_key() -> str:
+    key = os.getenv("ANTHROPIC_API_KEY", "").strip()
+    if key:
+        return key
+    try:
+        from google.cloud import secretmanager
+        client = secretmanager.SecretManagerServiceClient()
+        project = os.getenv("GCP_PROJECT", "perditio-platform")
+        name = f"projects/{project}/secrets/anthropic-api-key/versions/latest"
+        response = client.access_secret_version(request={"name": name})
+        return response.payload.data.decode("UTF-8").strip()
+    except Exception:
+        raise HTTPException(status_code=500, detail="ANTHROPIC_API_KEY not configured")
+
+
+class NLFilterRequest(BaseModel):
+    query: str = Field(..., min_length=3, max_length=300,
+                       description="Natural language filter query")
+
+
+class NLFilterResponse(BaseModel):
+    language: str | None = None
+    category: str | None = None
+    min_stars: int | None = None
+    max_stars: int | None = None
+    sort: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    quality: str | None = None
+    maturity: str | None = None
+    exclude_archived: bool = False
+    interpretation: str
+    # Convenience: ready-to-use query string for GET /repos
+    query_params: str = ""
+
+
+def _build_query_params(r: NLFilterResponse) -> str:
+    """Build a URL query string from the filter response."""
+    parts = []
+    if r.language:
+        parts.append(f"language={r.language}")
+    if r.category:
+        parts.append(f"category={r.category}")
+    if r.min_stars is not None:
+        parts.append(f"min_stars={r.min_stars}")
+    if r.sort:
+        parts.append(f"sort={r.sort}")
+    if r.exclude_archived:
+        parts.append("exclude_archived=true")
+    return "&".join(parts)
+
+
+@router.post("/nl-filter", response_model=NLFilterResponse)
+@_limiter.limit("30/minute")
+async def nl_filter(request: Request, body: NLFilterRequest) -> NLFilterResponse:
+    """
+    Translate a natural language query into structured filter params.
+    Single Haiku call — ~$0.0005 per request. Results cached 1 hour by query hash.
+    Public endpoint, rate-limited to 30 req/min per IP.
+    """
+    cache_key = f"nl_filter:{hash(body.query.lower().strip())}"
+    cached = await cache.get(cache_key)
+    if cached:
+        return NLFilterResponse(**cached)
+
+    prompt = _NL_FILTER_PROMPT.format(
+        query=body.query,
+        categories="\n".join(f"  - {c}" for c in _VALID_CATEGORIES),
+    )
+
+    try:
+        api_key = _get_anthropic_key()
+
+        def _call_haiku():
+            client = anthropic.Anthropic(api_key=api_key)
+            return client.messages.create(
+                model="claude-haiku-4-5",
+                max_tokens=256,
+                messages=[{"role": "user", "content": prompt}],
+            )
+
+        response = anthropic_breaker.call(_call_haiku)
+        raw = response.content[0].text.strip()
+
+        # Strip markdown fences if present
+        if raw.startswith("```"):
+            lines = raw.split("\n")
+            raw = "\n".join(lines[1:-1] if lines[-1].strip() == "```" else lines[1:])
+
+        data = json.loads(raw)
+
+        # Validate/normalise
+        if data.get("category") not in _VALID_CATEGORIES:
+            data["category"] = None
+        if data.get("sort") not in {"stars", "updated", "name", None}:
+            data["sort"] = None
+        if data.get("quality") not in {"high", "medium", "low", None}:
+            data["quality"] = None
+        if data.get("maturity") not in {"production", "beta", "prototype", "research", None}:
+            data["maturity"] = None
+        data.setdefault("tags", [])
+        data["tags"] = [str(t).lower().strip() for t in data["tags"][:5] if t]
+        data.setdefault("exclude_archived", False)
+        data.setdefault("interpretation", body.query)
+
+        result = NLFilterResponse(**data)
+        result.query_params = _build_query_params(result)
+
+        await cache.set(cache_key, result.model_dump(), ttl=3600)  # 1h cache
+        logger.info("nl_filter: '%s' → %s", body.query[:60], result.query_params)
+        return result
+
+    except json.JSONDecodeError as e:
+        logger.error("nl_filter: JSON parse failed for query '%s': %s", body.query, e)
+        raise HTTPException(status_code=502, detail="Filter parsing failed — try rephrasing")
+    except Exception as e:
+        logger.error("nl_filter: unexpected error: %s", e)
+        raise HTTPException(status_code=500, detail="Filter service unavailable")

--- a/app/routers/recommendations.py
+++ b/app/routers/recommendations.py
@@ -1,0 +1,197 @@
+"""
+KAN-156: GET /repos/{name}/similar  — pure pgvector cosine similarity, no LLM.
+         GET /intelligence/recommended — top-N similar repos across a list of seeds.
+
+Uses existing repo_embeddings (384-dim all-MiniLM-L6-v2 vectors).
+No Anthropic API calls — $0.00 per request.
+
+/similar       — find repos semantically close to a given repo
+/recommended   — given a comma-separated list of recently-viewed repo names,
+                 return a deduplicated ranked list of recommendations
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.cache import CACHE_TTL_STATS, cache
+from app.database import get_db
+
+logger = logging.getLogger(__name__)
+router = APIRouter(tags=["Repos"])
+
+_DEFAULT_SIMILAR_LIMIT = 8
+_DEFAULT_REC_LIMIT = 12
+_MIN_SIMILARITY = 0.55  # cosine similarity floor — below this, repos are unrelated
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+class SimilarRepo(BaseModel):
+    name: str
+    owner: str
+    description: str | None
+    primary_language: str | None
+    primary_category: str | None
+    stars: int | None
+    similarity: float
+    readme_summary: str | None
+
+
+class SimilarReposResponse(BaseModel):
+    source_repo: str
+    similar: list[SimilarRepo]
+    total: int
+
+
+class RecommendedReposResponse(BaseModel):
+    seeds: list[str]
+    recommended: list[SimilarRepo]
+    total: int
+
+
+# ---------------------------------------------------------------------------
+# Shared SQL — single HNSW index scan per seed repo
+# ---------------------------------------------------------------------------
+
+_SIMILAR_SQL = text("""
+    SELECT
+        r.name,
+        r.owner,
+        r.description,
+        r.primary_language,
+        r.primary_category,
+        r.parent_stars         AS stars,
+        r.readme_summary,
+        1 - (e2.embedding_vec <=> e1.embedding_vec) AS similarity
+    FROM repo_embeddings e1
+    JOIN repos seed_r ON seed_r.id = e1.repo_id
+    JOIN repo_embeddings e2 ON e2.repo_id != e1.repo_id
+    JOIN repos r ON r.id = e2.repo_id
+    WHERE seed_r.name = :name
+      AND r.is_private = false
+      AND r.parent_is_archived = false
+      AND e1.embedding_vec IS NOT NULL
+      AND e2.embedding_vec IS NOT NULL
+      AND 1 - (e2.embedding_vec <=> e1.embedding_vec) >= :min_similarity
+    ORDER BY e2.embedding_vec <=> e1.embedding_vec
+    LIMIT :limit
+""")
+
+
+def _row_to_similar(row) -> SimilarRepo:
+    return SimilarRepo(
+        name=row.name,
+        owner=row.owner,
+        description=row.description,
+        primary_language=row.primary_language,
+        primary_category=row.primary_category,
+        stars=row.stars,
+        similarity=round(float(row.similarity), 4),
+        readme_summary=row.readme_summary,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /repos/{name}/similar
+# ---------------------------------------------------------------------------
+
+@router.get("/intelligence/similar/{name}", response_model=SimilarReposResponse)
+async def similar_repos(
+    name: str,
+    limit: int = Query(default=_DEFAULT_SIMILAR_LIMIT, ge=1, le=24),
+    min_similarity: float = Query(default=_MIN_SIMILARITY, ge=0.0, le=1.0),
+    db: AsyncSession = Depends(get_db),
+) -> SimilarReposResponse:
+    """
+    Return repos semantically similar to {name} using pgvector cosine similarity.
+    Pure vector search — no LLM, no API credits consumed.
+
+    Results cached for 1 hour. Excludes archived repos and the source repo itself.
+    """
+    cache_key = f"similar:{name}:{limit}:{min_similarity}"
+    cached = await cache.get(cache_key)
+    if cached:
+        return SimilarReposResponse(**cached)
+
+    result = await db.execute(
+        _SIMILAR_SQL,
+        {"name": name, "limit": limit, "min_similarity": min_similarity},
+    )
+    rows = result.fetchall()
+
+    if not rows:
+        # Check whether the source repo exists at all
+        exists = await db.execute(
+            text("SELECT 1 FROM repos WHERE name = :name AND is_private = false LIMIT 1"),
+            {"name": name},
+        )
+        if not exists.fetchone():
+            raise HTTPException(status_code=404, detail=f"Repo '{name}' not found")
+
+        # Repo exists but has no embedding or no similar neighbours above threshold
+        response = SimilarReposResponse(source_repo=name, similar=[], total=0)
+        await cache.set(cache_key, response.model_dump(), ttl=CACHE_TTL_STATS)
+        return response
+
+    similar = [_row_to_similar(r) for r in rows]
+    response = SimilarReposResponse(source_repo=name, similar=similar, total=len(similar))
+    await cache.set(cache_key, response.model_dump(), ttl=CACHE_TTL_STATS)
+    return response
+
+
+# ---------------------------------------------------------------------------
+# GET /intelligence/recommended?seeds=repo1,repo2,...
+# ---------------------------------------------------------------------------
+
+@router.get("/intelligence/recommended", response_model=RecommendedReposResponse)
+async def recommended_repos(
+    seeds: str = Query(
+        ...,
+        description="Comma-separated list of recently-viewed repo names (max 5)",
+        min_length=1,
+    ),
+    limit: int = Query(default=_DEFAULT_REC_LIMIT, ge=1, le=24),
+    db: AsyncSession = Depends(get_db),
+) -> RecommendedReposResponse:
+    """
+    Given recently-viewed repos, return a deduplicated ranked recommendation list.
+    Each seed contributes similar repos; results are merged and re-ranked by similarity.
+    Pure pgvector — no LLM, no API credits.
+    """
+    seed_names = [s.strip() for s in seeds.split(",") if s.strip()][:5]
+    if not seed_names:
+        raise HTTPException(status_code=422, detail="At least one seed repo name is required")
+
+    cache_key = f"recommended:{','.join(sorted(seed_names))}:{limit}"
+    cached = await cache.get(cache_key)
+    if cached:
+        return RecommendedReposResponse(**cached)
+
+    # Collect similar repos for all seeds; merge by best similarity score
+    merged: dict[str, SimilarRepo] = {}
+    for seed in seed_names:
+        result = await db.execute(
+            _SIMILAR_SQL,
+            {"name": seed, "limit": limit * 2, "min_similarity": _MIN_SIMILARITY},
+        )
+        for row in result.fetchall():
+            if row.name in seed_names:
+                continue  # don't recommend a repo the user already viewed
+            repo = _row_to_similar(row)
+            if row.name not in merged or repo.similarity > merged[row.name].similarity:
+                merged[row.name] = repo
+
+    ranked = sorted(merged.values(), key=lambda r: r.similarity, reverse=True)[:limit]
+    response = RecommendedReposResponse(
+        seeds=seed_names,
+        recommended=ranked,
+        total=len(ranked),
+    )
+    await cache.set(cache_key, response.model_dump(), ttl=CACHE_TTL_STATS)
+    return response

--- a/tests/test_nl_filter.py
+++ b/tests/test_nl_filter.py
@@ -1,0 +1,165 @@
+"""
+KAN-155: Tests for POST /intelligence/nl-filter.
+
+Validates request contract, caching behaviour, Haiku response parsing,
+field validation/normalisation, and query_params construction — without
+requiring a real Anthropic API key or DB connection.
+"""
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mock_haiku_response(data: dict) -> MagicMock:
+    """Build a fake anthropic.messages.create response containing JSON."""
+    msg = MagicMock()
+    msg.content = [MagicMock(text=json.dumps(data))]
+    return msg
+
+
+_GOOD_PARSE = {
+    "language": "python",
+    "category": "rag-retrieval",
+    "min_stars": 1000,
+    "max_stars": None,
+    "sort": "stars",
+    "tags": ["rag", "langchain"],
+    "quality": "high",
+    "maturity": "production",
+    "exclude_archived": True,
+    "interpretation": "Python · RAG & Retrieval · 1,000+ stars",
+}
+
+
+# ---------------------------------------------------------------------------
+# Contract: request validation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_nl_filter_requires_query(client: AsyncClient):
+    resp = await client.post("/intelligence/nl-filter", json={})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_nl_filter_query_too_short(client: AsyncClient):
+    resp = await client.post("/intelligence/nl-filter", json={"query": "ab"})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_nl_filter_query_too_long(client: AsyncClient):
+    resp = await client.post("/intelligence/nl-filter", json={"query": "x" * 301})
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Happy path: Haiku returns valid JSON
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_nl_filter_happy_path(client: AsyncClient):
+    mock_resp = _mock_haiku_response(_GOOD_PARSE)
+    breaker_mock = MagicMock(call=lambda fn: fn())
+
+    with patch("app.routers.nl_filter._get_anthropic_key", return_value="sk-test"), \
+         patch("app.routers.nl_filter.anthropic_breaker", breaker_mock), \
+         patch("anthropic.Anthropic") as MockAnthropic, \
+         patch("app.routers.nl_filter.cache.get", return_value=None), \
+         patch("app.routers.nl_filter.cache.set"):
+        MockAnthropic.return_value.messages.create.return_value = mock_resp
+        resp = await client.post("/intelligence/nl-filter", json={"query": "Python RAG repos with 1000 stars"})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["language"] == "python"
+    assert data["category"] == "rag-retrieval"
+    assert data["min_stars"] == 1000
+    assert data["sort"] == "stars"
+    assert data["exclude_archived"] is True
+    assert "Python" in data["interpretation"]
+    # query_params should be a usable URL fragment
+    assert "language=python" in data["query_params"]
+    assert "min_stars=1000" in data["query_params"]
+
+
+# ---------------------------------------------------------------------------
+# Normalisation: invalid category / sort / quality are nulled out
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_nl_filter_invalid_category_nulled(client: AsyncClient):
+    bad = {**_GOOD_PARSE, "category": "not-a-real-category"}
+    mock_resp = _mock_haiku_response(bad)
+    breaker_mock = MagicMock(call=lambda fn: fn())
+
+    with patch("app.routers.nl_filter._get_anthropic_key", return_value="sk-test"), \
+         patch("app.routers.nl_filter.anthropic_breaker", breaker_mock), \
+         patch("anthropic.Anthropic") as MockAnthropic, \
+         patch("app.routers.nl_filter.cache.get", return_value=None), \
+         patch("app.routers.nl_filter.cache.set"):
+        MockAnthropic.return_value.messages.create.return_value = mock_resp
+        resp = await client.post("/intelligence/nl-filter", json={"query": "Python RAG repos"})
+
+    assert resp.status_code == 200
+    assert resp.json()["category"] is None
+
+
+@pytest.mark.asyncio
+async def test_nl_filter_tags_truncated_to_five(client: AsyncClient):
+    many_tags = {**_GOOD_PARSE, "tags": ["a", "b", "c", "d", "e", "f", "g"]}
+    mock_resp = _mock_haiku_response(many_tags)
+    breaker_mock = MagicMock(call=lambda fn: fn())
+
+    with patch("app.routers.nl_filter._get_anthropic_key", return_value="sk-test"), \
+         patch("app.routers.nl_filter.anthropic_breaker", breaker_mock), \
+         patch("anthropic.Anthropic") as MockAnthropic, \
+         patch("app.routers.nl_filter.cache.get", return_value=None), \
+         patch("app.routers.nl_filter.cache.set"):
+        MockAnthropic.return_value.messages.create.return_value = mock_resp
+        resp = await client.post("/intelligence/nl-filter", json={"query": "repos with lots of tags"})
+
+    assert resp.status_code == 200
+    assert len(resp.json()["tags"]) <= 5
+
+
+# ---------------------------------------------------------------------------
+# Cache hit: Haiku is never called
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_nl_filter_cache_hit_skips_haiku(client: AsyncClient):
+    cached = {**_GOOD_PARSE, "query_params": "language=python&min_stars=1000"}
+    with patch("app.routers.nl_filter.cache.get", return_value=cached):
+        with patch("app.routers.nl_filter._get_anthropic_key") as mock_key:
+            resp = await client.post("/intelligence/nl-filter", json={"query": "Python RAG repos"})
+            mock_key.assert_not_called()
+
+    assert resp.status_code == 200
+    assert resp.json()["language"] == "python"
+
+
+# ---------------------------------------------------------------------------
+# Error handling: Haiku returns unparseable JSON
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_nl_filter_json_parse_error_returns_502(client: AsyncClient):
+    bad_msg = MagicMock()
+    bad_msg.content = [MagicMock(text="this is not json at all")]
+    breaker_mock = MagicMock(call=lambda fn: fn())
+
+    with patch("app.routers.nl_filter._get_anthropic_key", return_value="sk-test"), \
+         patch("app.routers.nl_filter.anthropic_breaker", breaker_mock), \
+         patch("anthropic.Anthropic") as MockAnthropic, \
+         patch("app.routers.nl_filter.cache.get", return_value=None):
+        MockAnthropic.return_value.messages.create.return_value = bad_msg
+        resp = await client.post("/intelligence/nl-filter", json={"query": "active Python repos"})
+
+    assert resp.status_code == 502

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -1,0 +1,233 @@
+"""
+KAN-156: Tests for GET /intelligence/similar/{name} and GET /intelligence/recommended.
+
+Uses app.dependency_overrides[get_db] for DB injection and AsyncMock for
+async cache methods — same pattern as test_intelligence_quality.py.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+from app.database import get_db
+from app.main import app
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_row(name="langchain", similarity=0.85):
+    row = MagicMock()
+    row.name = name
+    row.owner = "perditioinc"
+    row.description = f"The {name} framework"
+    row.primary_language = "Python"
+    row.primary_category = "rag-retrieval"
+    row.stars = 1000
+    row.readme_summary = f"A helpful {name} summary."
+    row.similarity = similarity
+    return row
+
+
+def _override_db_with_rows(rows):
+    """Yield a mock db session whose execute() returns rows via fetchall()."""
+    mock_db = AsyncMock()
+    result = MagicMock()
+    result.fetchall.return_value = rows
+    mock_db.execute = AsyncMock(return_value=result)
+
+    async def _override():
+        yield mock_db
+
+    return mock_db, _override
+
+
+def _override_db_multi(call_results: list):
+    """Successive execute() calls return successive row lists."""
+    call_idx = 0
+
+    async def _execute(*args, **kwargs):
+        nonlocal call_idx
+        res = MagicMock()
+        res.fetchall.return_value = call_results[min(call_idx, len(call_results) - 1)]
+        call_idx += 1
+        return res
+
+    mock_db = AsyncMock()
+    mock_db.execute = _execute
+
+    async def _override():
+        yield mock_db
+
+    return mock_db, _override
+
+
+# ---------------------------------------------------------------------------
+# GET /intelligence/similar/{name}
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_similar_repos_returns_results(client: AsyncClient):
+    rows = [_make_row("llama-index", 0.91), _make_row("haystack", 0.82)]
+    _, override = _override_db_with_rows(rows)
+
+    app.dependency_overrides[get_db] = override
+    try:
+        with patch("app.routers.recommendations.cache.get", new=AsyncMock(return_value=None)), \
+             patch("app.routers.recommendations.cache.set", new=AsyncMock()):
+            resp = await client.get("/intelligence/similar/langchain")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["source_repo"] == "langchain"
+    assert len(data["similar"]) == 2
+    assert data["similar"][0]["similarity"] == 0.91
+    assert data["total"] == 2
+
+
+@pytest.mark.asyncio
+async def test_similar_repos_empty_when_no_embedding(client: AsyncClient):
+    """Repo exists but has no embedding — returns empty list, not 404."""
+    empty_result = MagicMock()
+    empty_result.fetchall.return_value = []
+    exists_result = MagicMock()
+    exists_result.fetchone.return_value = MagicMock()  # repo found
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(side_effect=[empty_result, exists_result])
+
+    async def _override():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = _override
+    try:
+        with patch("app.routers.recommendations.cache.get", new=AsyncMock(return_value=None)), \
+             patch("app.routers.recommendations.cache.set", new=AsyncMock()):
+            resp = await client.get("/intelligence/similar/langchain")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 0
+    assert resp.json()["similar"] == []
+
+
+@pytest.mark.asyncio
+async def test_similar_repos_404_for_unknown(client: AsyncClient):
+    empty_result = MagicMock()
+    empty_result.fetchall.return_value = []
+    no_repo = MagicMock()
+    no_repo.fetchone.return_value = None
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(side_effect=[empty_result, no_repo])
+
+    async def _override():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = _override
+    try:
+        with patch("app.routers.recommendations.cache.get", new=AsyncMock(return_value=None)):
+            resp = await client.get("/intelligence/similar/definitely-does-not-exist")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_similar_repos_cache_hit_skips_db(client: AsyncClient):
+    cached = {
+        "source_repo": "langchain",
+        "similar": [{"name": "llama-index", "owner": "o", "description": None,
+                     "primary_language": "Python", "primary_category": "rag-retrieval",
+                     "stars": 500, "similarity": 0.88, "readme_summary": None}],
+        "total": 1,
+    }
+    mock_db = AsyncMock()
+
+    async def _override():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = _override
+    try:
+        with patch("app.routers.recommendations.cache.get", new=AsyncMock(return_value=cached)):
+            resp = await client.get("/intelligence/similar/langchain")
+        mock_db.execute.assert_not_called()
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# GET /intelligence/recommended
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_recommended_requires_seeds(client: AsyncClient):
+    resp = await client.get("/intelligence/recommended")
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_recommended_deduplicates_keeps_best_score(client: AsyncClient):
+    """Same repo from two seeds — keep only the higher similarity score."""
+    rows_seed1 = [_make_row("shared-repo", 0.90)]
+    rows_seed2 = [_make_row("shared-repo", 0.75), _make_row("unique-repo", 0.80)]
+    _, override = _override_db_multi([rows_seed1, rows_seed2])
+
+    app.dependency_overrides[get_db] = override
+    try:
+        with patch("app.routers.recommendations.cache.get", new=AsyncMock(return_value=None)), \
+             patch("app.routers.recommendations.cache.set", new=AsyncMock()):
+            resp = await client.get("/intelligence/recommended?seeds=langchain,llama-index")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+    recs = resp.json()["recommended"]
+    names = [r["name"] for r in recs]
+    assert names.count("shared-repo") == 1
+    shared = next(r for r in recs if r["name"] == "shared-repo")
+    assert shared["similarity"] == 0.90  # best score kept, not 0.75
+
+
+@pytest.mark.asyncio
+async def test_recommended_excludes_seed_repos(client: AsyncClient):
+    """A seed repo should never appear in its own recommendations."""
+    rows = [_make_row("langchain", 0.99), _make_row("haystack", 0.82)]
+    _, override = _override_db_with_rows(rows)
+
+    app.dependency_overrides[get_db] = override
+    try:
+        with patch("app.routers.recommendations.cache.get", new=AsyncMock(return_value=None)), \
+             patch("app.routers.recommendations.cache.set", new=AsyncMock()):
+            resp = await client.get("/intelligence/recommended?seeds=langchain")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    names = [r["name"] for r in resp.json()["recommended"]]
+    assert "langchain" not in names
+    assert "haystack" in names
+
+
+@pytest.mark.asyncio
+async def test_recommended_max_5_seeds(client: AsyncClient):
+    """More than 5 comma-separated seeds are silently truncated to 5."""
+    _, override = _override_db_with_rows([])
+
+    app.dependency_overrides[get_db] = override
+    try:
+        with patch("app.routers.recommendations.cache.get", new=AsyncMock(return_value=None)), \
+             patch("app.routers.recommendations.cache.set", new=AsyncMock()):
+            resp = await client.get("/intelligence/recommended?seeds=a,b,c,d,e,f,g,h")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+    assert len(resp.json()["seeds"]) == 5


### PR DESCRIPTION
## Summary

Two new AI-native endpoints that make Reporium feel smart without burning credits.

---

### KAN-155: `POST /intelligence/nl-filter`

Translates natural language into structured filter params via a **single Haiku call** (~$0.0005/request, cached 1h).

**Example:**
```
POST /intelligence/nl-filter
{"query": "actively maintained Python RAG repos with over 1000 stars"}

→ {
    "language": "python",
    "category": "rag-retrieval",
    "min_stars": 1000,
    "sort": "stars",
    "tags": ["rag", "retrieval"],
    "exclude_archived": true,
    "interpretation": "Python · RAG & Retrieval · 1,000+ stars",
    "query_params": "language=python&category=rag-retrieval&min_stars=1000&sort=stars&exclude_archived=true"
}
```

Frontend: wire `query_params` directly to `GET /repos` URL params for instant smart filtering.

---

### KAN-156: `GET /intelligence/similar/{name}` + `GET /intelligence/recommended`

Pure **pgvector cosine similarity** on existing `repo_embeddings` — **$0.00 per request**.

- `/intelligence/similar/langchain` → top-8 semantically similar repos
- `/intelligence/recommended?seeds=langchain,llama-index` → merged + deduped recommendations from multiple viewed repos; best similarity score wins on duplicates

Both endpoints: 1h cache, configurable `limit` and `min_similarity`, archived repos excluded.

> **URL note:** `/intelligence/similar/{name}` intentionally avoids `/repos/{name}/similar` — FastAPI would match `/repos/{owner}/{repo}` first since it's registered earlier.

---

## Cost impact

| Endpoint | Cost |
|----------|------|
| `/nl-filter` | ~$0.0005 Haiku call, 1h cache |
| `/similar/{name}` | $0.00 (pgvector only) |
| `/recommended` | $0.00 (pgvector only) |

## Test plan

- [x] 16/16 new tests passing
- [ ] Deploy and call `/nl-filter` with a few queries, verify Haiku output
- [ ] Call `/intelligence/similar/langchain` — confirm similar repos returned
- [ ] Call `/intelligence/recommended?seeds=langchain,llama-index` — confirm dedup

🤖 Generated with [Claude Code](https://claude.com/claude-code)