### PR TITLE
KAN-155: fix POST /intelligence/nl-filter — circuit breaker AttributeError

### DIFF
--- a/app/routers/nl_filter.py
+++ b/app/routers/nl_filter.py
@@ -18,6 +18,7 @@ Example output: {
 The structured output maps directly to existing query params on GET /repos.
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -154,7 +155,8 @@ async def nl_filter(request: Request, body: NLFilterRequest) -> NLFilterResponse
                 messages=[{"role": "user", "content": prompt}],
             )
 
-        response = anthropic_breaker.call(_call_haiku)
+        with anthropic_breaker:
+            response = await asyncio.to_thread(_call_haiku)
         raw = response.content[0].text.strip()
 
         # Strip markdown fences if present


### PR DESCRIPTION
## Summary
- `anthropic_breaker.call()` does not exist; `CircuitBreaker` is a context manager only
- Every `POST /intelligence/nl-filter` was 500-ing with "Filter service unavailable"
- Fix: replace `.call(_call_haiku)` with `with anthropic_breaker: await asyncio.to_thread(_call_haiku)` — matches the pattern in `ingest.py`

## Root cause
`nl_filter.py` was written using a hypothetical `.call()` API that was never implemented on `CircuitBreaker`. The class only exposes `__enter__`/`__exit__`.

## Test plan
- [ ] `POST /intelligence/nl-filter` returns structured JSON (was previously always 500)
- [ ] Rate limiting still enforced (30/min per IP)
- [ ] Circuit breaker opens on Anthropic failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)