### PR TITLE
promote: dev → main (KAN audit: retention, streaming, utils, AI endpoints, security)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -58,6 +58,10 @@ async def lifespan(app: FastAPI):
     loop = _asyncio.get_event_loop()
     await loop.run_in_executor(None, _get_embedding_model)
     logger.info("Embedding model pre-warmed at startup")
+    # Start query_log retention purge loop (fire-and-forget background task).
+    from app.retention import retention_loop
+    _asyncio.create_task(retention_loop())
+    logger.info("Retention purge loop scheduled")
     yield
     await cache.disconnect()
     await engine.dispose()

--- a/app/main.py
+++ b/app/main.py
@@ -202,11 +202,15 @@ async def log_requests(request: Request, call_next):
     start = time.perf_counter()
     response = await call_next(request)
     duration_ms = round((time.perf_counter() - start) * 1000, 2)
+    # Redact query strings — they may contain user input, API keys, or PII
+    safe_path = request.url.path
+    if request.url.query:
+        safe_path = f"{safe_path}?<redacted>"
     logger.info(
         "request",
         extra={
             "method": request.method,
-            "path": request.url.path,
+            "path": safe_path,
             "status_code": response.status_code,
             "duration_ms": duration_ms,
         },

--- a/app/retention.py
+++ b/app/retention.py
@@ -1,0 +1,43 @@
+"""Background retention tasks for query_log and other PII stores."""
+import asyncio
+import logging
+import os
+
+from sqlalchemy import text
+
+from app.database import async_session_factory
+
+logger = logging.getLogger(__name__)
+
+RETENTION_DAYS = int(os.getenv("QUERY_LOG_RETENTION_DAYS", "90"))
+RETENTION_INTERVAL_SECONDS = 24 * 60 * 60  # 24 hours
+
+
+async def purge_old_query_logs(days: int = RETENTION_DAYS) -> int:
+    """Delete query_log rows older than ``days`` days. Returns row count."""
+    async with async_session_factory() as db:
+        # Parameterized interval to avoid SQL injection
+        result = await db.execute(
+            text("DELETE FROM query_log WHERE created_at < NOW() - (:days || ' days')::interval"),
+            {"days": days},
+        )
+        await db.commit()
+        return result.rowcount or 0
+
+
+async def retention_loop() -> None:
+    """Run purge every 24 hours. Fire and forget."""
+    if os.getenv("ENABLE_RETENTION_PURGE", "true").lower() != "true":
+        logger.info("Retention purge disabled")
+        return
+    while True:
+        try:
+            count = await purge_old_query_logs()
+            logger.info(
+                "Retention purge complete: deleted %d rows older than %d days",
+                count,
+                RETENTION_DAYS,
+            )
+        except Exception:
+            logger.exception("Retention purge failed (will retry next cycle)")
+        await asyncio.sleep(RETENTION_INTERVAL_SECONDS)

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -2,8 +2,10 @@ import json
 import logging
 from dataclasses import dataclass, field as dc_field
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
+from slowapi import Limiter
+from slowapi.util import get_remote_address
 from sqlalchemy import delete, func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -11,6 +13,7 @@ from app.auth import require_admin_key, verify_api_key
 from app.cache import cache
 from app.database import get_db
 from app.models.repo import IngestRun, Repo, RepoCategory, RepoEmbedding, RepoTag
+from app.rate_limit import rate_limit_storage
 from app.routers.library_full import invalidate_library_cache
 
 # ── 21-category taxonomy (mirrors ingestion/enrichment/taxonomy.py) ──────────
@@ -129,6 +132,7 @@ def _assign_categories_from_tags(tags: list[str]) -> list[dict]:
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["Admin"])
+_limiter = Limiter(key_func=get_remote_address, storage_uri=rate_limit_storage)
 
 # Canonical noise-tag list from Reporium taxonomy Phase 4 cleanup rules.
 NOISE_TAGS = frozenset({
@@ -235,7 +239,9 @@ async def data_quality(
 
 
 @router.post("/admin/tags/prune", response_model=dict)
+@_limiter.limit("10/minute")
 async def prune_tags(
+    request: Request,
     dry_run: bool = Query(default=False),
     db: AsyncSession = Depends(get_db),
     _api_key: str = Depends(verify_api_key),
@@ -246,7 +252,9 @@ async def prune_tags(
 
 
 @router.post("/admin/quality/compute", response_model=dict)
+@_limiter.limit("10/minute")
 async def compute_quality_signals(
+    request: Request,
     db: AsyncSession = Depends(get_db),
     _api_key: str = Depends(verify_api_key),
     _admin_key: None = Depends(require_admin_key),
@@ -306,7 +314,9 @@ async def compute_quality_signals(
 
 
 @router.post("/admin/embeddings/backfill", response_model=dict)
+@_limiter.limit("10/minute")
 async def backfill_embeddings(
+    request: Request,
     db: AsyncSession = Depends(get_db),
     _api_key: str = Depends(verify_api_key),
     _admin_key: None = Depends(require_admin_key),
@@ -569,7 +579,9 @@ def _match_tag_rule(rule: TagRule, search_text: str) -> bool:
 
 
 @router.post("/admin/tags/protocols", response_model=dict)
+@_limiter.limit("10/minute")
 async def tag_protocols(
+    request: Request,
     dry_run: bool = Query(default=False, description="Preview without writing"),
     db: AsyncSession = Depends(get_db),
     _api_key: str = Depends(verify_api_key),
@@ -656,7 +668,9 @@ async def tag_protocols(
 
 
 @router.post("/admin/taxonomy/bootstrap", response_model=dict)
+@_limiter.limit("10/minute")
 async def bootstrap_taxonomy(
+    request: Request,
     limit: int = Query(default=100, ge=1, le=500),
     dimension: str | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
@@ -901,7 +915,9 @@ async def list_runs(
 
 
 @router.post("/admin/enrichment/trigger", response_model=dict)
+@_limiter.limit("10/minute")
 async def trigger_enrichment(
+    request: Request,
     db: AsyncSession = Depends(get_db),
     _api_key: str = Depends(verify_api_key),
     _admin_key: None = Depends(require_admin_key),
@@ -921,7 +937,9 @@ async def trigger_enrichment(
     dependencies=[Depends(require_admin_key), Depends(verify_api_key)],
     status_code=201,
 )
+@_limiter.limit("10/minute")
 async def record_run(
+    request: Request,
     payload: dict,
     db: AsyncSession = Depends(get_db),
 ):
@@ -965,7 +983,9 @@ async def record_run(
 
 
 @router.post("/admin/backfill/categories", response_model=dict)
+@_limiter.limit("10/minute")
 async def backfill_categories(
+    request: Request,
     batch_size: int = Query(default=200, ge=1, le=1000),
     db: AsyncSession = Depends(get_db),
     _api_key: str = Depends(verify_api_key),
@@ -1058,7 +1078,9 @@ class SecuritySignalsPatch(BaseModel):
     dependencies=[Depends(require_admin_key)],
     summary="Set security risk signals for a repo",
 )
+@_limiter.limit("10/minute")
 async def set_repo_security_signals(
+    request: Request,
     repo_name: str,
     payload: SecuritySignalsPatch,
     db: AsyncSession = Depends(get_db),
@@ -1108,7 +1130,9 @@ async def set_repo_security_signals(
     dependencies=[Depends(require_admin_key)],
     summary="Clear security risk signals for a repo",
 )
+@_limiter.limit("10/minute")
 async def clear_repo_security_signals(
+    request: Request,
     repo_name: str,
     db: AsyncSession = Depends(get_db),
 ):

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -1123,3 +1123,22 @@ async def clear_repo_security_signals(
     invalidate_library_cache()
 
     return {"repo": repo_name, "security_signals": None}
+
+
+@router.post(
+    "/admin/retention/purge-query-logs",
+    summary="Manually purge old query_log rows (PII retention)",
+)
+async def admin_purge_query_logs(
+    days: int = Query(default=90, ge=30, le=3650),
+    _admin_key: None = Depends(require_admin_key),
+) -> dict:
+    """Delete query_log rows older than ``days`` days on demand.
+
+    The retention loop runs this automatically every 24 hours; this endpoint
+    is for ops/manual cleanup.
+    """
+    from app.retention import purge_old_query_logs
+
+    count = await purge_old_query_logs(days=days)
+    return {"purged": count, "cutoff_days": days}

--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -36,7 +36,7 @@ from app.database import async_session_factory, get_db
 from app.embeddings import get_embedding_model
 from app.models.session import AskSession
 from app.rate_limit import rate_limit_storage
-from app.utils import get_anthropic_key, vec_to_pg
+from app.utils import get_anthropic_key, log_nonfatal, vec_to_pg
 # Rate limiter for the public /ask endpoint (no auth, IP-based)
 _limiter = Limiter(key_func=get_remote_address, storage_uri=rate_limit_storage)
 
@@ -58,17 +58,13 @@ _INJECTION_PATTERNS = re.compile(
 _MAX_CONTENT_LEN = 200  # max chars per repo field in context (reduced from 400 for cost)
 
 # ---------------------------------------------------------------------------
-# KAN-197: Lazy singleton Anthropic client — avoids creating a new client per request
+# KAN-197 / Issue #215: Lazy singleton Anthropic client.
+# The singleton itself lives in app.utils; this thin wrapper is preserved so
+# existing tests that patch ``app.routers.intelligence._get_client`` still work.
 # ---------------------------------------------------------------------------
-_anthropic_client: anthropic.Anthropic | None = None
-
-
 def _get_client() -> anthropic.Anthropic:
-    global _anthropic_client
-    if _anthropic_client is None:
-        from app.utils import get_anthropic_key
-        _anthropic_client = anthropic.Anthropic(api_key=get_anthropic_key())
-    return _anthropic_client
+    from app.utils import get_anthropic_client
+    return get_anthropic_client()
 _SEMANTIC_CACHE_DISTANCE_THRESHOLD = 0.15  # cosine distance ≤0.15 ≈ similarity ≥0.85 — relaxed for more cache hits
 
 # ---------------------------------------------------------------------------
@@ -1004,7 +1000,7 @@ async def _log_query(
             )
             await session.commit()
     except Exception:
-        logger.exception("query_log insert failed (non-fatal)")
+        log_nonfatal("query_log insert")
 
 
 # ---------------------------------------------------------------------------
@@ -1035,7 +1031,7 @@ async def _load_session_turns(session_id: str, db: AsyncSession) -> list[dict]:
         )
         rows = result.fetchall()
     except Exception:
-        logger.exception("_load_session_turns failed (non-fatal) for session %s", session_id)
+        log_nonfatal("_load_session_turns", session_id=session_id)
         return []
 
     # Rows are newest-first; reverse to oldest-first for correct message order
@@ -1090,7 +1086,7 @@ async def _save_session_turn(session_id: str, question: str, answer: str) -> Non
             )
             await db.commit()
     except Exception:
-        logger.exception("Failed to save session turn")
+        log_nonfatal("_save_session_turn", session_id=session_id)
 
 
 class QueryRequest(BaseModel):
@@ -1558,7 +1554,8 @@ async def _prepare_query(
 
     embed_model = get_embedding_model()
 
-    # 1. Embed the question — model is pre-warmed at startup so this is fast
+    # 1. Embed the question — model is pre-warmed at startup so this is fast.
+    # Issue #208: Embedding is computed once per request in _prepare_query().
     query_embedding = embed_model.encode(question)
 
     # 2. Semantic cache check

--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -16,6 +16,7 @@ import re
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from typing import Literal
 from uuid import UUID
 
 import anthropic
@@ -1143,6 +1144,26 @@ class QueryResponse(BaseModel):
     tokens_used: dict
 
 
+class StreamEvent(BaseModel):
+    """
+    Schema for SSE events emitted by the /ask/stream endpoint.
+
+    Each event is serialized as ``data: <json>\\n\\n``. The ``type`` field
+    discriminates the payload:
+
+    - ``sources``: initial event carrying the retrieved ``sources`` list
+    - ``token``: incremental answer chunk in ``text``
+    - ``done``: terminal success event carrying ``tokens`` usage and ``model``
+    - ``error``: terminal failure event carrying ``message``
+    """
+    type: Literal["sources", "token", "done", "error"]
+    sources: list[dict] | None = None
+    text: str | None = None
+    message: str | None = None
+    tokens: dict | None = None
+    model: str | None = None
+
+
 class TaxonomyGapSignal(BaseModel):
     dimension: str
     value: str
@@ -1994,13 +2015,18 @@ async def intelligence_ask_stream(
 ) -> StreamingResponse:
     """
     Streaming endpoint — requires X-App-Token header.
-    Streams the answer as SSE events:
+    Streams the answer as SSE events. Each event payload conforms to the
+    :class:`StreamEvent` Pydantic schema defined above:
       data: {"type": "sources", "sources": [...]}   (sent immediately before generation)
       data: {"type": "token", "text": "..."}         (one per Claude streaming chunk)
-      data: {"type": "done", "tokens": {...}}         (final event with usage stats)
+      data: {"type": "done", "tokens": {...}, "model": "..."}  (final event with usage stats)
       data: {"type": "error", "message": "..."}       (on failure)
 
     Rate limited to 6/minute and 60/day per IP (same as /ask).
+
+    Backpressure: the generator detects client disconnects (via
+    ``request.is_disconnected()`` and ``GeneratorExit``) and aborts the
+    upstream Anthropic stream to avoid burning tokens on an abandoned client.
     """
     client_ip = get_remote_address(request)
 
@@ -2112,22 +2138,41 @@ async def intelligence_ask_stream(
 
             # Use a queue to bridge the sync streaming iterator to async
             import queue
+            import threading
             token_queue: queue.Queue = queue.Queue()
+            # Shared cancel flag — flipped when the client disconnects so the
+            # worker thread exits the Anthropic iterator on the next chunk and
+            # stops consuming tokens.
+            cancel_event = threading.Event()
 
             def _run_stream():
                 try:
                     with _stream_claude() as stream:
                         for text_chunk in stream.text_stream:
+                            if cancel_event.is_set():
+                                # Abort cleanly — the context manager will
+                                # close the underlying HTTP stream.
+                                return
                             token_queue.put(("token", text_chunk))
+                        if cancel_event.is_set():
+                            return
                         msg = stream.get_final_message()
                         token_queue.put(("done", msg))
                 except Exception as e:
-                    token_queue.put(("error", str(e)))
+                    if not cancel_event.is_set():
+                        token_queue.put(("error", str(e)))
 
             # Run the blocking streamer in a thread
             future = loop.run_in_executor(None, _run_stream)
 
             while True:
+                # Backpressure: bail out early if the client has gone away so
+                # we don't keep paying Anthropic for tokens nobody is reading.
+                if await request.is_disconnected():
+                    logger.info("Stream client disconnected")
+                    cancel_event.set()
+                    break
+
                 try:
                     item = await loop.run_in_executor(
                         None,
@@ -2135,6 +2180,7 @@ async def intelligence_ask_stream(
                     )
                 except queue.Empty:
                     yield f"data: {json.dumps({'type': 'error', 'message': 'Stream timed out'})}\n\n"
+                    cancel_event.set()
                     break
 
                 event_type, payload = item
@@ -2176,6 +2222,18 @@ async def intelligence_ask_stream(
 
             await future  # ensure thread cleanup
 
+        except GeneratorExit:
+            # Client disconnected (FastAPI/Starlette closes the generator).
+            # Signal the worker thread to abort the Anthropic stream so we
+            # stop accruing token cost, then re-raise per async-generator
+            # protocol.
+            logger.info("Stream client disconnected")
+            try:
+                cancel_event.set()
+            except NameError:
+                # Disconnect happened before the stream was set up.
+                pass
+            raise
         except Exception as e:
             logger.error("Streaming ask error: %s", str(e), exc_info=True)
             yield f"data: {json.dumps({'type': 'error', 'message': 'Internal server error. Please try again.'})}\n\n"

--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -1239,11 +1239,27 @@ def _coerce_cached_sources(raw_sources: object) -> list[SourceRepo]:
     return coerced
 
 
+def _validate_query_embedding(query_embedding) -> np.ndarray:
+    """Validate an embedding used for pgvector similarity search.
+
+    Rejects wrong-shape, NaN, and Infinity values to prevent corrupt or
+    hostile inputs from reaching the DB layer.
+    """
+    if not isinstance(query_embedding, np.ndarray):
+        query_embedding = np.asarray(query_embedding, dtype=np.float32)
+    if query_embedding.shape != (384,):
+        raise ValueError(f"Invalid embedding shape: {query_embedding.shape}")
+    if np.any(np.isnan(query_embedding)) or np.any(np.isinf(query_embedding)):
+        raise ValueError("Embedding contains NaN or Infinity")
+    return query_embedding
+
+
 async def _find_semantic_cache_hit(
     db: AsyncSession,
     *,
     question_embedding: np.ndarray,
 ) -> tuple[str, list[SourceRepo], str | None] | None:
+    question_embedding = _validate_query_embedding(question_embedding)
     result = await db.execute(
         text("""
             SELECT answer_full, sources, model
@@ -1581,6 +1597,7 @@ async def _prepare_query(
 
     t_embed = time.perf_counter()
 
+    query_embedding = _validate_query_embedding(query_embedding)
     vec_str = vec_to_pg(query_embedding)
 
     # 3. pgvector HNSW index scan — O(log N) instead of O(N) Python loop

--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -2608,3 +2608,274 @@ async def category_leaders(
     if not rows:
         raise HTTPException(status_code=404, detail=f"No repos found for category '{category}'")
     return {"category": category, "repos": rows}
+
+
+# ---------------------------------------------------------------------------
+# Issue #213: /category-momentum — categories ranked by repo addition velocity
+# Issue #214: /similar/{owner}/{name} — similar repos with SQL-based explanations
+# Both endpoints are $0 LLM cost (pure SQL + caching).
+# ---------------------------------------------------------------------------
+
+
+class CategoryMomentumItem(BaseModel):
+    id: str
+    name: str
+    description: str | None = None
+    new_7d: int
+    new_30d: int
+    total_repos: int
+    momentum_score: int
+
+
+class CategoryMomentumResponse(BaseModel):
+    generated_at: str
+    categories: list[CategoryMomentumItem]
+
+
+@router.get("/category-momentum", response_model=CategoryMomentumResponse)
+@_limiter.limit("30/minute")
+async def category_momentum(
+    request: Request,
+    limit: int = Query(20, ge=1, le=50),
+    db: AsyncSession = Depends(get_db),
+) -> CategoryMomentumResponse:
+    """
+    Categories ranked by repo addition velocity (new repos in the last 7/30 days).
+
+    Uses repo_categories (category_id, category_name) joined to repos.ingested_at
+    (Reporium has no repos.created_at — ingested_at is when the repo was added).
+    Pure SQL, $0 LLM cost. Cached for 1 hour.
+    """
+    cache_key = f"intelligence:category_momentum:v1:{limit}"
+    try:
+        cached = await cache.get(cache_key)
+        if cached:
+            return CategoryMomentumResponse(**cached)
+    except Exception:
+        pass
+
+    result = await db.execute(
+        text("""
+            SELECT rc.category_id AS id,
+                   MIN(rc.category_name) AS name,
+                   COUNT(CASE WHEN r.ingested_at > NOW() - INTERVAL '7 days' THEN 1 END)::int AS new_7d,
+                   COUNT(CASE WHEN r.ingested_at > NOW() - INTERVAL '30 days' THEN 1 END)::int AS new_30d,
+                   COUNT(*)::int AS total_repos
+            FROM repo_categories rc
+            JOIN repos r ON r.id = rc.repo_id AND r.is_private = false
+            GROUP BY rc.category_id
+            HAVING COUNT(CASE WHEN r.ingested_at > NOW() - INTERVAL '30 days' THEN 1 END) > 0
+            ORDER BY new_7d DESC, new_30d DESC
+            LIMIT :limit
+        """),
+        {"limit": limit},
+    )
+    categories = [
+        CategoryMomentumItem(
+            id=str(row.id),
+            name=row.name,
+            description=None,
+            new_7d=int(row.new_7d or 0),
+            new_30d=int(row.new_30d or 0),
+            total_repos=int(row.total_repos or 0),
+            momentum_score=int(row.new_7d or 0) * 4 + int(row.new_30d or 0),
+        )
+        for row in result.fetchall()
+    ]
+
+    response = CategoryMomentumResponse(
+        generated_at=datetime.now(timezone.utc).isoformat(),
+        categories=categories,
+    )
+    try:
+        await cache.set(cache_key, response.model_dump(), ttl=3600)
+    except Exception:
+        pass
+    return response
+
+
+class SimilarExplanation(BaseModel):
+    shared_categories: list[str]
+    shared_tags: list[str]
+    same_language: bool
+
+
+class SimilarRepoItem(BaseModel):
+    owner: str
+    name: str
+    github_url: str
+    score: int
+    explanation: SimilarExplanation
+
+
+class SimilarTarget(BaseModel):
+    owner: str
+    name: str
+
+
+class SimilarReposResponse(BaseModel):
+    target: SimilarTarget
+    similar: list[SimilarRepoItem]
+
+
+@router.get("/similar/{owner}/{name}", response_model=SimilarReposResponse)
+@_limiter.limit("60/minute")
+async def similar_repos(
+    request: Request,
+    owner: str,
+    name: str,
+    limit: int = Query(10, ge=1, le=25),
+    db: AsyncSession = Depends(get_db),
+) -> SimilarReposResponse:
+    """
+    Similar repos with SQL-based explanations of WHY they match.
+
+    Scoring: len(shared_categories)*3 + len(shared_tags)*2 + (1 if same_language else 0).
+    Pure SQL, $0 LLM cost. Cached for 15 minutes.
+    """
+    cache_key = f"intelligence:similar:v1:{owner}/{name}:{limit}"
+    try:
+        cached = await cache.get(cache_key)
+        if cached:
+            return SimilarReposResponse(**cached)
+    except Exception:
+        pass
+
+    # 1. Find target repo
+    target_row = (
+        await db.execute(
+            text("""
+                SELECT id, owner, name, primary_language
+                FROM repos
+                WHERE owner = :owner AND name = :name AND is_private = false
+                LIMIT 1
+            """),
+            {"owner": owner, "name": name},
+        )
+    ).first()
+    if target_row is None:
+        raise HTTPException(status_code=404, detail="Repository not found")
+
+    target_id = target_row.id
+    target_language = target_row.primary_language
+
+    # 2. Target categories + tags
+    target_cat_rows = (
+        await db.execute(
+            text("SELECT category_id, category_name FROM repo_categories WHERE repo_id = :rid"),
+            {"rid": target_id},
+        )
+    ).fetchall()
+    target_category_ids = {row.category_id for row in target_cat_rows}
+    target_category_names = {row.category_id: row.category_name for row in target_cat_rows}
+
+    target_tag_rows = (
+        await db.execute(
+            text("SELECT tag FROM repo_tags WHERE repo_id = :rid"),
+            {"rid": target_id},
+        )
+    ).fetchall()
+    target_tags = {row.tag for row in target_tag_rows}
+
+    # 3. Candidate repos sharing at least one category or tag
+    candidate_rows = (
+        await db.execute(
+            text("""
+                SELECT DISTINCT r.id, r.owner, r.name, r.github_url, r.primary_language
+                FROM repos r
+                WHERE r.is_private = false
+                  AND r.id <> :tid
+                  AND (
+                        r.id IN (SELECT repo_id FROM repo_categories WHERE category_id = ANY(:cat_ids))
+                     OR r.id IN (SELECT repo_id FROM repo_tags WHERE tag = ANY(:tags))
+                  )
+                LIMIT 20
+            """),
+            {
+                "tid": target_id,
+                "cat_ids": list(target_category_ids) if target_category_ids else [""],
+                "tags": list(target_tags) if target_tags else [""],
+            },
+        )
+    ).fetchall()
+
+    if not candidate_rows:
+        response = SimilarReposResponse(
+            target=SimilarTarget(owner=target_row.owner, name=target_row.name),
+            similar=[],
+        )
+        try:
+            await cache.set(cache_key, response.model_dump(), ttl=900)
+        except Exception:
+            pass
+        return response
+
+    candidate_ids = [row.id for row in candidate_rows]
+
+    # Batch-fetch categories and tags for all candidates
+    cand_cat_rows = (
+        await db.execute(
+            text(
+                "SELECT repo_id, category_id, category_name FROM repo_categories "
+                "WHERE repo_id = ANY(:ids)"
+            ),
+            {"ids": candidate_ids},
+        )
+    ).fetchall()
+    cand_cats: dict = {}
+    for row in cand_cat_rows:
+        cand_cats.setdefault(row.repo_id, []).append((row.category_id, row.category_name))
+
+    cand_tag_rows = (
+        await db.execute(
+            text("SELECT repo_id, tag FROM repo_tags WHERE repo_id = ANY(:ids)"),
+            {"ids": candidate_ids},
+        )
+    ).fetchall()
+    cand_tags: dict = {}
+    for row in cand_tag_rows:
+        cand_tags.setdefault(row.repo_id, []).append(row.tag)
+
+    # 4. Score each candidate
+    scored: list[SimilarRepoItem] = []
+    for row in candidate_rows:
+        these_cats = cand_cats.get(row.id, [])
+        these_tags = cand_tags.get(row.id, [])
+
+        shared_category_ids = {cid for cid, _ in these_cats if cid in target_category_ids}
+        shared_category_names = sorted(
+            {target_category_names[cid] for cid in shared_category_ids}
+        )
+        shared_tag_list = sorted(set(these_tags) & target_tags)
+        same_language = bool(
+            target_language and row.primary_language and target_language == row.primary_language
+        )
+        score = len(shared_category_names) * 3 + len(shared_tag_list) * 2 + (1 if same_language else 0)
+
+        scored.append(
+            SimilarRepoItem(
+                owner=row.owner,
+                name=row.name,
+                github_url=row.github_url,
+                score=score,
+                explanation=SimilarExplanation(
+                    shared_categories=shared_category_names,
+                    shared_tags=shared_tag_list,
+                    same_language=same_language,
+                ),
+            )
+        )
+
+    # 5. Top N by score desc
+    scored.sort(key=lambda item: item.score, reverse=True)
+    top = scored[:limit]
+
+    response = SimilarReposResponse(
+        target=SimilarTarget(owner=target_row.owner, name=target_row.name),
+        similar=top,
+    )
+    try:
+        await cache.set(cache_key, response.model_dump(), ttl=900)
+    except Exception:
+        pass
+    return response

--- a/app/routers/nl_filter.py
+++ b/app/routers/nl_filter.py
@@ -39,17 +39,13 @@ from app.utils import get_anthropic_key
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# KAN-197: Lazy singleton Anthropic client
+# KAN-197 / Issue #215: Lazy singleton Anthropic client lives in app.utils.
+# This thin wrapper is preserved so existing tests that patch
+# ``app.routers.nl_filter._get_client`` still work.
 # ---------------------------------------------------------------------------
-_anthropic_client: anthropic.Anthropic | None = None
-
-
 def _get_client() -> anthropic.Anthropic:
-    global _anthropic_client
-    if _anthropic_client is None:
-        from app.utils import get_anthropic_key
-        _anthropic_client = anthropic.Anthropic(api_key=get_anthropic_key())
-    return _anthropic_client
+    from app.utils import get_anthropic_client
+    return get_anthropic_client()
 
 
 # Per-model pricing (per 1M tokens)

--- a/app/routers/search.py
+++ b/app/routers/search.py
@@ -1,3 +1,4 @@
+import numpy as np
 from fastapi import APIRouter, Depends, Query, Request
 from slowapi import Limiter
 from slowapi.util import get_remote_address
@@ -60,12 +61,28 @@ async def search_repos(
     return [_repo_to_summary(r) for r in repos]
 
 
+def _validate_query_embedding(query_embedding) -> np.ndarray:
+    """Validate an embedding used for pgvector similarity search.
+
+    Rejects wrong-shape, NaN, and Infinity values to prevent corrupt or
+    hostile inputs from reaching the DB layer.
+    """
+    if not isinstance(query_embedding, np.ndarray):
+        query_embedding = np.asarray(query_embedding, dtype=np.float32)
+    if query_embedding.shape != (384,):
+        raise ValueError(f"Invalid embedding shape: {query_embedding.shape}")
+    if np.any(np.isnan(query_embedding)) or np.any(np.isinf(query_embedding)):
+        raise ValueError("Embedding contains NaN or Infinity")
+    return query_embedding
+
+
 async def _semantic_candidate_rows(
     db: AsyncSession,
     *,
     query_embedding,
     limit: int,
 ):
+    query_embedding = _validate_query_embedding(query_embedding)
     vec_str = vec_to_pg(query_embedding)
     result = await db.execute(
         text("""

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,10 +1,17 @@
 """Shared utility functions across routers."""
+from __future__ import annotations
+
 import logging
 import os
+from typing import TYPE_CHECKING
 
 from app.config import settings
 
+if TYPE_CHECKING:
+    import anthropic
+
 logger = logging.getLogger(__name__)
+_logger = logging.getLogger(__name__)
 
 
 def get_anthropic_key() -> str:
@@ -13,6 +20,39 @@ def get_anthropic_key() -> str:
     if not key:
         raise ValueError("ANTHROPIC_API_KEY not configured")
     return key
+
+
+# KAN-197 / Issue #215: Lazy singleton Anthropic client shared across routers.
+# Avoids creating a new client per request and keeps a single source of truth.
+_anthropic_client: "anthropic.Anthropic | None" = None
+
+
+def get_anthropic_client() -> "anthropic.Anthropic":
+    """Return the process-wide lazy singleton Anthropic client."""
+    global _anthropic_client
+    if _anthropic_client is None:
+        import anthropic
+        _anthropic_client = anthropic.Anthropic(api_key=get_anthropic_key())
+    return _anthropic_client
+
+
+def log_nonfatal(
+    operation: str,
+    *,
+    session_id: str | None = None,
+    extra_context: str | None = None,
+) -> None:
+    """Log a non-fatal exception from a fire-and-forget handler.
+
+    Must be called from within an ``except`` block — uses ``exc_info=True``
+    so the active exception traceback is included at WARNING level.
+    """
+    msg = f"{operation} failed (non-fatal)"
+    if session_id:
+        msg += f" for session {session_id}"
+    if extra_context:
+        msg += f" ({extra_context})"
+    _logger.warning(msg, exc_info=True)
 
 
 def vec_to_pg(vec) -> str:

--- a/tests/test_intelligence.py
+++ b/tests/test_intelligence.py
@@ -221,7 +221,7 @@ async def test_log_query_writes_row():
             hashed_ip=_hash_ip("203.0.113.42"),
             latency_ms=3450,
             model="claude-sonnet-4-20250514",
-            question_embedding=np.array([0.1, 0.2, 0.3]),
+            question_embedding=np.full(384, 0.1, dtype=np.float32),
         )
 
     mock_session.execute.assert_awaited_once()
@@ -236,7 +236,7 @@ async def test_log_query_writes_row():
     assert params["latency_ms"] == 3450
     assert params["model"] == "claude-sonnet-4-20250514"
     assert params["cache_hit"] is False
-    assert params["question_embedding_vec"] == "[0.10000000,0.20000000,0.30000000]"
+    assert params["question_embedding_vec"] == "[" + ",".join(["0.10000000"] * 384) + "]"
     mock_session.commit.assert_awaited_once()
 
 
@@ -300,7 +300,9 @@ async def test_find_semantic_cache_hit_returns_cached_answer():
     db = AsyncMock()
     db.execute = AsyncMock(return_value=SimpleNamespace(first=lambda: row))
 
-    cached = await _find_semantic_cache_hit(db, question_embedding=np.array([0.1, 0.2, 0.3]))
+    cached = await _find_semantic_cache_hit(
+        db, question_embedding=np.full(384, 0.1, dtype=np.float32)
+    )
 
     assert cached is not None
     answer, sources, model = cached
@@ -314,7 +316,7 @@ async def test_find_semantic_cache_hit_returns_cached_answer():
 async def test_run_query_returns_semantic_cache_hit_without_calling_anthropic():
     db = AsyncMock()
     fake_model = MagicMock()
-    fake_model.encode.return_value = np.array([0.1, 0.2, 0.3])
+    fake_model.encode.return_value = np.full(384, 0.1, dtype=np.float32)
     mock_log_query = AsyncMock()
 
     with patch("app.routers.intelligence._try_smart_route", new=AsyncMock(return_value=None)), \
@@ -408,7 +410,7 @@ async def test_run_query_raises_504_on_claude_timeout():
 
     db = AsyncMock()
     fake_model = MagicMock()
-    fake_model.encode.return_value = np.array([0.1, 0.2, 0.3])
+    fake_model.encode.return_value = np.full(384, 0.1, dtype=np.float32)
 
     # Simulate no semantic cache hit so we proceed to the Claude call
     async def _no_cache(*args, **kwargs):

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -1,0 +1,98 @@
+"""Tests for app.retention — query_log 90-day retention purge."""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app import retention
+
+
+@pytest.mark.asyncio
+async def test_purge_old_query_logs_executes_parameterized_delete():
+    """purge_old_query_logs should issue a parameterized DELETE and commit."""
+    exec_result = MagicMock()
+    exec_result.rowcount = 7
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(return_value=exec_result)
+    mock_db.commit = AsyncMock()
+
+    # async_session_factory() is used as an async context manager.
+    session_cm = MagicMock()
+    session_cm.__aenter__ = AsyncMock(return_value=mock_db)
+    session_cm.__aexit__ = AsyncMock(return_value=None)
+
+    factory = MagicMock(return_value=session_cm)
+
+    with patch.object(retention, "async_session_factory", factory):
+        count = await retention.purge_old_query_logs(days=90)
+
+    assert count == 7
+    factory.assert_called_once()
+    mock_db.execute.assert_awaited_once()
+    mock_db.commit.assert_awaited_once()
+
+    # Verify the SQL and bound parameters.
+    call_args = mock_db.execute.call_args
+    sql_clause = call_args.args[0]
+    params = call_args.args[1]
+    assert "DELETE FROM query_log" in str(sql_clause)
+    assert "created_at" in str(sql_clause)
+    assert params == {"days": 90}
+
+
+@pytest.mark.asyncio
+async def test_purge_old_query_logs_custom_days():
+    """Custom `days` argument flows through to the SQL parameters."""
+    exec_result = MagicMock()
+    exec_result.rowcount = 0
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(return_value=exec_result)
+    mock_db.commit = AsyncMock()
+
+    session_cm = MagicMock()
+    session_cm.__aenter__ = AsyncMock(return_value=mock_db)
+    session_cm.__aexit__ = AsyncMock(return_value=None)
+
+    factory = MagicMock(return_value=session_cm)
+
+    with patch.object(retention, "async_session_factory", factory):
+        count = await retention.purge_old_query_logs(days=30)
+
+    assert count == 0
+    params = mock_db.execute.call_args.args[1]
+    assert params == {"days": 30}
+
+
+@pytest.mark.asyncio
+async def test_purge_old_query_logs_handles_none_rowcount():
+    """If the driver returns rowcount=None, we should coerce to 0."""
+    exec_result = MagicMock()
+    exec_result.rowcount = None
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(return_value=exec_result)
+    mock_db.commit = AsyncMock()
+
+    session_cm = MagicMock()
+    session_cm.__aenter__ = AsyncMock(return_value=mock_db)
+    session_cm.__aexit__ = AsyncMock(return_value=None)
+
+    factory = MagicMock(return_value=session_cm)
+
+    with patch.object(retention, "async_session_factory", factory):
+        count = await retention.purge_old_query_logs()
+
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_retention_loop_disabled_returns_immediately(monkeypatch):
+    """When ENABLE_RETENTION_PURGE is false, the loop should exit immediately."""
+    monkeypatch.setenv("ENABLE_RETENTION_PURGE", "false")
+    # Should return without calling purge / sleep.
+    with patch.object(retention, "purge_old_query_logs", new=AsyncMock()) as mock_purge, \
+         patch("asyncio.sleep", new=AsyncMock()) as mock_sleep:
+        await retention.retention_loop()
+    mock_purge.assert_not_awaited()
+    mock_sleep.assert_not_awaited()

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -118,7 +119,7 @@ async def test_semantic_search_calls_distance_query_and_applies_limit():
         _ScalarsResult(repos),
     ])
     fake_model = MagicMock()
-    fake_model.encode.return_value = MagicMock(tolist=lambda: [0.1, 0.2, 0.3])
+    fake_model.encode.return_value = np.full(384, 0.1, dtype=np.float32)
 
     with patch("app.routers.search.get_embedding_model", return_value=fake_model):
         results = await _semantic_search(db, query="vector databases", limit=7)
@@ -144,7 +145,7 @@ async def test_semantic_search_falls_back_to_full_text_when_no_embeddings():
         _ScalarsResult(fallback_repos),  # full-text fallback returns results
     ])
     fake_model = MagicMock()
-    fake_model.encode.return_value = MagicMock(tolist=lambda: [0.1, 0.2, 0.3])
+    fake_model.encode.return_value = np.full(384, 0.1, dtype=np.float32)
 
     with patch("app.routers.search.get_embedding_model", return_value=fake_model):
         results = await _semantic_search(db, query="vector databases", limit=5)
@@ -172,7 +173,7 @@ async def test_semantic_search_returns_results_ordered_by_similarity():
         _ScalarsResult(repos),
     ])
     fake_model = MagicMock()
-    fake_model.encode.return_value = MagicMock(tolist=lambda: [0.1, 0.2, 0.3])
+    fake_model.encode.return_value = np.full(384, 0.1, dtype=np.float32)
 
     with patch("app.routers.search.get_embedding_model", return_value=fake_model):
         results = await _semantic_search(db, query="agent orchestration", limit=2)


### PR DESCRIPTION
## Summary
Promotes 5 merged PRs from dev to main after full audit (KAN-204 + #207-216).

- **#218** retention: parameterized query-log purge, 24h loop, admin endpoint
- **#217** streaming: SSE StreamEvent model, backpressure, cancel flag
- **#219** shared utils: singleton Anthropic client, log_nonfatal helper
- **#220** AI endpoints: /intelligence/category-momentum, /intelligence/similar
- **#221** security hardening: admin rate limits, query-string redaction, pgvector embedding validation

## Test plan
- [x] 221 tests pass on dev (2 env-gated skips)
- [x] Clean fast-forward, no conflicts merging dev → main
- [ ] Post-merge: verify Cloud Run deploy is healthy