### PR TITLE
KAN-124: API abuse protection layer

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -70,6 +70,31 @@ async def require_ingest_key(
     raise HTTPException(status_code=403, detail="Invalid ingest key")
 
 
+# ---------------------------------------------------------------------------
+# App token - lightweight guard on expensive LLM endpoints
+# ---------------------------------------------------------------------------
+
+_APP_TOKEN_HEADER = APIKeyHeader(name="X-App-Token", auto_error=False)
+
+
+async def require_app_token(
+    x_app_token: str | None = Security(_APP_TOKEN_HEADER),
+) -> None:
+    """
+    Lightweight app verification for expensive endpoints.
+    The token is a simple shared secret set via APP_API_TOKEN env var.
+    Not full auth — just prevents random scripts from hitting LLM endpoints.
+    """
+    expected = os.getenv("APP_API_TOKEN", "")
+    if not expected:
+        if _IS_PRODUCTION:
+            logger.error("APP_API_TOKEN not set in production — rejecting")
+            raise HTTPException(status_code=500, detail="Server misconfiguration")
+        return  # Dev mode
+    if x_app_token != expected:
+        raise HTTPException(status_code=403, detail="App token required")
+
+
 async def require_pubsub_push(
     request: Request,
     credentials: HTTPAuthorizationCredentials | None = Security(HTTPBearer(auto_error=False)),

--- a/app/cost_tracker.py
+++ b/app/cost_tracker.py
@@ -1,0 +1,46 @@
+"""In-memory daily LLM cost tracker with configurable cap."""
+import os
+import logging
+from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
+
+_DAILY_CAP = float(os.getenv("DAILY_LLM_COST_CAP", "5.0"))
+_state = {"date": "", "total_usd": 0.0, "calls": 0}
+
+
+def check_budget() -> bool:
+    """Returns True if under daily cap."""
+    today = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    if _state["date"] != today:
+        _state["date"] = today
+        _state["total_usd"] = 0.0
+        _state["calls"] = 0
+    return _state["total_usd"] < _DAILY_CAP
+
+
+def record_cost(cost_usd: float, model: str = "unknown"):
+    """Record an LLM call cost."""
+    check_budget()
+    _state["total_usd"] += cost_usd
+    _state["calls"] += 1
+    if _state["total_usd"] >= _DAILY_CAP * 0.8:
+        logger.warning(
+            "LLM daily budget at %.0f%% ($%.4f / $%.2f) after %d calls",
+            (_state["total_usd"] / _DAILY_CAP) * 100,
+            _state["total_usd"],
+            _DAILY_CAP,
+            _state["calls"],
+        )
+
+
+def get_usage() -> dict:
+    """Return current usage for monitoring."""
+    check_budget()
+    return {
+        "date": _state["date"],
+        "total_usd": round(_state["total_usd"], 4),
+        "calls": _state["calls"],
+        "cap_usd": _DAILY_CAP,
+        "remaining_usd": round(max(0, _DAILY_CAP - _state["total_usd"]), 4),
+    }

--- a/app/main.py
+++ b/app/main.py
@@ -188,7 +188,7 @@ app.add_middleware(
     allow_origins=_ALLOWED_ORIGINS,
     allow_origin_regex=r"https://reporium(-[a-z0-9]+)*\.vercel\.app",
     allow_methods=["GET", "POST"],
-    allow_headers=["Authorization", "Content-Type", "X-Admin-Key", "X-Ingest-Key", "Accept"],
+    allow_headers=["Authorization", "Content-Type", "X-Admin-Key", "X-Ingest-Key", "X-App-Token", "Accept"],
 )
 
 
@@ -252,7 +252,8 @@ if __name__ == "__main__":
 
 
 @app.get("/health")
-async def health():
+@limiter.limit("60/minute")
+async def health(request: Request):
     from sqlalchemy import text
 
     db_error: str | None = None

--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -26,9 +26,10 @@ from slowapi import Limiter
 from slowapi.util import get_remote_address
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
-from app.auth import verify_api_key
+from app.auth import require_app_token, verify_api_key
 from app.cache import CACHE_TTL_STATS, cache
 from app.circuit_breaker import anthropic_breaker
+from app.cost_tracker import check_budget, record_cost
 from app.database import async_session_factory, get_db
 from app.embeddings import get_embedding_model
 from app.models.session import AskSession
@@ -1531,6 +1532,13 @@ async def _run_query(
                 effective_session_id,
             )
 
+    # Daily cost cap check — reject before calling Claude if budget exhausted
+    if not check_budget():
+        raise HTTPException(
+            status_code=503,
+            detail="Service temporarily unavailable — daily usage limit reached. Try again tomorrow.",
+        )
+
     # Select model based on question complexity
     selected_model = _select_model(req.question, len(top_for_answer))
     logger.info("Model selected: %s for question length %d, %d repos", selected_model, len(req.question), len(top_for_answer))
@@ -1590,6 +1598,10 @@ async def _run_query(
         "output": message.usage.output_tokens,
         "total": message.usage.input_tokens + message.usage.output_tokens,
     }
+
+    # Record estimated cost (Haiku ~$0.0005/call, Sonnet ~$0.01/call)
+    _est_cost = 0.0005 if "haiku" in selected_model else 0.01
+    record_cost(_est_cost, model=selected_model)
 
     # 5. Build response
     sources = []
@@ -1662,15 +1674,16 @@ async def intelligence_query(
 
 
 @router.post("/ask", response_model=QueryResponse)
-@_limiter.limit("10/minute;100/day")
+@_limiter.limit("6/minute;60/day")
 async def intelligence_ask(
     request: Request,  # required by SlowAPI for IP-based rate limiting
     req: QueryRequest,
     db: AsyncSession = Depends(get_db),
+    _app: None = Depends(require_app_token),
 ):
     """
-    Public endpoint — no auth required. Ask a natural language question about
-    the repo knowledge base. Rate limited to 10/minute and 100/day per IP.
+    Public endpoint — requires X-App-Token header. Ask a natural language question
+    about the repo knowledge base. Rate limited to 6/minute and 60/day per IP.
 
     Pass ``session_id`` (UUID) in the request body to enable conversational
     memory — the last 3 turns of that session will be prepended to context.
@@ -1679,21 +1692,22 @@ async def intelligence_ask(
 
 
 @router.post("/ask/stream")
-@_limiter.limit("10/minute;100/day")
+@_limiter.limit("6/minute;60/day")
 async def intelligence_ask_stream(
     request: Request,
     req: QueryRequest,
     db: AsyncSession = Depends(get_db),
+    _app: None = Depends(require_app_token),
 ) -> StreamingResponse:
     """
-    Public streaming endpoint — no auth required.
+    Streaming endpoint — requires X-App-Token header.
     Streams the answer as SSE events:
       data: {"type": "sources", "sources": [...]}   (sent immediately before generation)
       data: {"type": "token", "text": "..."}         (one per Claude streaming chunk)
       data: {"type": "done", "tokens": {...}}         (final event with usage stats)
       data: {"type": "error", "message": "..."}       (on failure)
 
-    Rate limited to 10/minute and 100/day per IP (same as /ask).
+    Rate limited to 6/minute and 60/day per IP (same as /ask).
     """
     client_ip = get_remote_address(request)
 
@@ -1948,7 +1962,11 @@ async def intelligence_ask_stream(
             if req.session_id:
                 stream_history = await _load_session_turns(req.session_id, db)
 
-            # 6. Stream from Claude (with tiered model selection)
+            # 6. Daily cost cap check — reject before calling Claude if budget exhausted
+            if not check_budget():
+                yield f"data: {json.dumps({'type': 'error', 'message': 'Service temporarily unavailable — daily usage limit reached. Try again tomorrow.'})}\n\n"
+                return
+
             stream_selected_model = _select_model(req.question, len(top_for_answer))
             logger.info("Model selected: %s for question length %d, %d repos", stream_selected_model, len(req.question), len(top_for_answer))
 
@@ -2019,6 +2037,9 @@ async def intelligence_ask_stream(
                     output_tokens = payload.usage.output_tokens
                     tokens_info = {'input': input_tokens, 'output': output_tokens, 'total': input_tokens + output_tokens}
                     yield f"data: {json.dumps({'type': 'done', 'tokens': tokens_info, 'model': stream_selected_model})}\n\n"
+                    # Record estimated cost
+                    _stream_est_cost = 0.0005 if "haiku" in stream_selected_model else 0.01
+                    record_cost(_stream_est_cost, model=stream_selected_model)
                     # Cache the full LLM response in Redis (30 min TTL)
                     asyncio.create_task(cache.set(stream_redis_key, {
                         "answer": full_answer,
@@ -2101,7 +2122,7 @@ async def suggested_questions(
 
 
 @router.get("/portfolio-insights", response_model=PortfolioInsightsResponse)
-@_limiter.limit("12/minute")
+@_limiter.limit("6/minute")
 async def portfolio_insights(
     request: Request,
     db: AsyncSession = Depends(get_db),

--- a/app/routers/library_full.py
+++ b/app/routers/library_full.py
@@ -12,7 +12,9 @@ import time
 from collections import Counter, defaultdict
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, Query, Response
+from fastapi import APIRouter, Depends, Query, Request, Response
+from slowapi import Limiter
+from slowapi.util import get_remote_address
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -546,6 +548,7 @@ _TAXONOMY_RAW_TO_CANONICAL: dict[str, str] = {
 }
 
 router = APIRouter(tags=["Library"])
+_limiter = Limiter(key_func=get_remote_address)
 
 # In-memory cache: two tiers
 #   _cache["page_{page}_{page_size}"] → per-page enriched repos (5 min TTL)
@@ -1322,7 +1325,9 @@ async def _fetch_aggregates(db: AsyncSession) -> dict:
 
 
 @router.get("/library/full", response_model=dict)
+@_limiter.limit("5/minute")
 async def library_full(
+    request: Request,
     response: Response,
     db: AsyncSession = Depends(get_db),
     page: int = Query(default=1, ge=1, description="1-based page number"),

--- a/app/routers/nl_filter.py
+++ b/app/routers/nl_filter.py
@@ -25,12 +25,14 @@ import logging
 import os
 
 import anthropic
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 from slowapi import Limiter
 from slowapi.util import get_remote_address
+from app.auth import require_app_token
 from app.cache import cache
 from app.circuit_breaker import anthropic_breaker
+from app.cost_tracker import check_budget, record_cost
 
 logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/intelligence", tags=["Intelligence"])
@@ -128,17 +130,27 @@ def _build_query_params(r: NLFilterResponse) -> str:
 
 
 @router.post("/nl-filter", response_model=NLFilterResponse)
-@_limiter.limit("30/minute")
-async def nl_filter(request: Request, body: NLFilterRequest) -> NLFilterResponse:
+@_limiter.limit("15/minute")
+async def nl_filter(
+    request: Request,
+    body: NLFilterRequest,
+    _app: None = Depends(require_app_token),
+) -> NLFilterResponse:
     """
     Translate a natural language query into structured filter params.
     Single Haiku call — ~$0.0005 per request. Results cached 1 hour by query hash.
-    Public endpoint, rate-limited to 30 req/min per IP.
+    Requires X-App-Token header, rate-limited to 15 req/min per IP.
     """
     cache_key = f"nl_filter:{hash(body.query.lower().strip())}"
     cached = await cache.get(cache_key)
     if cached:
         return NLFilterResponse(**cached)
+
+    if not check_budget():
+        raise HTTPException(
+            status_code=503,
+            detail="Service temporarily unavailable — daily usage limit reached. Try again tomorrow.",
+        )
 
     prompt = _NL_FILTER_PROMPT.format(
         query=body.query,
@@ -158,6 +170,7 @@ async def nl_filter(request: Request, body: NLFilterRequest) -> NLFilterResponse
 
         with anthropic_breaker:
             response = await asyncio.to_thread(_call_haiku)
+        record_cost(0.0005, model="claude-haiku-4-5")
         raw = response.content[0].text.strip()
 
         # Strip markdown fences if present


### PR DESCRIPTION
## Summary
- **App token guard** on LLM endpoints (`X-App-Token` header required in production)
- **Daily cost cap** ($5 default via `DAILY_LLM_COST_CAP`) with 80% budget warnings
- **Tighter rate limits**: ask 6/min 60/day, nl-filter 15/min, portfolio-insights 6/min
- **Rate limit /health** (60/min) and /library/full (5/min)
- **Shared cost_tracker module** for budget monitoring across routers

## Test plan
- [x] 217 tests pass
- [ ] Set `APP_API_TOKEN` in Cloud Run secrets
- [ ] Set `NEXT_PUBLIC_APP_API_TOKEN` in Vercel env vars
- [ ] Verify unauthenticated /ask calls get 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)