### PR TITLE
P0 fix: prod stabilization — redis fallback, text[] drift, cross-category 500

### DIFF
--- a/app/models/repo.py
+++ b/app/models/repo.py
@@ -2,7 +2,7 @@ import uuid as _uuid_mod
 from datetime import datetime
 from uuid import UUID, uuid4
 
-from sqlalchemy import Boolean, Float, ForeignKey, Integer, Text, TIMESTAMP, UniqueConstraint
+from sqlalchemy import ARRAY, Boolean, Float, ForeignKey, Integer, Text, TIMESTAMP, UniqueConstraint
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import Mapped, mapped_column, relationship
@@ -76,7 +76,9 @@ class Repo(Base):
 
     # KAN-41 16-category taxonomy (backfilled by backfill_primary_category.py)
     primary_category: Mapped[str | None] = mapped_column(Text, nullable=True)
-    secondary_categories: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    # Prod column is text[] (verified 2026-04-05). Prior JSONB declaration caused
+    # `operator does not exist: text[] @> jsonb` in /repos/discover/cross-category.
+    secondary_categories: Mapped[list | None] = mapped_column(ARRAY(Text), nullable=True)
 
     # Relationships
     tags: Mapped[list["RepoTag"]] = relationship(

--- a/app/rate_limit.py
+++ b/app/rate_limit.py
@@ -2,12 +2,51 @@
 
 All routers should create their Limiter with ``storage_uri=rate_limit_storage``
 so that counters are shared across Cloud Run instances when Redis is available.
+
+Safety: if REDIS_URL is configured but the host is unreachable at process start,
+we probe with a 2s connect timeout and fall back to in-memory storage. This
+prevents SlowAPI's Redis backend from hanging every rate-limited request for
+the full Cloud Run request timeout — a failure mode that took prod down on
+2026-04-05 when a stale Memorystore IP was left in REDIS_URL.
 """
+import logging
+import socket
+from urllib.parse import urlparse
+
 from app.config import settings
 
-_redis_url = settings.redis_url or ""
-rate_limit_storage: str = (
-    _redis_url if _redis_url.startswith("redis")
-    else f"redis://{_redis_url}" if _redis_url
-    else "memory://"
-)
+logger = logging.getLogger(__name__)
+
+_REDIS_CONNECT_TIMEOUT_S = 2.0
+
+
+def _redis_reachable(url: str) -> bool:
+    """TCP-probe the Redis host with a short timeout. True iff the port is open."""
+    try:
+        parsed = urlparse(url if "://" in url else f"redis://{url}")
+        host = parsed.hostname
+        port = parsed.port or 6379
+        if not host:
+            return False
+        with socket.create_connection((host, port), timeout=_REDIS_CONNECT_TIMEOUT_S):
+            return True
+    except OSError as exc:
+        logger.warning(
+            "Rate-limiter Redis probe failed (%s); falling back to in-memory storage. "
+            "Cross-instance counters will be per-pod until Redis is reachable.",
+            exc,
+        )
+        return False
+
+
+def _resolve_storage() -> str:
+    raw = (settings.redis_url or "").strip()
+    if not raw:
+        return "memory://"
+    url = raw if raw.startswith("redis") else f"redis://{raw}"
+    if _redis_reachable(url):
+        return url
+    return "memory://"
+
+
+rate_limit_storage: str = _resolve_storage()

--- a/app/routers/repos.py
+++ b/app/routers/repos.py
@@ -193,19 +193,21 @@ async def cross_category_repos(
     # contained in secondary_categories. Sum the matches and keep repos with >= 2.
 
     # We build per-slug match expressions and sum them.
-    from sqlalchemy import case, literal_column
-    from sqlalchemy.dialects.postgresql import JSONB as PG_JSONB
+    # Prod column secondary_categories is text[] (verified 2026-04-05). Prior
+    # implementation used JSONB @> jsonb, which raised UndefinedFunctionError
+    # in production. Use text[] @> ARRAY[slug]::text[] instead.
+    from sqlalchemy import ARRAY, case, literal
 
     match_exprs = []
     for slug in slugs:
-        # primary_category exact match OR slug is in the JSONB array
+        # primary_category exact match OR slug is contained in the text[] array
         match_exprs.append(
             case(
                 (
                     or_(
                         Repo.primary_category == slug,
                         Repo.secondary_categories.op("@>")(
-                            cast(json.dumps([slug]), PG_JSONB)
+                            cast(literal([slug]), ARRAY(Text))
                         ),
                     ),
                     1,

--- a/tests/test_rate_limit_storage.py
+++ b/tests/test_rate_limit_storage.py
@@ -1,0 +1,46 @@
+"""Tests for rate-limit storage resolution — ensures we never hang on unreachable Redis.
+
+Regression test for the 2026-04-05 production outage where a stale REDIS_URL
+pointing to a decommissioned Memorystore IP caused every rate-limited request
+to 504 because SlowAPI's Redis backend had no connect timeout.
+"""
+import time
+from unittest.mock import patch
+
+import app.rate_limit as rl
+
+
+def _settings(url: str):
+    return type("S", (), {"redis_url": url})()
+
+
+def test_memory_fallback_when_redis_url_empty():
+    """Empty REDIS_URL → memory://, no network call."""
+    with patch.object(rl, "settings", _settings("")):
+        assert rl._resolve_storage() == "memory://"
+
+
+def test_memory_fallback_when_redis_unreachable():
+    """Unreachable REDIS_URL → memory:// (probe fails fast, no hang)."""
+    # 10.255.255.1 is a bogon — TCP connect should fail or timeout quickly.
+    with patch.object(rl, "settings", _settings("redis://10.255.255.1:6379")):
+        start = time.monotonic()
+        result = rl._resolve_storage()
+        elapsed = time.monotonic() - start
+    assert result == "memory://", f"Expected memory fallback, got {result!r}"
+    # 2s timeout + small slack. Must NOT hang for 60s like the prod outage.
+    assert elapsed < 5.0, f"Probe took {elapsed:.1f}s — should be <5s"
+
+
+def test_redis_url_used_when_reachable():
+    """Reachable Redis → returns the redis:// URL unchanged."""
+    with patch.object(rl, "settings", _settings("redis://reachable.local:6379")), \
+         patch.object(rl, "_redis_reachable", return_value=True):
+        assert rl._resolve_storage() == "redis://reachable.local:6379"
+
+
+def test_bare_host_coerced_to_redis_scheme():
+    """A bare host:port without scheme is treated as redis://host:port."""
+    with patch.object(rl, "settings", _settings("host.local:6379")), \
+         patch.object(rl, "_redis_reachable", return_value=True):
+        assert rl._resolve_storage() == "redis://host.local:6379"


### PR DESCRIPTION
## Incident
Production `/health` was returning 504 and rate-limited endpoints hung for 60s. Two pre-existing latent bugs were exposed while validating the post-KAN-audit deploy.

## Root causes
1. **Rate-limiter Redis hang** — `REDIS_URL` pointed to a decommissioned Memorystore IP (`10.59.171.123:6379`). No Memorystore instance existed in us-central1 and no VPC connector was attached. SlowAPI's Redis backend has no connect timeout, so every rate-limited request hung until Cloud Run's 60s request timeout.
2. **ORM drift** — `Repo.secondary_categories` was declared as `JSONB` in the model but the production column is `text[]`. `/repos/discover/cross-category` raised `operator does not exist: text[] @> jsonb`.

## Immediate mitigation (already applied)
- Removed stale `REDIS_URL` env var on Cloud Run
- Raised `timeoutSeconds` 60→300
- Restored `minScale=1` (audit #22 regression)
- Bumped memory to 1Gi
- New revision `reporium-api-00140-dgm` serving 100% traffic, `/health` 200 in 359ms

## Code fixes in this PR
- `app/rate_limit.py` — 2s TCP probe, fall back to `memory://` when Redis unreachable. Prevents recurrence regardless of env var state.
- `app/models/repo.py` — `secondary_categories` now `ARRAY(Text)`, matching prod.
- `app/routers/repos.py` — `cross_category_repos` uses `text[] @> ARRAY[slug]::text[]`.
- `tests/test_rate_limit_storage.py` — 4 new tests, including a regression test that asserts the probe returns in <5s (not the 60s prod hang).

## Test plan
- [x] 225 tests pass (+4 new), 2 env-gated skips
- [x] `/health` returns 200 after manual mitigation
- [x] `/intelligence/similar/{owner}/{name}` returns shared categories/tags
- [x] `/intelligence/category-momentum` returns 200
- [ ] After merge+deploy: confirm `/repos/discover/cross-category` returns 200 (not 500)
- [ ] After merge+deploy: confirm `rate_limit_storage=memory://` in logs (no Redis configured)