### PR TITLE
KAN-158: Conversational memory for /ask and /query

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -15,7 +15,7 @@ from slowapi.util import get_remote_address
 
 from app.cache import cache
 from app.database import async_session_factory, check_db_connection, engine
-from app.routers import admin, analytics, graph, ingest, intelligence, library, library_full, platform, repos, search, taxonomy, trends, webhooks, wiki
+from app.routers import admin, analytics, graph, ingest, intelligence, library, library_full, nl_filter, platform, recommendations, repos, search, taxonomy, trends, webhooks, wiki
 
 
 class _JsonFormatter(logging.Formatter):
@@ -235,6 +235,8 @@ app.include_router(platform.router)
 app.include_router(ingest.router)
 app.include_router(ingest.events_router)
 app.include_router(intelligence.router)
+app.include_router(nl_filter.router)
+app.include_router(recommendations.router)
 app.include_router(library_full.router)
 app.include_router(taxonomy.router, prefix="/taxonomy")
 app.include_router(admin.router)

--- a/app/models/session.py
+++ b/app/models/session.py
@@ -1,0 +1,24 @@
+"""SQLAlchemy model for ask_sessions — conversational memory for /ask (KAN-158)."""
+
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import Integer, Text, TIMESTAMP
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class AskSession(Base):
+    __tablename__ = "ask_sessions"
+
+    id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, default=uuid4)
+    session_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False, index=True)
+    turn_number: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    question: Mapped[str] = mapped_column(Text, nullable=False)
+    answer: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/app/routers/ingest.py
+++ b/app/routers/ingest.py
@@ -1,13 +1,18 @@
+import asyncio
 import base64
 import json
 import logging
+import os
 from datetime import datetime, timezone
 from uuid import uuid4
 
+import anthropic as _anthropic_lib
 from fastapi import APIRouter, Depends, HTTPException, Request
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 from sqlalchemy import select
+
+from app.circuit_breaker import anthropic_breaker
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -58,6 +63,128 @@ _TAXONOMY_DIMENSION_MAP = {
     "deployment_context": "deployment_context",
     "dependencies": "dependency",
 }
+
+
+# ---------------------------------------------------------------------------
+# KAN-157: Auto-enrichment helpers (Haiku, ~$0.0004/repo)
+# ---------------------------------------------------------------------------
+
+_AUTO_ENRICH_PROMPT = """Analyze this AI/ML GitHub repository and return a JSON object.
+
+Repository information:
+{repo_context}
+
+{{
+  "readme_summary": "2-3 sentence plain language description of what this repo does and who uses it",
+  "problem_solved": "1 sentence: what specific problem does this solve",
+  "quality_assessment": "high|medium|low — based on documentation quality, activity, and stars",
+  "maturity_level": "research|prototype|beta|production",
+  "skill_areas": ["AI/ML expertise domains — e.g. 'Retrieval-Augmented Generation', 'LoRA Fine-tuning'"],
+  "industries": ["industry verticals — e.g. 'Healthcare', 'FinTech' — omit if general-purpose"],
+  "use_cases": ["specific problems solved — e.g. 'Document Question Answering', 'Code Review Automation'"],
+  "modalities": ["data types — e.g. 'Text', 'Code', 'Image', 'Audio'"],
+  "ai_trends": ["AI paradigms — e.g. 'Agentic AI', 'Small Language Models', 'AI Safety'"],
+  "deployment_context": ["where it runs — e.g. 'Cloud API', 'Self-hosted', 'Edge/Mobile'"],
+  "integration_tags": ["specific frameworks/tools — lowercase — e.g. 'langchain', 'pytorch', 'fastapi'"]
+}}
+
+Rules:
+- Base all values on the description/context — no speculation
+- integration_tags: lowercase, specific library names only
+- Return ONLY valid JSON, no markdown, no explanation"""
+
+_ENRICH_TAXONOMY_DIMENSIONS = {
+    "skill_areas":        "skill_area",
+    "industries":         "industry",
+    "use_cases":          "use_case",
+    "modalities":         "modality",
+    "ai_trends":          "ai_trend",
+    "deployment_context": "deployment_context",
+}
+
+
+def _get_anthropic_key() -> str:
+    """Retrieve Anthropic API key from env or GCP Secret Manager."""
+    key = os.getenv("ANTHROPIC_API_KEY", "").strip()
+    if key:
+        return key
+    try:
+        from google.cloud import secretmanager
+        client = secretmanager.SecretManagerServiceClient()
+        project = os.getenv("GCP_PROJECT", "perditio-platform")
+        name = f"projects/{project}/secrets/anthropic-api-key/versions/latest"
+        response = client.access_secret_version(request={"name": name})
+        return response.payload.data.decode("UTF-8").strip()
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=f"ANTHROPIC_API_KEY not configured: {exc}")
+
+
+async def _enrich_repo_with_haiku(repo: Repo, db: AsyncSession) -> dict:
+    """
+    Call Claude Haiku to enrich a single repo with readme_summary, quality_signals,
+    and taxonomy dimensions. Returns a dict with enrichment outcome stats.
+
+    Uses asyncio.to_thread so the synchronous Anthropic SDK call doesn't block the loop.
+    """
+    parts = [
+        f"Name: {repo.owner}/{repo.name}",
+        f"Description: {repo.description or 'None'}",
+        f"Primary Language: {repo.primary_language or 'Unknown'}",
+    ]
+    if repo.forked_from:
+        parts.append(f"Forked from: {repo.forked_from}")
+    repo_context = "\n".join(parts)
+    prompt = _AUTO_ENRICH_PROMPT.format(repo_context=repo_context)
+
+    api_key = _get_anthropic_key()
+
+    def _call_haiku():
+        client = _anthropic_lib.Anthropic(api_key=api_key)
+        return client.messages.create(
+            model="claude-haiku-4-5",
+            max_tokens=800,
+            messages=[{"role": "user", "content": prompt}],
+        )
+
+    with anthropic_breaker:
+        response = await asyncio.to_thread(_call_haiku)
+
+    raw = response.content[0].text.strip()
+    if raw.startswith("```"):
+        lines = raw.split("\n")
+        raw = "\n".join(lines[1:-1] if lines[-1].strip() == "```" else lines[1:])
+
+    data = json.loads(raw)
+
+    # Validate quality/maturity
+    quality = data.get("quality_assessment", "medium")
+    if quality not in ("high", "medium", "low"):
+        quality = "medium"
+    maturity = data.get("maturity_level", "")
+    if maturity not in ("research", "prototype", "beta", "production"):
+        maturity = None
+
+    # Write enrichment columns
+    repo.readme_summary = data.get("readme_summary") or repo.readme_summary
+    repo.problem_solved = data.get("problem_solved") or repo.problem_solved
+    repo.integration_tags = [
+        t.lower().strip() for t in data.get("integration_tags", []) if t and isinstance(t, str)
+    ] or repo.integration_tags
+    repo.quality_signals = {"quality": quality, "maturity": maturity}
+    repo.updated_at = datetime.now(timezone.utc)
+
+    # Write taxonomy dimensions via the shared helper
+    taxonomy_dict = {k: data.get(k, []) for k in _ENRICH_TAXONOMY_DIMENSIONS}
+    await _upsert_repo_taxonomy(db, repo.id, taxonomy_dict)
+
+    await db.commit()
+
+    return {
+        "input_tokens": response.usage.input_tokens,
+        "output_tokens": response.usage.output_tokens,
+        "quality": quality,
+        "maturity": maturity,
+    }
 
 
 def _severity_for_repo_count(repo_count: int) -> str:
@@ -422,4 +549,90 @@ async def repo_ingested_event(
         "taxonomy_assign": assign_result,
         "gap_rebuild": gap_result,
         "portfolio_insights": insights_result,
+    }
+
+
+# ---------------------------------------------------------------------------
+# KAN-157: POST /ingest/events/repo-added
+# Triggered by Pub/Sub REPO_ADDED events when a new repo enters the platform.
+# ---------------------------------------------------------------------------
+
+@events_router.post("/repo-added", response_model=dict)
+async def repo_added_event(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """
+    Handle Pub/Sub REPO_ADDED push notifications.
+
+    When forksync or the ingestion pipeline adds a new repo, it publishes a
+    ``repo.added`` event with ``name_with_owner`` in the payload.  This handler:
+
+    1. Resolves the repo by name from the DB.
+    2. Skips if already enriched (idempotent).
+    3. Calls Claude Haiku to generate readme_summary, quality_signals, and
+       taxonomy dimensions — ~$0.0004 per repo.
+    4. Invalidates relevant caches.
+
+    Always returns HTTP 200 so Pub/Sub does not retry on transient enrichment
+    failures (errors are logged instead).
+    """
+    payload = _parse_pubsub_payload(await request.json())
+
+    # REPO_ADDED schema: {"name_with_owner": "owner/name", "stars": N, "language": "..."}
+    name_with_owner = (
+        payload.get("name_with_owner")
+        or payload.get("repo_name")
+        or payload.get("name")
+        or ""
+    )
+    # Extract bare repo name (the "name" column in repos table uses owner/name or just name)
+    # The repos table uses bare name as the unique key; strip owner prefix if present.
+    repo_name = name_with_owner.split("/")[-1] if name_with_owner else ""
+    if not repo_name:
+        logger.warning("repo-added event: no repo name in payload — skipping")
+        return {"status": "skipped", "reason": "no repo name in payload"}
+
+    result = await db.execute(select(Repo).where(Repo.name == repo_name))
+    repo = result.scalar_one_or_none()
+
+    if repo is None:
+        logger.warning("repo-added event: repo '%s' not found in DB — may not be ingested yet", repo_name)
+        return {"status": "skipped", "reason": f"repo '{repo_name}' not found in DB"}
+
+    if repo.quality_signals is not None:
+        logger.info("repo-added event: '%s' already enriched — skipping", repo_name)
+        return {"status": "skipped", "reason": "already enriched", "repo": repo_name}
+
+    logger.info("repo-added event: enriching '%s' with Haiku", repo_name)
+    try:
+        enrich_result = await _enrich_repo_with_haiku(repo, db)
+    except json.JSONDecodeError as exc:
+        logger.error("repo-added event: Haiku JSON parse error for '%s': %s", repo_name, exc)
+        return {"status": "error", "repo": repo_name, "reason": "json_parse_error"}
+    except HTTPException as exc:
+        logger.error("repo-added event: HTTP error for '%s': %s", repo_name, exc.detail)
+        return {"status": "error", "repo": repo_name, "reason": exc.detail}
+    except Exception as exc:
+        logger.error("repo-added event: unexpected error for '%s': %s", repo_name, exc)
+        return {"status": "error", "repo": repo_name, "reason": str(exc)}
+
+    # Invalidate caches so the enriched data appears immediately
+    await cache.invalidate(f"repos:detail:{repo_name}")
+    await cache.invalidate("library:full*")
+    await cache.invalidate(f"similar:{repo_name}:*")
+    invalidate_library_cache()
+
+    logger.info(
+        "repo-added event: '%s' enriched — quality=%s maturity=%s tokens=%d+%d",
+        repo_name,
+        enrich_result.get("quality"),
+        enrich_result.get("maturity"),
+        enrich_result.get("input_tokens", 0),
+        enrich_result.get("output_tokens", 0),
+    )
+    return {
+        "status": "ok",
+        "repo": repo_name,
+        "enrichment": enrich_result,
     }

--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -30,6 +30,7 @@ from app.cache import CACHE_TTL_STATS, cache
 from app.circuit_breaker import anthropic_breaker
 from app.database import async_session_factory, get_db
 from app.embeddings import get_embedding_model
+from app.models.session import AskSession
 # Rate limiter for the public /ask endpoint (no auth, IP-based)
 _limiter = Limiter(key_func=get_remote_address)
 
@@ -184,9 +185,89 @@ async def _log_query(
         logger.exception("query_log insert failed (non-fatal)")
 
 
+# ---------------------------------------------------------------------------
+# KAN-158: Conversational memory helpers — session-scoped last-3-turns store
+# ---------------------------------------------------------------------------
+
+_MAX_SESSION_TURNS = 3  # turns prepended to Claude's messages array
+
+
+async def _load_session_turns(session_id: str, db: AsyncSession) -> list[dict]:
+    """
+    Return up to _MAX_SESSION_TURNS prior turns for a session, oldest-first.
+
+    Each element is {"role": "user"|"assistant", "content": "..."} ready to
+    prepend to the Claude messages array.
+    """
+    try:
+        result = await db.execute(
+            text("""
+                SELECT question, answer
+                FROM ask_sessions
+                WHERE session_id = CAST(:sid AS uuid)
+                  AND created_at > NOW() - INTERVAL '24 hours'
+                ORDER BY turn_number DESC
+                LIMIT :max_turns
+            """),
+            {"sid": session_id, "max_turns": _MAX_SESSION_TURNS},
+        )
+        rows = result.fetchall()
+    except Exception:
+        logger.exception("_load_session_turns failed (non-fatal) for session %s", session_id)
+        return []
+
+    # Rows are newest-first; reverse to oldest-first for correct message order
+    turns: list[dict] = []
+    for row in reversed(rows):
+        turns.append({"role": "user", "content": row.question})
+        turns.append({"role": "assistant", "content": row.answer})
+    return turns
+
+
+async def _save_session_turn(
+    session_id: str, question: str, answer: str, db: AsyncSession
+) -> None:
+    """Append one turn to ask_sessions. Fire-and-forget — never raises."""
+    try:
+        # Determine the next turn number for this session
+        result = await db.execute(
+            text("""
+                SELECT COALESCE(MAX(turn_number), -1)
+                FROM ask_sessions
+                WHERE session_id = CAST(:sid AS uuid)
+            """),
+            {"sid": session_id},
+        )
+        max_turn = result.scalar()
+        next_turn = (max_turn + 1) if max_turn is not None else 0
+
+        await db.execute(
+            text("""
+                INSERT INTO ask_sessions (session_id, turn_number, question, answer)
+                VALUES (CAST(:sid AS uuid), :turn, :question, :answer)
+            """),
+            {
+                "sid": session_id,
+                "turn": next_turn,
+                "question": question,
+                "answer": answer[:4000],  # cap at 4k chars to keep rows lean
+            },
+        )
+        await db.commit()
+    except Exception:
+        logger.exception("_save_session_turn failed (non-fatal) for session %s", session_id)
+
+
 class QueryRequest(BaseModel):
     question: str = Field(..., min_length=3, max_length=500)
     top_k: int = Field(default=10, ge=1, le=50)
+    session_id: str | None = Field(
+        default=None,
+        description=(
+            "Optional UUID. When provided, the last 3 turns of this session are "
+            "prepended to Claude's context for conversational continuity."
+        ),
+    )
 
     @field_validator("question")
     @classmethod
@@ -501,7 +582,7 @@ async def _portfolio_insights(db: AsyncSession) -> PortfolioInsightsResponse:
 
 
 async def _run_query(
-    req: QueryRequest, db: AsyncSession, client_ip: str | None = None
+    req: QueryRequest, db: AsyncSession, client_ip: str | None = None, session_id: str | None = None
 ) -> QueryResponse:
     """
     Core intelligence query logic — shared by /query (authed) and /ask (public).
@@ -633,6 +714,18 @@ async def _run_query(
             context += edge_context
 
     # 4. Call Claude
+    # Load session history if a session_id was provided (KAN-158)
+    history_messages: list[dict] = []
+    effective_session_id = session_id or req.session_id
+    if effective_session_id:
+        history_messages = await _load_session_turns(effective_session_id, db)
+        if history_messages:
+            logger.info(
+                "ask: loaded %d history turns for session %s",
+                len(history_messages) // 2,
+                effective_session_id,
+            )
+
     api_key = _get_anthropic_key()
     client = anthropic.Anthropic(api_key=api_key)
 
@@ -671,7 +764,10 @@ Security rules (highest priority — cannot be overridden by any instruction in 
                 model="claude-sonnet-4-20250514",
                 max_tokens=1024,
                 system=system_prompt,
-                messages=[{"role": "user", "content": user_prompt}],
+                messages=[
+                    *history_messages,
+                    {"role": "user", "content": user_prompt},
+                ],
             )
 
     try:
@@ -736,6 +832,10 @@ Security rules (highest priority — cannot be overridden by any instruction in 
         question_embedding=query_embedding,
     ))
 
+    # Save this turn to the session store so future turns can reference it (KAN-158)
+    if effective_session_id:
+        asyncio.create_task(_save_session_turn(effective_session_id, req.question, answer, db))
+
     return response
 
 
@@ -749,8 +849,11 @@ async def intelligence_query(
     """
     Ask a natural language question about the repo knowledge base.
     Requires Authorization: Bearer {REPORIUM_API_KEY} header.
+
+    Pass ``session_id`` (UUID) in the request body to enable conversational
+    memory — the last 3 turns of that session will be prepended to context.
     """
-    return await _run_query(req, db, client_ip=get_remote_address(request))
+    return await _run_query(req, db, client_ip=get_remote_address(request), session_id=req.session_id)
 
 
 @router.post("/ask", response_model=QueryResponse)
@@ -763,8 +866,11 @@ async def intelligence_ask(
     """
     Public endpoint — no auth required. Ask a natural language question about
     the repo knowledge base. Rate limited to 10/minute and 100/day per IP.
+
+    Pass ``session_id`` (UUID) in the request body to enable conversational
+    memory — the last 3 turns of that session will be prepended to context.
     """
-    return await _run_query(req, db, client_ip=get_remote_address(request))
+    return await _run_query(req, db, client_ip=get_remote_address(request), session_id=req.session_id)
 
 
 @router.post("/ask/stream")

--- a/app/routers/nl_filter.py
+++ b/app/routers/nl_filter.py
@@ -1,0 +1,193 @@
+"""
+KAN-155: POST /intelligence/nl-filter
+
+Translates a natural language query into structured filter params for the
+/repos and /library/full endpoints. Single Haiku call per request — ~$0.0005.
+
+Example input:  "actively maintained Python RAG repos with over 1000 stars"
+Example output: {
+    "language": "python",
+    "category": "rag-retrieval",
+    "min_stars": 1000,
+    "sort": "stars",
+    "tags": ["rag", "retrieval"],
+    "quality": "high",
+    "interpretation": "Python · RAG & Retrieval · 1,000+ stars · sorted by stars"
+}
+
+The structured output maps directly to existing query params on GET /repos.
+"""
+
+import json
+import logging
+import os
+
+import anthropic
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+from app.cache import cache
+from app.circuit_breaker import anthropic_breaker
+
+logger = logging.getLogger(__name__)
+router = APIRouter(prefix="/intelligence", tags=["Intelligence"])
+_limiter = Limiter(key_func=get_remote_address)
+
+# Valid categories in the Reporium taxonomy
+_VALID_CATEGORIES = [
+    "agents", "rag-retrieval", "llm-serving", "fine-tuning", "evaluation",
+    "orchestration", "vector-databases", "observability", "security-safety",
+    "code-generation", "data-processing", "computer-vision", "nlp-text",
+    "speech-audio", "generative-media", "infrastructure",
+]
+
+_NL_FILTER_PROMPT = """You are a search query parser for Reporium — a curated library of AI/ML GitHub repositories.
+
+Convert the following natural language search into structured filter parameters.
+
+Natural language query: {query}
+
+Valid categories (pick the single best match, or null if not applicable):
+{categories}
+
+Return ONLY valid JSON matching this schema — no markdown, no explanation:
+{{
+  "language": "<lowercase language name or null>",
+  "category": "<one of the valid categories above, or null>",
+  "min_stars": <integer >= 0 or null>,
+  "max_stars": <integer or null>,
+  "sort": "<one of: stars | updated | name, or null>",
+  "tags": ["<relevant tag keywords — lowercase, specific>"],
+  "quality": "<high | medium | low | null — only set if explicitly mentioned>",
+  "maturity": "<production | beta | prototype | research | null — only if mentioned>",
+  "exclude_archived": <true if user wants active repos, false otherwise>,
+  "interpretation": "<short human-readable summary: what filters were applied, e.g. 'Python · RAG & Retrieval · 1,000+ stars'>"
+}}
+
+Rules:
+- Only set fields that are clearly implied by the query — don't guess
+- min_stars: "popular" → 500, "widely used" → 1000, "very popular" → 5000
+- sort: default to "stars" if popularity is mentioned, "updated" if recency is mentioned
+- tags: extract meaningful keywords (e.g. "rag", "langchain", "fine-tuning") — max 5
+- exclude_archived: true if query mentions "active", "maintained", "recent", "working"
+- interpretation: be concise, use · as separator"""
+
+
+def _get_anthropic_key() -> str:
+    key = os.getenv("ANTHROPIC_API_KEY", "").strip()
+    if key:
+        return key
+    try:
+        from google.cloud import secretmanager
+        client = secretmanager.SecretManagerServiceClient()
+        project = os.getenv("GCP_PROJECT", "perditio-platform")
+        name = f"projects/{project}/secrets/anthropic-api-key/versions/latest"
+        response = client.access_secret_version(request={"name": name})
+        return response.payload.data.decode("UTF-8").strip()
+    except Exception:
+        raise HTTPException(status_code=500, detail="ANTHROPIC_API_KEY not configured")
+
+
+class NLFilterRequest(BaseModel):
+    query: str = Field(..., min_length=3, max_length=300,
+                       description="Natural language filter query")
+
+
+class NLFilterResponse(BaseModel):
+    language: str | None = None
+    category: str | None = None
+    min_stars: int | None = None
+    max_stars: int | None = None
+    sort: str | None = None
+    tags: list[str] = Field(default_factory=list)
+    quality: str | None = None
+    maturity: str | None = None
+    exclude_archived: bool = False
+    interpretation: str
+    # Convenience: ready-to-use query string for GET /repos
+    query_params: str = ""
+
+
+def _build_query_params(r: NLFilterResponse) -> str:
+    """Build a URL query string from the filter response."""
+    parts = []
+    if r.language:
+        parts.append(f"language={r.language}")
+    if r.category:
+        parts.append(f"category={r.category}")
+    if r.min_stars is not None:
+        parts.append(f"min_stars={r.min_stars}")
+    if r.sort:
+        parts.append(f"sort={r.sort}")
+    if r.exclude_archived:
+        parts.append("exclude_archived=true")
+    return "&".join(parts)
+
+
+@router.post("/nl-filter", response_model=NLFilterResponse)
+@_limiter.limit("30/minute")
+async def nl_filter(request: Request, body: NLFilterRequest) -> NLFilterResponse:
+    """
+    Translate a natural language query into structured filter params.
+    Single Haiku call — ~$0.0005 per request. Results cached 1 hour by query hash.
+    Public endpoint, rate-limited to 30 req/min per IP.
+    """
+    cache_key = f"nl_filter:{hash(body.query.lower().strip())}"
+    cached = await cache.get(cache_key)
+    if cached:
+        return NLFilterResponse(**cached)
+
+    prompt = _NL_FILTER_PROMPT.format(
+        query=body.query,
+        categories="\n".join(f"  - {c}" for c in _VALID_CATEGORIES),
+    )
+
+    try:
+        api_key = _get_anthropic_key()
+
+        def _call_haiku():
+            client = anthropic.Anthropic(api_key=api_key)
+            return client.messages.create(
+                model="claude-haiku-4-5",
+                max_tokens=256,
+                messages=[{"role": "user", "content": prompt}],
+            )
+
+        response = anthropic_breaker.call(_call_haiku)
+        raw = response.content[0].text.strip()
+
+        # Strip markdown fences if present
+        if raw.startswith("```"):
+            lines = raw.split("\n")
+            raw = "\n".join(lines[1:-1] if lines[-1].strip() == "```" else lines[1:])
+
+        data = json.loads(raw)
+
+        # Validate/normalise
+        if data.get("category") not in _VALID_CATEGORIES:
+            data["category"] = None
+        if data.get("sort") not in {"stars", "updated", "name", None}:
+            data["sort"] = None
+        if data.get("quality") not in {"high", "medium", "low", None}:
+            data["quality"] = None
+        if data.get("maturity") not in {"production", "beta", "prototype", "research", None}:
+            data["maturity"] = None
+        data.setdefault("tags", [])
+        data["tags"] = [str(t).lower().strip() for t in data["tags"][:5] if t]
+        data.setdefault("exclude_archived", False)
+        data.setdefault("interpretation", body.query)
+
+        result = NLFilterResponse(**data)
+        result.query_params = _build_query_params(result)
+
+        await cache.set(cache_key, result.model_dump(), ttl=3600)  # 1h cache
+        logger.info("nl_filter: '%s' → %s", body.query[:60], result.query_params)
+        return result
+
+    except json.JSONDecodeError as e:
+        logger.error("nl_filter: JSON parse failed for query '%s': %s", body.query, e)
+        raise HTTPException(status_code=502, detail="Filter parsing failed — try rephrasing")
+    except Exception as e:
+        logger.error("nl_filter: unexpected error: %s", e)
+        raise HTTPException(status_code=500, detail="Filter service unavailable")

--- a/app/routers/recommendations.py
+++ b/app/routers/recommendations.py
@@ -1,0 +1,197 @@
+"""
+KAN-156: GET /repos/{name}/similar  — pure pgvector cosine similarity, no LLM.
+         GET /intelligence/recommended — top-N similar repos across a list of seeds.
+
+Uses existing repo_embeddings (384-dim all-MiniLM-L6-v2 vectors).
+No Anthropic API calls — $0.00 per request.
+
+/similar       — find repos semantically close to a given repo
+/recommended   — given a comma-separated list of recently-viewed repo names,
+                 return a deduplicated ranked list of recommendations
+"""
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.cache import CACHE_TTL_STATS, cache
+from app.database import get_db
+
+logger = logging.getLogger(__name__)
+router = APIRouter(tags=["Repos"])
+
+_DEFAULT_SIMILAR_LIMIT = 8
+_DEFAULT_REC_LIMIT = 12
+_MIN_SIMILARITY = 0.55  # cosine similarity floor — below this, repos are unrelated
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+class SimilarRepo(BaseModel):
+    name: str
+    owner: str
+    description: str | None
+    primary_language: str | None
+    primary_category: str | None
+    stars: int | None
+    similarity: float
+    readme_summary: str | None
+
+
+class SimilarReposResponse(BaseModel):
+    source_repo: str
+    similar: list[SimilarRepo]
+    total: int
+
+
+class RecommendedReposResponse(BaseModel):
+    seeds: list[str]
+    recommended: list[SimilarRepo]
+    total: int
+
+
+# ---------------------------------------------------------------------------
+# Shared SQL — single HNSW index scan per seed repo
+# ---------------------------------------------------------------------------
+
+_SIMILAR_SQL = text("""
+    SELECT
+        r.name,
+        r.owner,
+        r.description,
+        r.primary_language,
+        r.primary_category,
+        r.parent_stars         AS stars,
+        r.readme_summary,
+        1 - (e2.embedding_vec <=> e1.embedding_vec) AS similarity
+    FROM repo_embeddings e1
+    JOIN repos seed_r ON seed_r.id = e1.repo_id
+    JOIN repo_embeddings e2 ON e2.repo_id != e1.repo_id
+    JOIN repos r ON r.id = e2.repo_id
+    WHERE seed_r.name = :name
+      AND r.is_private = false
+      AND r.parent_is_archived = false
+      AND e1.embedding_vec IS NOT NULL
+      AND e2.embedding_vec IS NOT NULL
+      AND 1 - (e2.embedding_vec <=> e1.embedding_vec) >= :min_similarity
+    ORDER BY e2.embedding_vec <=> e1.embedding_vec
+    LIMIT :limit
+""")
+
+
+def _row_to_similar(row) -> SimilarRepo:
+    return SimilarRepo(
+        name=row.name,
+        owner=row.owner,
+        description=row.description,
+        primary_language=row.primary_language,
+        primary_category=row.primary_category,
+        stars=row.stars,
+        similarity=round(float(row.similarity), 4),
+        readme_summary=row.readme_summary,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /repos/{name}/similar
+# ---------------------------------------------------------------------------
+
+@router.get("/intelligence/similar/{name}", response_model=SimilarReposResponse)
+async def similar_repos(
+    name: str,
+    limit: int = Query(default=_DEFAULT_SIMILAR_LIMIT, ge=1, le=24),
+    min_similarity: float = Query(default=_MIN_SIMILARITY, ge=0.0, le=1.0),
+    db: AsyncSession = Depends(get_db),
+) -> SimilarReposResponse:
+    """
+    Return repos semantically similar to {name} using pgvector cosine similarity.
+    Pure vector search — no LLM, no API credits consumed.
+
+    Results cached for 1 hour. Excludes archived repos and the source repo itself.
+    """
+    cache_key = f"similar:{name}:{limit}:{min_similarity}"
+    cached = await cache.get(cache_key)
+    if cached:
+        return SimilarReposResponse(**cached)
+
+    result = await db.execute(
+        _SIMILAR_SQL,
+        {"name": name, "limit": limit, "min_similarity": min_similarity},
+    )
+    rows = result.fetchall()
+
+    if not rows:
+        # Check whether the source repo exists at all
+        exists = await db.execute(
+            text("SELECT 1 FROM repos WHERE name = :name AND is_private = false LIMIT 1"),
+            {"name": name},
+        )
+        if not exists.fetchone():
+            raise HTTPException(status_code=404, detail=f"Repo '{name}' not found")
+
+        # Repo exists but has no embedding or no similar neighbours above threshold
+        response = SimilarReposResponse(source_repo=name, similar=[], total=0)
+        await cache.set(cache_key, response.model_dump(), ttl=CACHE_TTL_STATS)
+        return response
+
+    similar = [_row_to_similar(r) for r in rows]
+    response = SimilarReposResponse(source_repo=name, similar=similar, total=len(similar))
+    await cache.set(cache_key, response.model_dump(), ttl=CACHE_TTL_STATS)
+    return response
+
+
+# ---------------------------------------------------------------------------
+# GET /intelligence/recommended?seeds=repo1,repo2,...
+# ---------------------------------------------------------------------------
+
+@router.get("/intelligence/recommended", response_model=RecommendedReposResponse)
+async def recommended_repos(
+    seeds: str = Query(
+        ...,
+        description="Comma-separated list of recently-viewed repo names (max 5)",
+        min_length=1,
+    ),
+    limit: int = Query(default=_DEFAULT_REC_LIMIT, ge=1, le=24),
+    db: AsyncSession = Depends(get_db),
+) -> RecommendedReposResponse:
+    """
+    Given recently-viewed repos, return a deduplicated ranked recommendation list.
+    Each seed contributes similar repos; results are merged and re-ranked by similarity.
+    Pure pgvector — no LLM, no API credits.
+    """
+    seed_names = [s.strip() for s in seeds.split(",") if s.strip()][:5]
+    if not seed_names:
+        raise HTTPException(status_code=422, detail="At least one seed repo name is required")
+
+    cache_key = f"recommended:{','.join(sorted(seed_names))}:{limit}"
+    cached = await cache.get(cache_key)
+    if cached:
+        return RecommendedReposResponse(**cached)
+
+    # Collect similar repos for all seeds; merge by best similarity score
+    merged: dict[str, SimilarRepo] = {}
+    for seed in seed_names:
+        result = await db.execute(
+            _SIMILAR_SQL,
+            {"name": seed, "limit": limit * 2, "min_similarity": _MIN_SIMILARITY},
+        )
+        for row in result.fetchall():
+            if row.name in seed_names:
+                continue  # don't recommend a repo the user already viewed
+            repo = _row_to_similar(row)
+            if row.name not in merged or repo.similarity > merged[row.name].similarity:
+                merged[row.name] = repo
+
+    ranked = sorted(merged.values(), key=lambda r: r.similarity, reverse=True)[:limit]
+    response = RecommendedReposResponse(
+        seeds=seed_names,
+        recommended=ranked,
+        total=len(ranked),
+    )
+    await cache.set(cache_key, response.model_dump(), ttl=CACHE_TTL_STATS)
+    return response

--- a/migrations/versions/021_ask_sessions.py
+++ b/migrations/versions/021_ask_sessions.py
@@ -1,0 +1,44 @@
+"""Add ask_sessions table for conversational memory (KAN-158).
+
+Stores the last N question/answer turns per session so /ask and /query
+can prepend prior context to Claude's messages array.
+
+Each session is identified by a client-provided UUID.  Rows are lightweight
+(question + answer text only — no embeddings) and indexed on (session_id, turn_number)
+for fast last-N-turns retrieval.
+
+Revision ID: 021
+Revises: 020
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+
+revision = "021"
+down_revision = "020"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "ask_sessions",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("session_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("turn_number", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("question", sa.Text, nullable=False),
+        sa.Column("answer", sa.Text, nullable=False),
+        sa.Column("created_at", sa.TIMESTAMP(timezone=True), nullable=False, server_default=sa.text("now()")),
+    )
+    op.create_index(
+        "idx_ask_sessions_session_id_turn",
+        "ask_sessions",
+        ["session_id", "turn_number"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_ask_sessions_session_id_turn", table_name="ask_sessions")
+    op.drop_table("ask_sessions")

--- a/tests/test_ask_memory.py
+++ b/tests/test_ask_memory.py
@@ -1,0 +1,257 @@
+"""
+KAN-158: Tests for conversational memory in POST /intelligence/ask.
+
+Validates:
+- session_id is optional (backward compatible — no session_id = stateless)
+- History turns are loaded and prepended to Claude's messages
+- Turn is saved after a successful answer
+- History load failure is non-fatal (still answers)
+- Turn save failure is non-fatal
+- _load_session_turns returns oldest-first order
+- _save_session_turn increments turn_number correctly
+
+Uses AsyncMock / MagicMock patterns from test_intelligence_quality.py.
+"""
+import json
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+import numpy as np
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.main import app
+from app.routers.intelligence import (
+    _load_session_turns,
+    _save_session_turn,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+_SESSION_ID = str(uuid.uuid4())
+
+
+def _make_claude_response(text: str = "Here is my answer.") -> MagicMock:
+    msg = MagicMock()
+    msg.content = [MagicMock(text=text)]
+    msg.usage = MagicMock(input_tokens=400, output_tokens=200)
+    return msg
+
+
+def _make_db_override_for_ask(rows=None, session_rows=None):
+    """
+    Yields a mock DB for /ask tests where _find_semantic_cache_hit is patched.
+
+    With the semantic cache patched, actual DB execute() calls in _run_query are:
+    1. Vector search → fetchall() = [] (empty — no embeddings in test DB)
+    2. (edge query is skipped when top_for_answer is empty)
+    3. _load_session_turns → fetchall() = session_rows (if session_id given)
+    4. _save_session_turn max query → scalar() = -1 (if session_id given)
+    5. _save_session_turn insert → (ignored)
+    """
+    mock_db = AsyncMock()
+
+    empty_fetchall = MagicMock()
+    empty_fetchall.fetchall.return_value = []
+
+    if session_rows is not None:
+        session_result = MagicMock()
+        session_result.fetchall.return_value = session_rows
+    else:
+        session_result = MagicMock()
+        session_result.fetchall.return_value = []
+
+    # For _save_session_turn: scalar returns -1 (no prior turns) → next_turn=0
+    scalar_result = MagicMock()
+    scalar_result.scalar.return_value = -1
+
+    call_idx = 0
+    results = [empty_fetchall, session_result, scalar_result, MagicMock()]
+
+    async def _execute(*args, **kwargs):
+        nonlocal call_idx
+        res = results[min(call_idx, len(results) - 1)]
+        call_idx += 1
+        return res
+
+    mock_db.execute = _execute
+    mock_db.commit = AsyncMock()
+
+    async def _override():
+        yield mock_db
+
+    return mock_db, _override
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for session helpers
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_load_session_turns_returns_oldest_first():
+    """Rows fetched newest-first (DESC) are reversed to oldest-first for messages."""
+    # Simulate 2 rows returned newest-first
+    row1 = MagicMock()
+    row1.question = "What is langchain?"
+    row1.answer = "Langchain is an LLM framework."
+    row2 = MagicMock()
+    row2.question = "How do I use it?"
+    row2.answer = "Import langchain and create a chain."
+
+    mock_db = AsyncMock()
+    result = MagicMock()
+    result.fetchall.return_value = [row1, row2]  # newest-first from DB
+    mock_db.execute = AsyncMock(return_value=result)
+
+    turns = await _load_session_turns(_SESSION_ID, mock_db)
+
+    # Should be reversed: row2 (oldest) first, then row1
+    assert len(turns) == 4  # 2 turns × 2 messages each
+    assert turns[0]["role"] == "user"
+    assert turns[0]["content"] == "How do I use it?"   # row2 is oldest → first
+    assert turns[1]["role"] == "assistant"
+    assert turns[2]["role"] == "user"
+    assert turns[2]["content"] == "What is langchain?"
+
+
+@pytest.mark.asyncio
+async def test_load_session_turns_returns_empty_on_db_error():
+    """DB error during load is non-fatal — returns empty list."""
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(side_effect=Exception("DB unreachable"))
+
+    turns = await _load_session_turns(_SESSION_ID, mock_db)
+    assert turns == []
+
+
+@pytest.mark.asyncio
+async def test_save_session_turn_does_not_raise_on_error():
+    """DB error during save is non-fatal."""
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(side_effect=Exception("DB write failed"))
+
+    # Should not raise
+    await _save_session_turn(_SESSION_ID, "question", "answer", mock_db)
+
+
+@pytest.mark.asyncio
+async def test_save_session_turn_increments_turn_number():
+    """Turn number is MAX(turn_number) + 1; SQL returns the raw max value."""
+    mock_db = AsyncMock()
+
+    # SQL: SELECT COALESCE(MAX(turn_number), -1) — returns 2 (existing max turn = 2)
+    scalar_result = MagicMock()
+    scalar_result.scalar.return_value = 2  # existing max turn = 2
+    insert_result = MagicMock()
+    mock_db.execute = AsyncMock(side_effect=[scalar_result, insert_result])
+    mock_db.commit = AsyncMock()
+
+    await _save_session_turn(_SESSION_ID, "q", "a", mock_db)
+
+    # Python computes next_turn = max_turn + 1 = 2 + 1 = 3
+    calls = mock_db.execute.call_args_list
+    insert_call = calls[1]
+    params = insert_call[0][1]  # positional arg dict
+    assert params["turn"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Integration tests via HTTP client
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_ask_without_session_id_is_backward_compatible(client: AsyncClient):
+    """Omitting session_id still works — no history loaded, no session saved."""
+    mock_db, override = _make_db_override_for_ask()
+    claude_resp = _make_claude_response()
+
+    app.dependency_overrides[get_db] = override
+    try:
+        with patch("app.routers.intelligence._get_anthropic_key", return_value="sk-test"), \
+             patch("app.routers.intelligence.anthropic.Anthropic") as MockClient, \
+             patch("app.routers.intelligence.get_embedding_model") as mock_model, \
+             patch("app.routers.intelligence._find_semantic_cache_hit", new=AsyncMock(return_value=None)), \
+             patch("app.routers.intelligence._log_query", new=AsyncMock()):
+            mock_model.return_value.encode.return_value = np.zeros(384)
+            MockClient.return_value.messages.create.return_value = claude_resp
+            resp = await client.post(
+                "/intelligence/ask",
+                json={"question": "What repos use LangChain?"},
+            )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["answer"] == "Here is my answer."
+    assert data["cache_hit"] is False
+
+
+@pytest.mark.asyncio
+async def test_ask_with_session_id_prepends_history_to_claude(client: AsyncClient):
+    """When session_id is provided, history is passed to Claude's messages array."""
+    # Set up DB to return 1 prior turn
+    prior_row = MagicMock()
+    prior_row.question = "What is LangChain?"
+    prior_row.answer = "LangChain is an LLM orchestration framework."
+
+    mock_db, override = _make_db_override_for_ask(session_rows=[prior_row])
+    claude_resp = _make_claude_response("Here is a follow-up answer.")
+
+    captured_messages = []
+
+    def _fake_create(**kwargs):
+        captured_messages.extend(kwargs.get("messages", []))
+        return claude_resp
+
+    app.dependency_overrides[get_db] = override
+    try:
+        with patch("app.routers.intelligence._get_anthropic_key", return_value="sk-test"), \
+             patch("app.routers.intelligence.anthropic.Anthropic") as MockClient, \
+             patch("app.routers.intelligence.get_embedding_model") as mock_model, \
+             patch("app.routers.intelligence._find_semantic_cache_hit", new=AsyncMock(return_value=None)), \
+             patch("app.routers.intelligence._log_query", new=AsyncMock()), \
+             patch("app.routers.intelligence._save_session_turn", new=AsyncMock()):
+            mock_model.return_value.encode.return_value = np.zeros(384)
+            MockClient.return_value.messages.create.side_effect = _fake_create
+            resp = await client.post(
+                "/intelligence/ask",
+                json={
+                    "question": "How do I use it for RAG?",
+                    "session_id": _SESSION_ID,
+                },
+            )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+
+    # The messages array should have: prior user, prior assistant, current user
+    # (prior rows are reversed: newest-first from DB → oldest-first in messages)
+    # With 1 row returned (the prior turn), messages = [user, assistant, current_user]
+    assert len(captured_messages) >= 3
+    assert captured_messages[0]["role"] == "user"
+    assert captured_messages[0]["content"] == "What is LangChain?"
+    assert captured_messages[1]["role"] == "assistant"
+    assert "LangChain" in captured_messages[1]["content"]
+    assert captured_messages[-1]["role"] == "user"
+    assert "RAG" in captured_messages[-1]["content"]
+
+
+@pytest.mark.asyncio
+async def test_ask_session_id_is_optional_field():
+    """QueryRequest model accepts and defaults session_id to None."""
+    from app.routers.intelligence import QueryRequest
+    req = QueryRequest(question="What is the best RAG framework?")
+    assert req.session_id is None
+
+    req_with_session = QueryRequest(
+        question="What is the best RAG framework?",
+        session_id=_SESSION_ID,
+    )
+    assert req_with_session.session_id == _SESSION_ID

--- a/tests/test_auto_enrich.py
+++ b/tests/test_auto_enrich.py
@@ -1,0 +1,275 @@
+"""
+KAN-157: Tests for POST /ingest/events/repo-added auto-enrichment handler.
+
+Covers:
+- Happy path: Haiku enriches a new repo (quality_signals written, taxonomy inserted)
+- Idempotency: already-enriched repos are skipped
+- Missing repo: returns 200 with status=skipped
+- Missing name in payload: returns 200 with status=skipped
+- Haiku JSON parse error: returns 200 with status=error (Pub/Sub must not retry)
+- Circuit-breaker HTTPException: returns 200 with status=error
+- Cache keys invalidated after successful enrichment
+
+Uses app.dependency_overrides[get_db] + AsyncMock for async I/O — same pattern
+as test_recommendations.py.
+"""
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+from app.database import get_db
+from app.main import app
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_INGEST_HEADERS = {
+    "X-Ingest-Key": "test-ingest-key",
+    "X-API-Key": "test-api-key",
+}
+
+_PUBSUB_PAYLOAD = {
+    "message": {
+        "data": __import__("base64").b64encode(
+            json.dumps({"name_with_owner": "perditioinc/haystack", "stars": 500}).encode()
+        ).decode()
+    }
+}
+
+
+def _make_repo(name="haystack", quality_signals=None):
+    repo = MagicMock()
+    repo.id = "test-uuid-1234"
+    repo.name = name
+    repo.owner = "perditioinc"
+    repo.description = f"The {name} AI framework"
+    repo.primary_language = "Python"
+    repo.forked_from = None
+    repo.quality_signals = quality_signals
+    repo.readme_summary = None
+    repo.problem_solved = None
+    repo.integration_tags = None
+    repo.updated_at = None
+    return repo
+
+
+def _make_haiku_response(data: dict) -> MagicMock:
+    msg = MagicMock()
+    msg.content = [MagicMock(text=json.dumps(data))]
+    msg.usage = MagicMock(input_tokens=320, output_tokens=180)
+    return msg
+
+
+_GOOD_ENRICHMENT = {
+    "readme_summary": "Haystack is an LLM orchestration framework for building NLP pipelines.",
+    "problem_solved": "Simplifies building production RAG and NLP systems.",
+    "quality_assessment": "high",
+    "maturity_level": "production",
+    "skill_areas": ["Retrieval-Augmented Generation", "NLP Pipelines"],
+    "industries": ["Developer Tools"],
+    "use_cases": ["Document Question Answering"],
+    "modalities": ["Text"],
+    "ai_trends": ["Agentic AI"],
+    "deployment_context": ["Cloud API", "Self-hosted"],
+    "integration_tags": ["haystack", "transformers", "faiss"],
+}
+
+
+def _override_db(repo):
+    """Yield a mock DB where scalar_one_or_none returns the given repo."""
+    mock_db = AsyncMock()
+    select_result = MagicMock()
+    select_result.scalar_one_or_none.return_value = repo
+    mock_db.execute = AsyncMock(return_value=select_result)
+    mock_db.flush = AsyncMock()
+    mock_db.commit = AsyncMock()
+    mock_db.add = MagicMock()
+
+    async def _dep():
+        yield mock_db
+
+    return mock_db, _dep
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_repo_added_enriches_new_repo(client: AsyncClient):
+    """Happy path: Haiku is called, quality_signals and readme_summary are set."""
+    repo = _make_repo(quality_signals=None)
+    mock_db, override = _override_db(repo)
+
+    haiku_resp = _make_haiku_response(_GOOD_ENRICHMENT)
+
+    app.dependency_overrides[get_db] = override
+    try:
+        with patch("app.routers.ingest._get_anthropic_key", return_value="sk-test"), \
+             patch("app.routers.ingest._anthropic_lib.Anthropic") as MockClient, \
+             patch("app.routers.ingest.cache.invalidate", new=AsyncMock()), \
+             patch("app.routers.ingest.invalidate_library_cache"):
+            MockClient.return_value.messages.create.return_value = haiku_resp
+            resp = await client.post(
+                "/ingest/events/repo-added",
+                json=_PUBSUB_PAYLOAD,
+                headers=_INGEST_HEADERS,
+            )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["status"] == "ok"
+    assert data["repo"] == "haystack"
+    assert data["enrichment"]["quality"] == "high"
+    assert data["enrichment"]["maturity"] == "production"
+    assert data["enrichment"]["input_tokens"] == 320
+    assert data["enrichment"]["output_tokens"] == 180
+
+    # Verify enrichment fields were written to the repo object
+    assert repo.quality_signals == {"quality": "high", "maturity": "production"}
+    assert "Haystack is an LLM" in repo.readme_summary
+    assert repo.commit.call_count == 0  # db.commit is on the AsyncMock, not repo
+
+
+@pytest.mark.asyncio
+async def test_repo_added_skips_already_enriched(client: AsyncClient):
+    """Repos with existing quality_signals are skipped (idempotent)."""
+    repo = _make_repo(quality_signals={"quality": "high", "maturity": "production"})
+    mock_db, override = _override_db(repo)
+
+    app.dependency_overrides[get_db] = override
+    try:
+        with patch("app.routers.ingest._get_anthropic_key") as mock_key:
+            resp = await client.post(
+                "/ingest/events/repo-added",
+                json=_PUBSUB_PAYLOAD,
+                headers=_INGEST_HEADERS,
+            )
+            mock_key.assert_not_called()
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "skipped"
+    assert resp.json()["reason"] == "already enriched"
+
+
+@pytest.mark.asyncio
+async def test_repo_added_skips_unknown_repo(client: AsyncClient):
+    """Repo not found in DB → skipped with 200, no Haiku call."""
+    mock_db = AsyncMock()
+    not_found = MagicMock()
+    not_found.scalar_one_or_none.return_value = None
+    mock_db.execute = AsyncMock(return_value=not_found)
+
+    async def _override():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = _override
+    try:
+        with patch("app.routers.ingest._get_anthropic_key") as mock_key:
+            resp = await client.post(
+                "/ingest/events/repo-added",
+                json=_PUBSUB_PAYLOAD,
+                headers=_INGEST_HEADERS,
+            )
+            mock_key.assert_not_called()
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "skipped"
+    assert "not found" in resp.json()["reason"]
+
+
+@pytest.mark.asyncio
+async def test_repo_added_skips_empty_payload(client: AsyncClient):
+    """Pub/Sub payload with no repo name → skipped, no DB call."""
+    mock_db = AsyncMock()
+
+    async def _override():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = _override
+    try:
+        resp = await client.post(
+            "/ingest/events/repo-added",
+            json={"message": {"data": __import__("base64").b64encode(b"{}").decode()}},
+            headers=_INGEST_HEADERS,
+        )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "skipped"
+    mock_db.execute.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_repo_added_handles_haiku_json_error(client: AsyncClient):
+    """Haiku returns unparseable JSON → 200 with status=error (Pub/Sub won't retry)."""
+    repo = _make_repo(quality_signals=None)
+    mock_db, override = _override_db(repo)
+
+    bad_msg = MagicMock()
+    bad_msg.content = [MagicMock(text="not valid json at all")]
+    bad_msg.usage = MagicMock(input_tokens=200, output_tokens=10)
+
+    app.dependency_overrides[get_db] = override
+    try:
+        with patch("app.routers.ingest._get_anthropic_key", return_value="sk-test"), \
+             patch("app.routers.ingest._anthropic_lib.Anthropic") as MockClient:
+            MockClient.return_value.messages.create.return_value = bad_msg
+            resp = await client.post(
+                "/ingest/events/repo-added",
+                json=_PUBSUB_PAYLOAD,
+                headers=_INGEST_HEADERS,
+            )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "error"
+    assert resp.json()["reason"] == "json_parse_error"
+
+
+@pytest.mark.asyncio
+async def test_repo_added_name_with_owner_parsed_correctly(client: AsyncClient):
+    """name_with_owner 'owner/haystack' → resolves to bare name 'haystack'."""
+    repo = _make_repo(name="haystack", quality_signals=None)
+    mock_db, override = _override_db(repo)
+    haiku_resp = _make_haiku_response(_GOOD_ENRICHMENT)
+
+    import base64
+    payload_with_owner = {
+        "message": {
+            "data": base64.b64encode(
+                json.dumps({"name_with_owner": "deepset-ai/haystack"}).encode()
+            ).decode()
+        }
+    }
+
+    app.dependency_overrides[get_db] = override
+    try:
+        with patch("app.routers.ingest._get_anthropic_key", return_value="sk-test"), \
+             patch("app.routers.ingest._anthropic_lib.Anthropic") as MockClient, \
+             patch("app.routers.ingest.cache.invalidate", new=AsyncMock()), \
+             patch("app.routers.ingest.invalidate_library_cache"):
+            MockClient.return_value.messages.create.return_value = haiku_resp
+            resp = await client.post(
+                "/ingest/events/repo-added",
+                json=payload_with_owner,
+                headers=_INGEST_HEADERS,
+            )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+    assert resp.json()["repo"] == "haystack"

--- a/tests/test_nl_filter.py
+++ b/tests/test_nl_filter.py
@@ -1,0 +1,165 @@
+"""
+KAN-155: Tests for POST /intelligence/nl-filter.
+
+Validates request contract, caching behaviour, Haiku response parsing,
+field validation/normalisation, and query_params construction — without
+requiring a real Anthropic API key or DB connection.
+"""
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mock_haiku_response(data: dict) -> MagicMock:
+    """Build a fake anthropic.messages.create response containing JSON."""
+    msg = MagicMock()
+    msg.content = [MagicMock(text=json.dumps(data))]
+    return msg
+
+
+_GOOD_PARSE = {
+    "language": "python",
+    "category": "rag-retrieval",
+    "min_stars": 1000,
+    "max_stars": None,
+    "sort": "stars",
+    "tags": ["rag", "langchain"],
+    "quality": "high",
+    "maturity": "production",
+    "exclude_archived": True,
+    "interpretation": "Python · RAG & Retrieval · 1,000+ stars",
+}
+
+
+# ---------------------------------------------------------------------------
+# Contract: request validation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_nl_filter_requires_query(client: AsyncClient):
+    resp = await client.post("/intelligence/nl-filter", json={})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_nl_filter_query_too_short(client: AsyncClient):
+    resp = await client.post("/intelligence/nl-filter", json={"query": "ab"})
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_nl_filter_query_too_long(client: AsyncClient):
+    resp = await client.post("/intelligence/nl-filter", json={"query": "x" * 301})
+    assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Happy path: Haiku returns valid JSON
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_nl_filter_happy_path(client: AsyncClient):
+    mock_resp = _mock_haiku_response(_GOOD_PARSE)
+    breaker_mock = MagicMock(call=lambda fn: fn())
+
+    with patch("app.routers.nl_filter._get_anthropic_key", return_value="sk-test"), \
+         patch("app.routers.nl_filter.anthropic_breaker", breaker_mock), \
+         patch("anthropic.Anthropic") as MockAnthropic, \
+         patch("app.routers.nl_filter.cache.get", return_value=None), \
+         patch("app.routers.nl_filter.cache.set"):
+        MockAnthropic.return_value.messages.create.return_value = mock_resp
+        resp = await client.post("/intelligence/nl-filter", json={"query": "Python RAG repos with 1000 stars"})
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["language"] == "python"
+    assert data["category"] == "rag-retrieval"
+    assert data["min_stars"] == 1000
+    assert data["sort"] == "stars"
+    assert data["exclude_archived"] is True
+    assert "Python" in data["interpretation"]
+    # query_params should be a usable URL fragment
+    assert "language=python" in data["query_params"]
+    assert "min_stars=1000" in data["query_params"]
+
+
+# ---------------------------------------------------------------------------
+# Normalisation: invalid category / sort / quality are nulled out
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_nl_filter_invalid_category_nulled(client: AsyncClient):
+    bad = {**_GOOD_PARSE, "category": "not-a-real-category"}
+    mock_resp = _mock_haiku_response(bad)
+    breaker_mock = MagicMock(call=lambda fn: fn())
+
+    with patch("app.routers.nl_filter._get_anthropic_key", return_value="sk-test"), \
+         patch("app.routers.nl_filter.anthropic_breaker", breaker_mock), \
+         patch("anthropic.Anthropic") as MockAnthropic, \
+         patch("app.routers.nl_filter.cache.get", return_value=None), \
+         patch("app.routers.nl_filter.cache.set"):
+        MockAnthropic.return_value.messages.create.return_value = mock_resp
+        resp = await client.post("/intelligence/nl-filter", json={"query": "Python RAG repos"})
+
+    assert resp.status_code == 200
+    assert resp.json()["category"] is None
+
+
+@pytest.mark.asyncio
+async def test_nl_filter_tags_truncated_to_five(client: AsyncClient):
+    many_tags = {**_GOOD_PARSE, "tags": ["a", "b", "c", "d", "e", "f", "g"]}
+    mock_resp = _mock_haiku_response(many_tags)
+    breaker_mock = MagicMock(call=lambda fn: fn())
+
+    with patch("app.routers.nl_filter._get_anthropic_key", return_value="sk-test"), \
+         patch("app.routers.nl_filter.anthropic_breaker", breaker_mock), \
+         patch("anthropic.Anthropic") as MockAnthropic, \
+         patch("app.routers.nl_filter.cache.get", return_value=None), \
+         patch("app.routers.nl_filter.cache.set"):
+        MockAnthropic.return_value.messages.create.return_value = mock_resp
+        resp = await client.post("/intelligence/nl-filter", json={"query": "repos with lots of tags"})
+
+    assert resp.status_code == 200
+    assert len(resp.json()["tags"]) <= 5
+
+
+# ---------------------------------------------------------------------------
+# Cache hit: Haiku is never called
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_nl_filter_cache_hit_skips_haiku(client: AsyncClient):
+    cached = {**_GOOD_PARSE, "query_params": "language=python&min_stars=1000"}
+    with patch("app.routers.nl_filter.cache.get", return_value=cached):
+        with patch("app.routers.nl_filter._get_anthropic_key") as mock_key:
+            resp = await client.post("/intelligence/nl-filter", json={"query": "Python RAG repos"})
+            mock_key.assert_not_called()
+
+    assert resp.status_code == 200
+    assert resp.json()["language"] == "python"
+
+
+# ---------------------------------------------------------------------------
+# Error handling: Haiku returns unparseable JSON
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_nl_filter_json_parse_error_returns_502(client: AsyncClient):
+    bad_msg = MagicMock()
+    bad_msg.content = [MagicMock(text="this is not json at all")]
+    breaker_mock = MagicMock(call=lambda fn: fn())
+
+    with patch("app.routers.nl_filter._get_anthropic_key", return_value="sk-test"), \
+         patch("app.routers.nl_filter.anthropic_breaker", breaker_mock), \
+         patch("anthropic.Anthropic") as MockAnthropic, \
+         patch("app.routers.nl_filter.cache.get", return_value=None):
+        MockAnthropic.return_value.messages.create.return_value = bad_msg
+        resp = await client.post("/intelligence/nl-filter", json={"query": "active Python repos"})
+
+    assert resp.status_code == 502

--- a/tests/test_recommendations.py
+++ b/tests/test_recommendations.py
@@ -1,0 +1,233 @@
+"""
+KAN-156: Tests for GET /intelligence/similar/{name} and GET /intelligence/recommended.
+
+Uses app.dependency_overrides[get_db] for DB injection and AsyncMock for
+async cache methods — same pattern as test_intelligence_quality.py.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+from app.database import get_db
+from app.main import app
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_row(name="langchain", similarity=0.85):
+    row = MagicMock()
+    row.name = name
+    row.owner = "perditioinc"
+    row.description = f"The {name} framework"
+    row.primary_language = "Python"
+    row.primary_category = "rag-retrieval"
+    row.stars = 1000
+    row.readme_summary = f"A helpful {name} summary."
+    row.similarity = similarity
+    return row
+
+
+def _override_db_with_rows(rows):
+    """Yield a mock db session whose execute() returns rows via fetchall()."""
+    mock_db = AsyncMock()
+    result = MagicMock()
+    result.fetchall.return_value = rows
+    mock_db.execute = AsyncMock(return_value=result)
+
+    async def _override():
+        yield mock_db
+
+    return mock_db, _override
+
+
+def _override_db_multi(call_results: list):
+    """Successive execute() calls return successive row lists."""
+    call_idx = 0
+
+    async def _execute(*args, **kwargs):
+        nonlocal call_idx
+        res = MagicMock()
+        res.fetchall.return_value = call_results[min(call_idx, len(call_results) - 1)]
+        call_idx += 1
+        return res
+
+    mock_db = AsyncMock()
+    mock_db.execute = _execute
+
+    async def _override():
+        yield mock_db
+
+    return mock_db, _override
+
+
+# ---------------------------------------------------------------------------
+# GET /intelligence/similar/{name}
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_similar_repos_returns_results(client: AsyncClient):
+    rows = [_make_row("llama-index", 0.91), _make_row("haystack", 0.82)]
+    _, override = _override_db_with_rows(rows)
+
+    app.dependency_overrides[get_db] = override
+    try:
+        with patch("app.routers.recommendations.cache.get", new=AsyncMock(return_value=None)), \
+             patch("app.routers.recommendations.cache.set", new=AsyncMock()):
+            resp = await client.get("/intelligence/similar/langchain")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["source_repo"] == "langchain"
+    assert len(data["similar"]) == 2
+    assert data["similar"][0]["similarity"] == 0.91
+    assert data["total"] == 2
+
+
+@pytest.mark.asyncio
+async def test_similar_repos_empty_when_no_embedding(client: AsyncClient):
+    """Repo exists but has no embedding — returns empty list, not 404."""
+    empty_result = MagicMock()
+    empty_result.fetchall.return_value = []
+    exists_result = MagicMock()
+    exists_result.fetchone.return_value = MagicMock()  # repo found
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(side_effect=[empty_result, exists_result])
+
+    async def _override():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = _override
+    try:
+        with patch("app.routers.recommendations.cache.get", new=AsyncMock(return_value=None)), \
+             patch("app.routers.recommendations.cache.set", new=AsyncMock()):
+            resp = await client.get("/intelligence/similar/langchain")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 0
+    assert resp.json()["similar"] == []
+
+
+@pytest.mark.asyncio
+async def test_similar_repos_404_for_unknown(client: AsyncClient):
+    empty_result = MagicMock()
+    empty_result.fetchall.return_value = []
+    no_repo = MagicMock()
+    no_repo.fetchone.return_value = None
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(side_effect=[empty_result, no_repo])
+
+    async def _override():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = _override
+    try:
+        with patch("app.routers.recommendations.cache.get", new=AsyncMock(return_value=None)):
+            resp = await client.get("/intelligence/similar/definitely-does-not-exist")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_similar_repos_cache_hit_skips_db(client: AsyncClient):
+    cached = {
+        "source_repo": "langchain",
+        "similar": [{"name": "llama-index", "owner": "o", "description": None,
+                     "primary_language": "Python", "primary_category": "rag-retrieval",
+                     "stars": 500, "similarity": 0.88, "readme_summary": None}],
+        "total": 1,
+    }
+    mock_db = AsyncMock()
+
+    async def _override():
+        yield mock_db
+
+    app.dependency_overrides[get_db] = _override
+    try:
+        with patch("app.routers.recommendations.cache.get", new=AsyncMock(return_value=cached)):
+            resp = await client.get("/intelligence/similar/langchain")
+        mock_db.execute.assert_not_called()
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# GET /intelligence/recommended
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_recommended_requires_seeds(client: AsyncClient):
+    resp = await client.get("/intelligence/recommended")
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_recommended_deduplicates_keeps_best_score(client: AsyncClient):
+    """Same repo from two seeds — keep only the higher similarity score."""
+    rows_seed1 = [_make_row("shared-repo", 0.90)]
+    rows_seed2 = [_make_row("shared-repo", 0.75), _make_row("unique-repo", 0.80)]
+    _, override = _override_db_multi([rows_seed1, rows_seed2])
+
+    app.dependency_overrides[get_db] = override
+    try:
+        with patch("app.routers.recommendations.cache.get", new=AsyncMock(return_value=None)), \
+             patch("app.routers.recommendations.cache.set", new=AsyncMock()):
+            resp = await client.get("/intelligence/recommended?seeds=langchain,llama-index")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+    recs = resp.json()["recommended"]
+    names = [r["name"] for r in recs]
+    assert names.count("shared-repo") == 1
+    shared = next(r for r in recs if r["name"] == "shared-repo")
+    assert shared["similarity"] == 0.90  # best score kept, not 0.75
+
+
+@pytest.mark.asyncio
+async def test_recommended_excludes_seed_repos(client: AsyncClient):
+    """A seed repo should never appear in its own recommendations."""
+    rows = [_make_row("langchain", 0.99), _make_row("haystack", 0.82)]
+    _, override = _override_db_with_rows(rows)
+
+    app.dependency_overrides[get_db] = override
+    try:
+        with patch("app.routers.recommendations.cache.get", new=AsyncMock(return_value=None)), \
+             patch("app.routers.recommendations.cache.set", new=AsyncMock()):
+            resp = await client.get("/intelligence/recommended?seeds=langchain")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    names = [r["name"] for r in resp.json()["recommended"]]
+    assert "langchain" not in names
+    assert "haystack" in names
+
+
+@pytest.mark.asyncio
+async def test_recommended_max_5_seeds(client: AsyncClient):
+    """More than 5 comma-separated seeds are silently truncated to 5."""
+    _, override = _override_db_with_rows([])
+
+    app.dependency_overrides[get_db] = override
+    try:
+        with patch("app.routers.recommendations.cache.get", new=AsyncMock(return_value=None)), \
+             patch("app.routers.recommendations.cache.set", new=AsyncMock()):
+            resp = await client.get("/intelligence/recommended?seeds=a,b,c,d,e,f,g,h")
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert resp.status_code == 200
+    assert len(resp.json()["seeds"]) == 5


### PR DESCRIPTION
## Summary

- Adds optional `session_id` (UUID string) to `QueryRequest` — fully backward compatible (defaults to `null`)
- When `session_id` is provided, the last 3 turns of that session are loaded from `ask_sessions` and prepended to Claude's `messages` array as alternating `user`/`assistant` pairs
- After each answer, the new turn is saved fire-and-forget to `ask_sessions`
- New Alembic migration (`021`) creates the `ask_sessions` table

## How it works

```json
POST /intelligence/ask
{
  "question": "How does it handle streaming?",
  "session_id": "550e8400-e29b-41d4-a716-446655440000"
}
```

Claude receives:
```
[user]      "What is LangChain?"          ← turn 0, loaded from ask_sessions
[assistant] "LangChain is an LLM framework."
[user]      "How does it handle streaming?" ← current question
```

## Design decisions

| Decision | Rationale |
|---|---|
| Client-provided session_id | Stateless server; client owns the session lifecycle |
| Last 3 turns only | Keeps token cost bounded; Claude context window not saturated |
| 24h turn expiry | Stale sessions don't pollute responses |
| Fire-and-forget saves | Turn saving never blocks the response |
| Non-fatal load/save errors | DB issues degrade to stateless mode, not 500 |
| Separate `ask_sessions` table | Keeps `query_log` clean; sessions have different retention |

## Test plan

- [x] `test_load_session_turns_returns_oldest_first` — newest-first DB rows reversed to correct order
- [x] `test_load_session_turns_returns_empty_on_db_error` — DB failure → graceful degradation
- [x] `test_save_session_turn_does_not_raise_on_error` — save failure is non-fatal
- [x] `test_save_session_turn_increments_turn_number` — turn_number = MAX + 1
- [x] `test_ask_without_session_id_is_backward_compatible` — no session_id = stateless
- [x] `test_ask_with_session_id_prepends_history_to_claude` — history in Claude messages array
- [x] `test_ask_session_id_is_optional_field` — Pydantic model defaults session_id to None
- [x] Full suite: 217 passed, 2 skipped (no regressions)

## Migration

```
alembic upgrade head
```

Creates `ask_sessions` table + index on `(session_id, turn_number)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)