### PR TITLE
KAN-124: Smart routing v2 + prompt caching + streaming fixes

### DIFF
--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -1,5 +1,6 @@
 import json
 import logging
+from dataclasses import dataclass, field as dc_field
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from pydantic import BaseModel
@@ -404,98 +405,167 @@ async def backfill_embeddings(
     return {"backfilled": backfilled, "vec_synced": synced, "errors": errors}
 
 
-# ── AI agent protocol tagging ─────────────────────────────────────────────────
-# Detects CLI, MCP, and A2A protocol indicators from repo name, description,
-# tags, and readme_summary. Zero LLM cost — pure keyword matching.
+# ── AI agent protocol & framework tagging ────────────────────────────────────
+# Detects protocols, AI frameworks, and SDK indicators from repo name,
+# description, readme_summary, and tags. Zero LLM cost — pure keyword matching.
+#
+# Keywords are split into two confidence tiers:
+#   "strong"  — Unambiguous identifiers. One match is enough to tag.
+#               e.g. "langchain", "crewai", "mcp-server"
+#   "weak"    — Generic words that ALSO happen to be library/concept names.
+#               e.g. "transformers", "datasets", "eval", "adapter"
+#               A weak keyword only fires when CORROBORATED by:
+#                 • at least ONE strong keyword for the same tag, OR
+#                 • at least TWO weak keywords for the same tag
+#
+# This eliminates false positives like tagging a generic CSV-parsing repo
+# "HuggingFace" just because its description mentions "datasets".
 
-_PROTOCOL_RULES: list[tuple[str, list[str]]] = [
-    # --- Protocols ---
-    ("MCP", [
+@dataclass
+class TagRule:
+    """One tagging rule with confidence-tiered keywords."""
+    tag: str
+    strong: list[str] = dc_field(default_factory=list)  # one match → tag
+    weak: list[str] = dc_field(default_factory=list)    # needs corroboration
+
+
+_TAG_RULES: list[TagRule] = [
+    # ── Protocols ──
+    TagRule("MCP", strong=[
         "mcp", "model context protocol", "mcp-server", "mcp server",
         "model-context-protocol", "mcp-client", "mcp plugin",
         "mcp-tool", "modelcontextprotocol",
     ]),
-    ("CLI", [
-        "cli tool", "command-line", "command line interface",
-        "cli interface", "terminal tool", "cli app", "cli utility",
-        "command line tool", "cli framework", "cli library",
+    TagRule("CLI", strong=[
+        "cli tool", "command-line tool", "command line interface",
+        "cli interface", "cli app", "cli utility", "cli framework",
+        "cli library",
+    ], weak=[
+        "command-line", "terminal tool",
     ]),
-    ("A2A", [
+    TagRule("A2A", strong=[
         "a2a", "agent-to-agent", "agent to agent", "a2a protocol",
-        "inter-agent", "multi-agent communication", "agent communication",
-        "agent protocol",
+        "inter-agent",
+    ], weak=[
+        "multi-agent communication", "agent communication", "agent protocol",
     ]),
-    # --- AI Frameworks & SDKs ---
-    ("LangChain", [
+    # ── AI Frameworks & SDKs ──
+    TagRule("LangChain", strong=[
         "langchain", "lang-chain", "langchain-community", "langserve",
         "langsmith", "langgraph",
     ]),
-    ("LlamaIndex", [
+    TagRule("LlamaIndex", strong=[
         "llamaindex", "llama-index", "llama_index", "gpt-index",
     ]),
-    ("CrewAI", [
+    TagRule("CrewAI", strong=[
         "crewai", "crew-ai", "crew ai",
     ]),
-    ("AutoGen", [
-        "autogen", "auto-gen", "pyautogen", "ag2",
+    TagRule("AutoGen", strong=[
+        "autogen", "pyautogen",
+    ], weak=[
+        "auto-gen", "ag2",
     ]),
-    ("Ollama", [
+    TagRule("Ollama", strong=[
         "ollama",
     ]),
-    ("vLLM", [
-        "vllm", "v-llm",
+    TagRule("vLLM", strong=[
+        "vllm",
+    ], weak=[
+        "v-llm",
     ]),
-    ("HuggingFace", [
-        "huggingface", "hugging face", "transformers", "diffusers",
-        "datasets", "accelerate", "peft", "trl",
+    TagRule("HuggingFace", strong=[
+        "huggingface", "hugging face", "huggingface.co",
+        "from_pretrained",  # unmistakable HF API call
+    ], weak=[
+        "transformers", "diffusers", "datasets", "accelerate",
+        "peft", "trl", "tokenizer",
     ]),
-    ("OpenAI", [
-        "openai", "gpt-4", "gpt-3", "chatgpt", "whisper", "dall-e",
+    TagRule("OpenAI", strong=[
+        "openai", "openai api", "openai-python",
+    ], weak=[
+        "gpt-4", "gpt-3", "chatgpt", "whisper", "dall-e",
     ]),
-    ("Anthropic", [
-        "anthropic", "claude", "claude-api",
+    TagRule("Anthropic", strong=[
+        "anthropic", "anthropic api", "claude-api",
+    ], weak=[
+        "claude",
     ]),
-    ("Vercel AI SDK", [
+    TagRule("Vercel AI SDK", strong=[
         "ai sdk", "vercel ai", "@ai-sdk",
     ]),
-    ("Streamlit", [
+    TagRule("Streamlit", strong=[
         "streamlit",
     ]),
-    ("Gradio", [
+    TagRule("Gradio", strong=[
         "gradio",
     ]),
-    ("FastAPI", [
-        "fastapi", "fast-api",
+    TagRule("FastAPI", strong=[
+        "fastapi",
+    ], weak=[
+        "fast-api",
     ]),
-    ("Docker", [
-        "docker", "dockerfile", "docker-compose", "containerized",
+    TagRule("Docker", strong=[
+        "dockerfile", "docker-compose", "docker compose",
+    ], weak=[
+        "docker", "containerized",
     ]),
-    ("Kubernetes", [
-        "kubernetes", "k8s", "helm chart",
+    TagRule("Kubernetes", strong=[
+        "kubernetes", "k8s",
+    ], weak=[
+        "helm chart",
     ]),
-    ("RAG", [
+    # ── AI Patterns ──
+    TagRule("RAG", strong=[
         "rag pipeline", "retrieval augmented", "retrieval-augmented",
-        "vector search", "vector database", "vector store",
-        "chromadb", "chroma", "pinecone", "weaviate", "qdrant", "milvus",
+        "chromadb", "pinecone", "weaviate", "qdrant", "milvus",
+    ], weak=[
+        "vector search", "vector database", "vector store", "chroma",
     ]),
-    ("Fine-Tuning", [
-        "fine-tune", "fine-tuning", "finetuning", "finetune", "lora",
-        "qlora", "adapter", "sft", "rlhf", "dpo",
+    TagRule("Fine-Tuning", strong=[
+        "fine-tune", "fine-tuning", "finetuning", "finetune",
+        "lora", "qlora", "rlhf", "dpo",
+    ], weak=[
+        "adapter", "sft",
     ]),
-    ("Agents", [
-        "ai agent", "autonomous agent", "agent framework", "tool-use",
-        "tool use", "function calling", "tool calling", "agentic",
-        "multi-agent", "agent orchestration",
+    TagRule("Agents", strong=[
+        "ai agent", "autonomous agent", "agent framework", "agentic",
+        "agent orchestration",
+    ], weak=[
+        "tool-use", "tool use", "function calling", "tool calling",
+        "multi-agent",
     ]),
-    ("Evaluation", [
+    TagRule("Evaluation", strong=[
+        "llm eval", "llm evaluation", "llm benchmark", "llm judge",
+        "model evaluation", "red teaming", "evals framework",
+    ], weak=[
         "eval", "evaluation", "benchmark", "leaderboard", "scoring",
-        "llm judge", "red team",
+        "red team",
     ]),
-    ("Prompt Engineering", [
+    TagRule("Prompt Engineering", strong=[
         "prompt engineering", "prompt template", "prompt management",
-        "prompt chain", "prompt optimization", "dspy",
+        "prompt optimization", "dspy",
+    ], weak=[
+        "prompt chain",
     ]),
 ]
+
+
+def _match_tag_rule(rule: TagRule, search_text: str) -> bool:
+    """
+    Return True if the repo text qualifies for this tag.
+
+    Logic:
+      • Any strong keyword match → True immediately
+      • Weak keywords alone need corroboration:
+        – 2+ weak matches → True
+        – 1 weak match alone → False (too noisy)
+    """
+    strong_hits = sum(1 for kw in rule.strong if kw in search_text)
+    if strong_hits > 0:
+        return True
+
+    weak_hits = sum(1 for kw in rule.weak if kw in search_text)
+    return weak_hits >= 2
 
 
 @router.post("/admin/tags/protocols", response_model=dict)
@@ -508,9 +578,14 @@ async def tag_protocols(
     """
     Scan all public repos and tag with protocol indicators (MCP, CLI, A2A)
     and AI framework/SDK tags (LangChain, LlamaIndex, CrewAI, AutoGen,
-    Ollama, vLLM, HuggingFace, OpenAI, Anthropic, etc.) based on keyword
-    matching in name, description, readme_summary, and tags.
-    Zero LLM cost — pure keyword matching.
+    Ollama, vLLM, HuggingFace, OpenAI, Anthropic, etc.) using confidence-
+    tiered keyword matching.
+
+    Strong keywords (e.g. "langchain", "crewai") tag on a single match.
+    Weak keywords (e.g. "transformers", "datasets", "eval") require 2+
+    matches to tag — prevents false positives on generic terms.
+
+    Zero LLM cost — pure keyword matching with noise filtering.
     """
     # Fetch repos with their text fields and existing tags
     result = await db.execute(text("""
@@ -524,7 +599,8 @@ async def tag_protocols(
     """))
     rows = result.fetchall()
 
-    tagged: dict[str, list[str]] = {}  # protocol → list of repo names
+    tagged: dict[str, list[str]] = {}  # tag → list of repo names
+    matched_by: dict[str, dict[str, str]] = {}  # tag → {repo: match_type}
     inserts = 0
     skipped = 0
 
@@ -534,10 +610,14 @@ async def tag_protocols(
             row.name, row.description, row.readme_summary, row.all_tags,
         ])).lower()
 
-        for protocol, keywords in _PROTOCOL_RULES:
-            if any(kw in search_text for kw in keywords):
+        for rule in _TAG_RULES:
+            if _match_tag_rule(rule, search_text):
+                # Determine which tier matched for diagnostics
+                strong_hit = any(kw in search_text for kw in rule.strong)
+                match_type = "strong" if strong_hit else "weak×2+"
                 if dry_run:
-                    tagged.setdefault(protocol, []).append(row.name)
+                    tagged.setdefault(rule.tag, []).append(row.name)
+                    matched_by.setdefault(rule.tag, {})[row.name] = match_type
                     continue
                 try:
                     async with db.begin_nested():
@@ -545,9 +625,10 @@ async def tag_protocols(
                             INSERT INTO repo_tags (repo_id, tag)
                             VALUES (:repo_id, :tag)
                             ON CONFLICT (repo_id, tag) DO NOTHING
-                        """), {"repo_id": str(row.id), "tag": protocol})
+                        """), {"repo_id": str(row.id), "tag": rule.tag})
                     inserts += 1
-                    tagged.setdefault(protocol, []).append(row.name)
+                    tagged.setdefault(rule.tag, []).append(row.name)
+                    matched_by.setdefault(rule.tag, {})[row.name] = match_type
                 except Exception:
                     skipped += 1
 
@@ -560,7 +641,17 @@ async def tag_protocols(
         "tagged_count": sum(len(v) for v in tagged.values()),
         "inserts": inserts,
         "skipped": skipped,
-        "protocols": {k: {"count": len(v), "repos": sorted(v)} for k, v in tagged.items()},
+        "tags": {
+            k: {
+                "count": len(v),
+                "repos": sorted(v),
+                "match_breakdown": {
+                    "strong": sum(1 for r in v if matched_by.get(k, {}).get(r) == "strong"),
+                    "weak_corroborated": sum(1 for r in v if matched_by.get(k, {}).get(r) == "weak×2+"),
+                },
+            }
+            for k, v in tagged.items()
+        },
     }
 
 

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -409,18 +409,91 @@ async def backfill_embeddings(
 # tags, and readme_summary. Zero LLM cost — pure keyword matching.
 
 _PROTOCOL_RULES: list[tuple[str, list[str]]] = [
+    # --- Protocols ---
     ("MCP", [
         "mcp", "model context protocol", "mcp-server", "mcp server",
         "model-context-protocol", "mcp-client", "mcp plugin",
+        "mcp-tool", "modelcontextprotocol",
     ]),
     ("CLI", [
         "cli tool", "command-line", "command line interface",
         "cli interface", "terminal tool", "cli app", "cli utility",
-        "command line tool",
+        "command line tool", "cli framework", "cli library",
     ]),
     ("A2A", [
         "a2a", "agent-to-agent", "agent to agent", "a2a protocol",
-        "inter-agent", "multi-agent communication",
+        "inter-agent", "multi-agent communication", "agent communication",
+        "agent protocol",
+    ]),
+    # --- AI Frameworks & SDKs ---
+    ("LangChain", [
+        "langchain", "lang-chain", "langchain-community", "langserve",
+        "langsmith", "langgraph",
+    ]),
+    ("LlamaIndex", [
+        "llamaindex", "llama-index", "llama_index", "gpt-index",
+    ]),
+    ("CrewAI", [
+        "crewai", "crew-ai", "crew ai",
+    ]),
+    ("AutoGen", [
+        "autogen", "auto-gen", "pyautogen", "ag2",
+    ]),
+    ("Ollama", [
+        "ollama",
+    ]),
+    ("vLLM", [
+        "vllm", "v-llm",
+    ]),
+    ("HuggingFace", [
+        "huggingface", "hugging face", "transformers", "diffusers",
+        "datasets", "accelerate", "peft", "trl",
+    ]),
+    ("OpenAI", [
+        "openai", "gpt-4", "gpt-3", "chatgpt", "whisper", "dall-e",
+    ]),
+    ("Anthropic", [
+        "anthropic", "claude", "claude-api",
+    ]),
+    ("Vercel AI SDK", [
+        "ai sdk", "vercel ai", "@ai-sdk",
+    ]),
+    ("Streamlit", [
+        "streamlit",
+    ]),
+    ("Gradio", [
+        "gradio",
+    ]),
+    ("FastAPI", [
+        "fastapi", "fast-api",
+    ]),
+    ("Docker", [
+        "docker", "dockerfile", "docker-compose", "containerized",
+    ]),
+    ("Kubernetes", [
+        "kubernetes", "k8s", "helm chart",
+    ]),
+    ("RAG", [
+        "rag pipeline", "retrieval augmented", "retrieval-augmented",
+        "vector search", "vector database", "vector store",
+        "chromadb", "chroma", "pinecone", "weaviate", "qdrant", "milvus",
+    ]),
+    ("Fine-Tuning", [
+        "fine-tune", "fine-tuning", "finetuning", "finetune", "lora",
+        "qlora", "adapter", "sft", "rlhf", "dpo",
+    ]),
+    ("Agents", [
+        "ai agent", "autonomous agent", "agent framework", "tool-use",
+        "tool use", "function calling", "tool calling", "agentic",
+        "multi-agent", "agent orchestration",
+    ]),
+    ("Evaluation", [
+        "eval", "evaluation", "benchmark", "leaderboard", "scoring",
+        "llm judge", "red team",
+    ]),
+    ("Prompt Engineering", [
+        "prompt engineering", "prompt template", "prompt management",
+        "prompt chain", "prompt optimization", "dspy",
     ]),
 ]
 
@@ -434,7 +507,9 @@ async def tag_protocols(
 ):
     """
     Scan all public repos and tag with protocol indicators (MCP, CLI, A2A)
-    based on keyword matching in name, description, readme_summary, and tags.
+    and AI framework/SDK tags (LangChain, LlamaIndex, CrewAI, AutoGen,
+    Ollama, vLLM, HuggingFace, OpenAI, Anthropic, etc.) based on keyword
+    matching in name, description, readme_summary, and tags.
     Zero LLM cost — pure keyword matching.
     """
     # Fetch repos with their text fields and existing tags

--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -77,9 +77,14 @@ _ROUTE_TOP_STARRED = re.compile(
     re.IGNORECASE,
 )
 _ROUTE_REPO_INFO = re.compile(
-    r"^(what is|tell me about|describe|info about|show me|explain)\s+(?:the\s+)?(?:repo(?:sitory)?\s+)?(?P<name>[a-zA-Z0-9_-]+(?:/[a-zA-Z0-9_-]+)?)\s*\?*$",
+    r"^(what is|tell me about|describe|info about|explain)\s+(?:the\s+)?(?:repo(?:sitory)?\s+)?(?P<name>[a-zA-Z0-9_-]+(?:/[a-zA-Z0-9_-]+)?)\s*\?*$",
     re.IGNORECASE,
 )
+# Words that look like repo names but aren't — prevent false repo lookups
+_REPO_INFO_BLACKLIST = {
+    "stats", "statistics", "categories", "languages", "tags", "reporium",
+    "this", "that", "it", "everything", "all", "nothing", "the",
+}
 _ROUTE_COUNT_LANGUAGE = re.compile(
     r"^how many\s+(?:repos?|repositories|tools?|projects?)\s+(?:are\s+)?(?:written\s+)?(?:in|use|using)\s+(?P<lang>[a-zA-Z0-9#+]+)\s*\?*$",
     re.IGNORECASE,
@@ -93,7 +98,7 @@ _ROUTE_COUNT_TAGS = re.compile(
     re.IGNORECASE,
 )
 _ROUTE_STATS = re.compile(
-    r"^(what are|show|give me|tell me)\s+(?:the\s+)?(?:overall\s+)?(?:library\s+)?stats\s*\?*$",
+    r"^(what are|show|give me|tell me|get)\s+(?:me\s+)?(?:the\s+)?(?:overall\s+)?(?:library\s+)?(?:repo(?:sitory)?\s+)?stats(?:istics)?\s*\?*$",
     re.IGNORECASE,
 )
 
@@ -200,45 +205,45 @@ async def _try_smart_route(question: str, db: AsyncSession) -> dict | None:
     m = _ROUTE_REPO_INFO.match(q)
     if m:
         name = m.group("name").strip()
-        # Try exact match, then LIKE match
-        result = await db.execute(text("""
-            SELECT name, owner, description, primary_category,
-                   COALESCE(parent_stars, stargazers_count, 0) as stars,
-                   language, forked_from, readme_summary, problem_solved,
-                   license_spdx
-            FROM repos
-            WHERE is_private = false
-              AND (LOWER(name) = LOWER(:name) OR LOWER(name) LIKE LOWER(:like_name))
-            ORDER BY CASE WHEN LOWER(name) = LOWER(:name) THEN 0 ELSE 1 END,
-                     COALESCE(parent_stars, stargazers_count, 0) DESC
-            LIMIT 1
-        """), {"name": name, "like_name": f"%{name}%"})
-        row = result.first()
-        if row:
-            parts = [f"**{row.owner}/{row.name}**"]
-            if row.primary_category:
-                parts.append(f"Category: {row.primary_category}")
-            if row.language:
-                parts.append(f"Language: {row.language}")
-            parts.append(f"Stars: {row.stars:,}")
-            if row.license_spdx:
-                parts.append(f"License: {row.license_spdx}")
-            if row.description:
-                parts.append(f"\n{row.description}")
-            if row.problem_solved:
-                parts.append(f"\n**What it solves:** {row.problem_solved}")
-            if row.readme_summary:
-                parts.append(f"\n**Summary:** {row.readme_summary[:300]}")
-            return {
-                "answer": "\n".join(parts),
-                "sources": [{
-                    "name": row.name, "owner": row.owner,
-                    "stars": row.stars, "relevance_score": 1.0,
-                    "description": row.description, "forked_from": row.forked_from,
-                    "problem_solved": row.problem_solved, "integration_tags": [],
-                }],
-                "route": "repo_info",
-            }
+        if name.lower() not in _REPO_INFO_BLACKLIST:
+            result = await db.execute(text("""
+                SELECT name, owner, description, primary_category,
+                       COALESCE(parent_stars, stargazers_count, 0) as stars,
+                       language, forked_from, readme_summary, problem_solved,
+                       license_spdx
+                FROM repos
+                WHERE is_private = false
+                  AND (LOWER(name) = LOWER(:name) OR LOWER(name) LIKE LOWER(:like_name))
+                ORDER BY CASE WHEN LOWER(name) = LOWER(:name) THEN 0 ELSE 1 END,
+                         COALESCE(parent_stars, stargazers_count, 0) DESC
+                LIMIT 1
+            """), {"name": name, "like_name": f"%{name}%"})
+            row = result.first()
+            if row:
+                parts = [f"**{row.owner}/{row.name}**"]
+                if row.primary_category:
+                    parts.append(f"Category: {row.primary_category}")
+                if row.language:
+                    parts.append(f"Language: {row.language}")
+                parts.append(f"Stars: {row.stars:,}")
+                if row.license_spdx:
+                    parts.append(f"License: {row.license_spdx}")
+                if row.description:
+                    parts.append(f"\n{row.description}")
+                if row.problem_solved:
+                    parts.append(f"\n**What it solves:** {row.problem_solved}")
+                if row.readme_summary:
+                    parts.append(f"\n**Summary:** {row.readme_summary[:300]}")
+                return {
+                    "answer": "\n".join(parts),
+                    "sources": [{
+                        "name": row.name, "owner": row.owner,
+                        "stars": row.stars, "relevance_score": 1.0,
+                        "description": row.description, "forked_from": row.forked_from,
+                        "problem_solved": row.problem_solved, "integration_tags": [],
+                    }],
+                    "route": "repo_info",
+                }
         # Fall through to LLM if no match
         return None
 

--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -52,6 +52,278 @@ _INJECTION_PATTERNS = re.compile(
 _MAX_CONTENT_LEN = 400  # max chars per repo field in context
 _SEMANTIC_CACHE_DISTANCE_THRESHOLD = 0.08  # cosine distance ≤ 0.08 ≈ similarity ≥ 0.92
 
+# ---------------------------------------------------------------------------
+# KAN-124: Smart routing — answer questions with SQL when possible, skip LLM
+# ---------------------------------------------------------------------------
+# Question patterns that can be answered without calling Claude.
+# Each rule: (compiled regex, handler function name, route label)
+# Handler functions receive (question: str, match: re.Match, db: AsyncSession)
+# and return (answer: str, sources: list[dict]) or None to fall through to LLM.
+
+_ROUTE_COUNT = re.compile(
+    r"^how many (repos?|repositories|tools?|projects?|libraries?)(\s.*)?\?*$",
+    re.IGNORECASE,
+)
+_ROUTE_COUNT_CATEGORY = re.compile(
+    r"^how many (repos?|repositories|tools?|projects?|libraries?)\s+(are |in |for |about |with |use |have )?(the )?(category\s+)?(?P<category>.+?)(\s+category)?\?*$",
+    re.IGNORECASE,
+)
+_ROUTE_LIST_CATEGORIES = re.compile(
+    r"^(what|list|show|which)\s+(are\s+)?(the\s+)?(categories|topics|groups)(\s+available)?\?*$",
+    re.IGNORECASE,
+)
+_ROUTE_TOP_STARRED = re.compile(
+    r"^(what|which|show|list)\s+(are\s+)?(the\s+)?(?:top|most[- ]starred|popular|best)\s+(\d+\s+)?(repos?|repositories|tools?|projects?)?\?*$",
+    re.IGNORECASE,
+)
+_ROUTE_REPO_INFO = re.compile(
+    r"^(what is|tell me about|describe|info about|show me|explain)\s+(?:the\s+)?(?:repo(?:sitory)?\s+)?(?P<name>[a-zA-Z0-9_-]+(?:/[a-zA-Z0-9_-]+)?)\s*\?*$",
+    re.IGNORECASE,
+)
+_ROUTE_COUNT_LANGUAGE = re.compile(
+    r"^how many\s+(?:repos?|repositories|tools?|projects?)\s+(?:are\s+)?(?:written\s+)?(?:in|use|using)\s+(?P<lang>[a-zA-Z0-9#+]+)\s*\?*$",
+    re.IGNORECASE,
+)
+_ROUTE_LIST_LANGUAGES = re.compile(
+    r"^(what|which|list|show)\s+(?:are\s+)?(?:the\s+)?(?:programming\s+)?languages?\s+(?:are\s+)?(?:used|available|supported|represented)\s*\?*$",
+    re.IGNORECASE,
+)
+_ROUTE_COUNT_TAGS = re.compile(
+    r"^how many\s+(?:repos?|repositories|tools?|projects?)\s+(?:are\s+)?(?:tagged\s+(?:with\s+)?|have\s+(?:the\s+)?tag\s+)(?P<tag>[a-zA-Z0-9_-]+)\s*\?*$",
+    re.IGNORECASE,
+)
+_ROUTE_STATS = re.compile(
+    r"^(what are|show|give me|tell me)\s+(?:the\s+)?(?:overall\s+)?(?:library\s+)?stats\s*\?*$",
+    re.IGNORECASE,
+)
+
+
+async def _try_smart_route(question: str, db: AsyncSession) -> dict | None:
+    """
+    Attempt to answer the question with a pure SQL query.
+    Returns a dict with {"answer": str, "sources": list, "route": str} or None.
+    """
+    q = question.strip()
+
+    # --- Total count ---
+    m = _ROUTE_COUNT.match(q)
+    if m and not _ROUTE_COUNT_CATEGORY.match(q) and not _ROUTE_COUNT_LANGUAGE.match(q) and not _ROUTE_COUNT_TAGS.match(q):
+        result = await db.execute(text(
+            "SELECT COUNT(*) FROM repos WHERE is_private = false"
+        ))
+        count = result.scalar()
+        return {
+            "answer": f"There are **{count:,}** public repositories tracked in Reporium.",
+            "sources": [],
+            "route": "count_total",
+        }
+
+    # --- Count by category ---
+    m = _ROUTE_COUNT_CATEGORY.match(q)
+    if m:
+        cat_query = m.group("category").strip().lower()
+        result = await db.execute(text("""
+            SELECT primary_category, COUNT(*) as cnt
+            FROM repos
+            WHERE is_private = false
+              AND LOWER(primary_category) LIKE :cat
+            GROUP BY primary_category
+            ORDER BY cnt DESC
+        """), {"cat": f"%{cat_query}%"})
+        rows = result.fetchall()
+        if rows:
+            parts = [f"- **{row.primary_category}**: {row.cnt} repos" for row in rows]
+            total = sum(row.cnt for row in rows)
+            return {
+                "answer": f"Found **{total:,}** repos matching \"{cat_query}\":\n\n" + "\n".join(parts),
+                "sources": [],
+                "route": "count_category",
+            }
+        return {
+            "answer": f"No repos found with a category matching \"{cat_query}\". Try browsing categories on the home page.",
+            "sources": [],
+            "route": "count_category",
+        }
+
+    # --- List categories ---
+    m = _ROUTE_LIST_CATEGORIES.match(q)
+    if m:
+        result = await db.execute(text("""
+            SELECT primary_category, COUNT(*) as cnt
+            FROM repos
+            WHERE is_private = false AND primary_category IS NOT NULL
+            GROUP BY primary_category
+            ORDER BY cnt DESC
+        """))
+        rows = result.fetchall()
+        parts = [f"- **{row.primary_category}** ({row.cnt} repos)" for row in rows]
+        return {
+            "answer": f"Reporium tracks repos across **{len(rows)}** categories:\n\n" + "\n".join(parts),
+            "sources": [],
+            "route": "list_categories",
+        }
+
+    # --- Top starred repos ---
+    m = _ROUTE_TOP_STARRED.match(q)
+    if m:
+        limit = int(m.group(4).strip()) if m.group(4) else 10
+        limit = min(limit, 25)  # cap
+        result = await db.execute(text("""
+            SELECT name, owner, COALESCE(parent_stars, stargazers_count, 0) as stars,
+                   primary_category, description
+            FROM repos
+            WHERE is_private = false
+            ORDER BY COALESCE(parent_stars, stargazers_count, 0) DESC
+            LIMIT :limit
+        """), {"limit": limit})
+        rows = result.fetchall()
+        parts = []
+        sources = []
+        for row in rows:
+            stars_str = f"{row.stars:,}" if row.stars else "0"
+            cat_str = f" ({row.primary_category})" if row.primary_category else ""
+            parts.append(f"- **{row.owner}/{row.name}**{cat_str} — {stars_str} stars")
+            sources.append({
+                "name": row.name, "owner": row.owner,
+                "stars": row.stars, "relevance_score": 1.0,
+                "description": row.description,
+                "forked_from": None, "problem_solved": None,
+                "integration_tags": [],
+            })
+        return {
+            "answer": f"Top {limit} most-starred repos in Reporium:\n\n" + "\n".join(parts),
+            "sources": sources,
+            "route": "top_starred",
+        }
+
+    # --- Specific repo info ---
+    m = _ROUTE_REPO_INFO.match(q)
+    if m:
+        name = m.group("name").strip()
+        # Try exact match, then LIKE match
+        result = await db.execute(text("""
+            SELECT name, owner, description, primary_category,
+                   COALESCE(parent_stars, stargazers_count, 0) as stars,
+                   language, forked_from, readme_summary, problem_solved,
+                   license_spdx
+            FROM repos
+            WHERE is_private = false
+              AND (LOWER(name) = LOWER(:name) OR LOWER(name) LIKE LOWER(:like_name))
+            ORDER BY CASE WHEN LOWER(name) = LOWER(:name) THEN 0 ELSE 1 END,
+                     COALESCE(parent_stars, stargazers_count, 0) DESC
+            LIMIT 1
+        """), {"name": name, "like_name": f"%{name}%"})
+        row = result.first()
+        if row:
+            parts = [f"**{row.owner}/{row.name}**"]
+            if row.primary_category:
+                parts.append(f"Category: {row.primary_category}")
+            if row.language:
+                parts.append(f"Language: {row.language}")
+            parts.append(f"Stars: {row.stars:,}")
+            if row.license_spdx:
+                parts.append(f"License: {row.license_spdx}")
+            if row.description:
+                parts.append(f"\n{row.description}")
+            if row.problem_solved:
+                parts.append(f"\n**What it solves:** {row.problem_solved}")
+            if row.readme_summary:
+                parts.append(f"\n**Summary:** {row.readme_summary[:300]}")
+            return {
+                "answer": "\n".join(parts),
+                "sources": [{
+                    "name": row.name, "owner": row.owner,
+                    "stars": row.stars, "relevance_score": 1.0,
+                    "description": row.description, "forked_from": row.forked_from,
+                    "problem_solved": row.problem_solved, "integration_tags": [],
+                }],
+                "route": "repo_info",
+            }
+        # Fall through to LLM if no match
+        return None
+
+    # --- Count by language ---
+    m = _ROUTE_COUNT_LANGUAGE.match(q)
+    if m:
+        lang = m.group("lang").strip()
+        result = await db.execute(text("""
+            SELECT COUNT(*) FROM repos
+            WHERE is_private = false AND LOWER(language) = LOWER(:lang)
+        """), {"lang": lang})
+        count = result.scalar()
+        return {
+            "answer": f"There are **{count:,}** repos written in {lang} tracked in Reporium.",
+            "sources": [],
+            "route": "count_language",
+        }
+
+    # --- List languages ---
+    m = _ROUTE_LIST_LANGUAGES.match(q)
+    if m:
+        result = await db.execute(text("""
+            SELECT language, COUNT(*) as cnt
+            FROM repos
+            WHERE is_private = false AND language IS NOT NULL
+            GROUP BY language
+            ORDER BY cnt DESC
+            LIMIT 20
+        """))
+        rows = result.fetchall()
+        parts = [f"- **{row.language}** ({row.cnt} repos)" for row in rows]
+        return {
+            "answer": f"Top programming languages across Reporium:\n\n" + "\n".join(parts),
+            "sources": [],
+            "route": "list_languages",
+        }
+
+    # --- Count by tag ---
+    m = _ROUTE_COUNT_TAGS.match(q)
+    if m:
+        tag = m.group("tag").strip().lower()
+        result = await db.execute(text("""
+            SELECT COUNT(*) FROM repos
+            WHERE is_private = false
+              AND EXISTS (
+                SELECT 1 FROM unnest(enriched_tags) t WHERE LOWER(t) = :tag
+              )
+        """), {"tag": tag})
+        count = result.scalar()
+        return {
+            "answer": f"There are **{count:,}** repos tagged with \"{tag}\" in Reporium.",
+            "sources": [],
+            "route": "count_tag",
+        }
+
+    # --- Overall stats ---
+    m = _ROUTE_STATS.match(q)
+    if m:
+        result = await db.execute(text("""
+            SELECT
+                COUNT(*) as total,
+                COUNT(DISTINCT primary_category) as categories,
+                COUNT(DISTINCT language) FILTER (WHERE language IS NOT NULL) as languages,
+                SUM(COALESCE(parent_stars, stargazers_count, 0)) as total_stars,
+                COUNT(*) FILTER (WHERE forked_from IS NOT NULL) as forked,
+                COUNT(*) FILTER (WHERE forked_from IS NULL) as original
+            FROM repos WHERE is_private = false
+        """))
+        row = result.first()
+        if row:
+            return {
+                "answer": (
+                    f"**Reporium Library Stats:**\n\n"
+                    f"- **{row.total:,}** total public repos\n"
+                    f"- **{row.categories}** categories\n"
+                    f"- **{row.languages}** programming languages\n"
+                    f"- **{row.total_stars:,}** total stars\n"
+                    f"- **{row.original:,}** original repos, **{row.forked:,}** forks"
+                ),
+                "sources": [],
+                "route": "stats_overview",
+            }
+
+    return None  # No smart route matched — fall through to LLM
+
 
 def _sanitize_question(question: str) -> str:
     """Raise ValueError if the question contains injection patterns."""
@@ -593,6 +865,35 @@ async def _run_query(
     4. Return answer with source repos and relevance scores
     """
     _started_at = time.monotonic()
+
+    # 0. Smart routing — answer simple questions with SQL, no LLM call needed
+    smart_result = await _try_smart_route(req.question, db)
+    if smart_result is not None:
+        logger.info("ask: smart-routed via %s (no LLM)", smart_result["route"])
+        sources = _coerce_cached_sources(smart_result["sources"])
+        response = QueryResponse(
+            answer=smart_result["answer"],
+            sources=sources,
+            question=req.question,
+            model=f"smart-route:{smart_result['route']}",
+            answered_at=datetime.now(timezone.utc).isoformat(),
+            embedding_candidates=0,
+            cache_hit=False,
+            tokens_used={"input": 0, "output": 0, "total": 0},
+        )
+        asyncio.create_task(_log_query(
+            question=req.question,
+            answer=smart_result["answer"],
+            sources=smart_result["sources"],
+            tokens_prompt=0,
+            tokens_completion=0,
+            hashed_ip=_hash_ip(client_ip),
+            latency_ms=int((time.monotonic() - _started_at) * 1000),
+            model=f"smart-route:{smart_result['route']}",
+            cache_hit=False,
+        ))
+        return response
+
     model = get_embedding_model()
 
     # 1. Embed the question — model is pre-warmed at startup so this is fast
@@ -894,9 +1195,34 @@ async def intelligence_ask_stream(
 
     async def event_generator():
         _started_at = time.monotonic()
-        model = get_embedding_model()
 
         try:
+            # 0. Smart routing — answer simple questions with SQL, skip LLM entirely
+            smart_result = await _try_smart_route(req.question, db)
+            if smart_result is not None:
+                logger.info("ask/stream: smart-routed via %s (no LLM)", smart_result["route"])
+                sources = _coerce_cached_sources(smart_result["sources"])
+                yield f"data: {json.dumps({'type': 'sources', 'sources': [s.model_dump() for s in sources], 'cache_hit': False, 'route': smart_result['route']})}\n\n"
+                # Stream answer word-by-word
+                words = smart_result["answer"].split(" ")
+                for i, word in enumerate(words):
+                    chunk = word + (" " if i < len(words) - 1 else "")
+                    yield f"data: {json.dumps({'type': 'token', 'text': chunk})}\n\n"
+                    await asyncio.sleep(0)
+                yield f"data: {json.dumps({'type': 'done', 'tokens': {'input': 0, 'output': 0, 'total': 0}, 'route': smart_result['route']})}\n\n"
+                asyncio.create_task(_log_query(
+                    question=req.question, answer=smart_result["answer"],
+                    sources=smart_result["sources"],
+                    tokens_prompt=0, tokens_completion=0,
+                    hashed_ip=_hash_ip(client_ip),
+                    latency_ms=int((time.monotonic() - _started_at) * 1000),
+                    model=f"smart-route:{smart_result['route']}",
+                    cache_hit=False,
+                ))
+                return
+
+            model = get_embedding_model()
+
             # 1. Embed the question
             query_embedding = model.encode(req.question)
 

--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -97,6 +97,18 @@ _ROUTE_COUNT_TAGS = re.compile(
     r"^how many\s+(?:repos?|repositories|tools?|projects?)\s+(?:are\s+)?(?:tagged\s+(?:with\s+)?|have\s+(?:the\s+)?tag\s+)(?P<tag>[a-zA-Z0-9_-]+)\s*\?*$",
     re.IGNORECASE,
 )
+_ROUTE_LIST_BY_LANGUAGE = re.compile(
+    r"^(?:what|which|list|show)\s+(?:are\s+)?(?:the\s+)?(?:repos?|repositories|tools?|projects?)\s+(?:written\s+)?(?:in|using|that use)\s+(?P<lang>[a-zA-Z0-9#+]+)\s*\?*$",
+    re.IGNORECASE,
+)
+_ROUTE_MOST_ADJECTIVE = re.compile(
+    r"^(?:what|which|show)\s+(?:is|are)\s+(?:the\s+)?(?:most\s+)?(?P<adj>active|recent|newest|oldest|forked|starred|popular)\s+(?:\d+\s+)?(?:repos?|repositories|tools?|projects?)?\s*\?*$",
+    re.IGNORECASE,
+)
+_ROUTE_CATEGORY_REPOS = re.compile(
+    r"^(?:what|which|list|show)\s+(?:are\s+)?(?:the\s+)?(?:repos?|repositories|tools?|projects?)\s+(?:in|for|about|under)\s+(?:the\s+)?(?:category\s+)?(?P<cat>.+?)\s*\?*$",
+    re.IGNORECASE,
+)
 _ROUTE_STATS = re.compile(
     r"^(what are|show|give me|tell me|get)\s+(?:me\s+)?(?:the\s+)?(?:overall\s+)?(?:library\s+)?(?:repo(?:sitory)?\s+)?stats(?:istics)?\s*\?*$",
     re.IGNORECASE,
@@ -298,6 +310,83 @@ async def _try_smart_route(question: str, db: AsyncSession) -> dict | None:
             "sources": [],
             "route": "count_tag",
         }
+
+    # --- List repos by language ---
+    m = _ROUTE_LIST_BY_LANGUAGE.match(q)
+    if m:
+        lang = m.group("lang").strip()
+        result = await db.execute(text("""
+            SELECT name, owner, COALESCE(parent_stars, stargazers_count, 0) as stars,
+                   primary_category, description
+            FROM repos
+            WHERE is_private = false AND LOWER(language) = LOWER(:lang)
+            ORDER BY COALESCE(parent_stars, stargazers_count, 0) DESC
+            LIMIT 15
+        """), {"lang": lang})
+        rows = result.fetchall()
+        if rows:
+            parts = [f"- **{r.owner}/{r.name}** — {r.stars:,} stars" + (f" ({r.primary_category})" if r.primary_category else "") for r in rows]
+            return {
+                "answer": f"Top {lang} repos in Reporium ({len(rows)} shown):\n\n" + "\n".join(parts),
+                "sources": [{"name": r.name, "owner": r.owner, "stars": r.stars, "relevance_score": 1.0, "description": r.description, "forked_from": None, "problem_solved": None, "integration_tags": []} for r in rows],
+                "route": "list_by_language",
+            }
+        return {
+            "answer": f"No repos found written in {lang}.",
+            "sources": [],
+            "route": "list_by_language",
+        }
+
+    # --- Most [adjective] repos ---
+    m = _ROUTE_MOST_ADJECTIVE.match(q)
+    if m:
+        adj = m.group("adj").strip().lower()
+        order_map = {
+            "active": "activity_score DESC NULLS LAST",
+            "recent": "COALESCE(your_last_push_at, upstream_last_push_at, github_updated_at, updated_at) DESC NULLS LAST",
+            "newest": "created_at DESC NULLS LAST",
+            "oldest": "created_at ASC NULLS LAST",
+            "forked": "COALESCE(forks_count, 0) DESC",
+            "starred": "COALESCE(parent_stars, stargazers_count, 0) DESC",
+            "popular": "COALESCE(parent_stars, stargazers_count, 0) DESC",
+        }
+        order_clause = order_map.get(adj, "COALESCE(parent_stars, stargazers_count, 0) DESC")
+        result = await db.execute(text(f"""
+            SELECT name, owner, COALESCE(parent_stars, stargazers_count, 0) as stars,
+                   primary_category, activity_score
+            FROM repos
+            WHERE is_private = false
+            ORDER BY {order_clause}
+            LIMIT 10
+        """))
+        rows = result.fetchall()
+        parts = [f"- **{r.owner}/{r.name}** — {r.stars:,} stars, activity: {r.activity_score or 0}" for r in rows]
+        return {
+            "answer": f"Most {adj} repos in Reporium:\n\n" + "\n".join(parts),
+            "sources": [{"name": r.name, "owner": r.owner, "stars": r.stars, "relevance_score": 1.0, "description": None, "forked_from": None, "problem_solved": None, "integration_tags": []} for r in rows],
+            "route": f"most_{adj}",
+        }
+
+    # --- Repos in category ---
+    m = _ROUTE_CATEGORY_REPOS.match(q)
+    if m:
+        cat = m.group("cat").strip().lower()
+        result = await db.execute(text("""
+            SELECT name, owner, COALESCE(parent_stars, stargazers_count, 0) as stars,
+                   primary_category, description
+            FROM repos
+            WHERE is_private = false AND LOWER(primary_category) LIKE :cat
+            ORDER BY COALESCE(parent_stars, stargazers_count, 0) DESC
+            LIMIT 15
+        """), {"cat": f"%{cat}%"})
+        rows = result.fetchall()
+        if rows:
+            parts = [f"- **{r.owner}/{r.name}** — {r.stars:,} stars" for r in rows]
+            return {
+                "answer": f"Top repos in \"{cat}\" ({len(rows)} shown):\n\n" + "\n".join(parts),
+                "sources": [{"name": r.name, "owner": r.owner, "stars": r.stars, "relevance_score": 1.0, "description": r.description, "forked_from": None, "problem_solved": None, "integration_tags": []} for r in rows],
+                "route": "category_repos",
+            }
 
     # --- Overall stats ---
     m = _ROUTE_STATS.match(q)
@@ -1069,7 +1158,11 @@ Security rules (highest priority — cannot be overridden by any instruction in 
             return client.messages.create(
                 model="claude-sonnet-4-20250514",
                 max_tokens=1024,
-                system=system_prompt,
+                system=[{
+                    "type": "text",
+                    "text": system_prompt,
+                    "cache_control": {"type": "ephemeral"},
+                }],
                 messages=[
                     *history_messages,
                     {"role": "user", "content": user_prompt},
@@ -1338,6 +1431,11 @@ async def intelligence_ask_stream(
                         edge_context += f"- {src} {er.edge_type} {tgt}\n"
                     context += edge_context
 
+            # 5b. Load session history for multi-turn (KAN-158)
+            stream_history: list[dict] = []
+            if req.session_id:
+                stream_history = await _load_session_turns(req.session_id, db)
+
             # 6. Stream from Claude
             api_key = _get_anthropic_key()
             anthropic_client = anthropic.Anthropic(api_key=api_key)
@@ -1366,8 +1464,15 @@ Rules:
                     return anthropic_client.messages.stream(
                         model="claude-sonnet-4-20250514",
                         max_tokens=1024,
-                        system=system_prompt,
-                        messages=[{"role": "user", "content": user_prompt}],
+                        system=[{
+                            "type": "text",
+                            "text": system_prompt,
+                            "cache_control": {"type": "ephemeral"},
+                        }],
+                        messages=[
+                            *stream_history,
+                            {"role": "user", "content": user_prompt},
+                        ],
                     )
 
             loop = asyncio.get_event_loop()
@@ -1417,6 +1522,9 @@ Rules:
                         model="claude-sonnet-4-20250514",
                         question_embedding=query_embedding,
                     ))
+                    # Save turn to session for multi-turn continuity (KAN-158)
+                    if req.session_id and full_answer:
+                        asyncio.create_task(_save_session_turn(req.session_id, req.question, full_answer, db))
                     break
                 elif event_type == "error":
                     yield f"data: {json.dumps({'type': 'error', 'message': payload})}\n\n"
@@ -1436,6 +1544,67 @@ Rules:
             "X-Accel-Buffering": "no",  # disable Nginx buffering
         },
     )
+
+
+@router.get("/suggestions")
+@_limiter.limit("30/minute")
+async def suggested_questions(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Return popular/diverse questions from query_log for the ask bar.
+    Zero LLM cost — pulls from historical queries ranked by frequency
+    and answer quality. Cached for 1 hour.
+    """
+    cache_key = "intelligence:suggestions"
+    cached = await cache.get(cache_key)
+    if cached:
+        return cached
+
+    result = await db.execute(text("""
+        SELECT question, COUNT(*) as freq,
+               AVG(tokens_completion) as avg_tokens
+        FROM query_log
+        WHERE answer_full IS NOT NULL
+          AND cache_hit = false
+          AND LENGTH(question) BETWEEN 10 AND 120
+          AND question NOT LIKE '%ignore%'
+          AND tokens_completion > 50
+        GROUP BY question
+        ORDER BY freq DESC, avg_tokens DESC
+        LIMIT 20
+    """))
+    rows = result.fetchall()
+
+    # Deduplicate similar questions (simple prefix check)
+    seen_prefixes: set[str] = set()
+    suggestions: list[str] = []
+    for row in rows:
+        prefix = row.question[:30].lower()
+        if prefix not in seen_prefixes:
+            seen_prefixes.add(prefix)
+            suggestions.append(row.question)
+        if len(suggestions) >= 8:
+            break
+
+    # Fallback if no history yet
+    if len(suggestions) < 4:
+        defaults = [
+            "What are the best LLM inference frameworks?",
+            "Which repos support MCP?",
+            "What are the most active repos?",
+            "Show me RAG tools with the most stars",
+        ]
+        for d in defaults:
+            if d not in suggestions:
+                suggestions.append(d)
+            if len(suggestions) >= 8:
+                break
+
+    response = {"suggestions": suggestions}
+    await cache.set(cache_key, response, ttl=CACHE_TTL_STATS)
+    return response
 
 
 @router.get("/portfolio-insights", response_model=PortfolioInsightsResponse)

--- a/tests/test_intelligence.py
+++ b/tests/test_intelligence.py
@@ -317,7 +317,8 @@ async def test_run_query_returns_semantic_cache_hit_without_calling_anthropic():
     fake_model.encode.return_value = np.array([0.1, 0.2, 0.3])
     mock_log_query = AsyncMock()
 
-    with patch("app.routers.intelligence.get_embedding_model", return_value=fake_model), \
+    with patch("app.routers.intelligence._try_smart_route", new=AsyncMock(return_value=None)), \
+         patch("app.routers.intelligence.get_embedding_model", return_value=fake_model), \
          patch("app.routers.intelligence._find_semantic_cache_hit", new=AsyncMock(return_value=(
              "Cached answer",
              _coerce_cached_sources([{"owner": "perditioinc", "name": "reporium", "relevance_score": 0.88}]),


### PR DESCRIPTION
## Summary
Follow-up to #176 (already merged). Adds:
- 3 new SQL smart routes (list by language, most active/starred, repos in category)
- Fixes stats/repo_info regex bugs found in production testing
- Anthropic prompt caching on system prompt (ephemeral cache_control)
- Streaming endpoint session history loading + turn saving (KAN-158 bug)
- GET /intelligence/suggestions endpoint (popular questions from query_log)

## Test plan
- [ ] `POST /ask {"question":"show me stats"}` → instant SQL response
- [ ] `POST /ask {"question":"repos in agents"}` → category repo list
- [ ] `POST /ask {"question":"what are the most active repos"}` → sorted by activity
- [ ] `POST /ask {"question":"repos in python"}` → language list
- [ ] `GET /intelligence/suggestions` → returns popular questions
- [ ] Multi-turn streaming: send session_id, verify history loaded in 2nd turn

🤖 Generated with [Claude Code](https://claude.com/claude-code)