### PR TITLE
KAN-124: Add CORS for Vercel preview URLs and localhost

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -180,11 +180,13 @@ _ALLOWED_ORIGINS = [
     "https://reporium.com",
     "https://www.reporium.com",
     "https://perditioinc.github.io",
+    "http://localhost:3000",
 ]
 
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_ALLOWED_ORIGINS,
+    allow_origin_regex=r"https://reporium.*\.vercel\.app",
     allow_methods=["GET", "POST"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
## Summary
- Add `allow_origin_regex` for Vercel preview deployment URLs (`reporium*.vercel.app`)
- Add `localhost:3000` to allowed origins for local dev
- Required for KAN-124 knowledge graph testing on preview deployments

## Test plan
- [ ] Verify reporium.com/graph still loads (existing CORS)
- [ ] Verify Vercel preview deployment graph page loads
- [ ] Verify localhost:3000/graph loads during local dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)