### PR TITLE
feat: SLOs, Sentry audit, /metrics/slo endpoint

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -15,6 +15,7 @@ from slowapi.util import get_remote_address
 
 from app.cache import cache
 from app.rate_limit import rate_limit_storage
+from app.slo_observer import slo_observer
 from app.database import async_session_factory, check_db_connection, engine
 from app.routers import admin, analytics, graph, ingest, intelligence, library, library_full, nl_filter, platform, recommendations, repos, search, taxonomy, trends, webhooks, wiki
 
@@ -202,6 +203,11 @@ async def log_requests(request: Request, call_next):
     start = time.perf_counter()
     response = await call_next(request)
     duration_ms = round((time.perf_counter() - start) * 1000, 2)
+    # Record against rolling SLO histogram (no-op for untracked routes).
+    try:
+        slo_observer.record(request.url.path, duration_ms, response.status_code)
+    except Exception:  # observer must never break the request path
+        pass
     # Redact query strings — they may contain user input, API keys, or PII
     safe_path = request.url.path
     if request.url.query:

--- a/app/routers/platform.py
+++ b/app/routers/platform.py
@@ -10,6 +10,17 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth import require_ingest_key, verify_api_key
 from app.database import get_db
 from app.models.repo import Repo, RepoAIDevSkill, RepoCategory
+from app.slo_observer import slo_observer
+
+# SLO targets documented in docs/SLOs.md. These are the thresholds the
+# /metrics/slo endpoint compares live values against. Keeping the dict here
+# (rather than in slo_observer) keeps the observer pure and testable.
+_SLO_TARGETS: dict[str, dict] = {
+    "/health": {"p95_ms": 500, "max_error_rate": 0.001},
+    "/library/full": {"p95_ms": 2000, "max_error_rate": 0.01},
+    "/intelligence/ask": {"p95_ms": 15000, "p99_ms": 25000, "max_error_rate": 0.01},
+    "/intelligence/nl-filter": {"p95_ms": 3000, "max_error_rate": 0.01},
+}
 
 router = APIRouter(tags=["Platform"])
 
@@ -78,6 +89,47 @@ async def audit_status(db: AsyncSession = Depends(get_db)) -> dict:
         "last_forksync_run": None,
         "ingestion_status": "not_running",
         "checked_at": datetime.now(timezone.utc).isoformat(),
+    }
+
+
+@router.get("/metrics/slo", response_model=dict)
+async def metrics_slo() -> dict:
+    """
+    Live 24h SLO snapshot for the routes documented in docs/SLOs.md.
+
+    Values come from an in-memory rolling histogram populated by the request
+    logging middleware — single-process only, no Prometheus yet. This endpoint
+    is intended for smoke-level dashboarding and on-call debugging; it is NOT
+    a replacement for Cloud Monitoring.
+    """
+    snapshot = slo_observer.snapshot()
+    routes: dict[str, dict] = {}
+    for route, target in _SLO_TARGETS.items():
+        observed = snapshot.get(route, {})
+        p95 = observed.get("p95_ms")
+        p99 = observed.get("p99_ms")
+        err = observed.get("error_rate")
+
+        breaches: list[str] = []
+        if p95 is not None and "p95_ms" in target and p95 > target["p95_ms"]:
+            breaches.append(f"p95 {p95}ms > target {target['p95_ms']}ms")
+        if p99 is not None and "p99_ms" in target and p99 > target["p99_ms"]:
+            breaches.append(f"p99 {p99}ms > target {target['p99_ms']}ms")
+        if err is not None and err > target["max_error_rate"]:
+            breaches.append(f"error_rate {err} > target {target['max_error_rate']}")
+
+        routes[route] = {
+            "target": target,
+            "observed": observed,
+            "status": "breach" if breaches else ("ok" if observed.get("count") else "no_data"),
+            "breaches": breaches,
+        }
+
+    return {
+        "window_seconds": 24 * 60 * 60,
+        "source": "in_memory_histogram",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "routes": routes,
     }
 
 

--- a/app/slo_observer.py
+++ b/app/slo_observer.py
@@ -1,0 +1,120 @@
+"""
+Lightweight in-memory SLO histogram used by the /metrics/slo endpoint.
+
+This is intentionally minimal — no Prometheus, no external dependency.
+It keeps a rolling 24h window of (timestamp, latency_ms, status_code) triples
+per route and computes p50/p95/p99 + availability on demand.
+
+When a proper metrics backend is wired up (Cloud Monitoring / Prometheus) this
+module will be replaced. Until then it gives us a single-process view that is
+good enough for dashboard-style debugging and smoke-level SLO tracking.
+"""
+from __future__ import annotations
+
+import bisect
+import threading
+import time
+from dataclasses import dataclass
+from typing import Iterable
+
+# Rolling window length. 24h keeps the memory footprint small for a service
+# that does < 1M req/day (we are currently < 50k req/day).
+WINDOW_SECONDS = 24 * 60 * 60
+
+# Routes we actively track against documented SLOs. Anything else is ignored
+# so we don't balloon memory with one-off paths (/openapi.json, /docs, etc.).
+TRACKED_ROUTES: frozenset[str] = frozenset(
+    {
+        "/health",
+        "/library/full",
+        "/intelligence/ask",
+        "/intelligence/nl-filter",
+    }
+)
+
+
+@dataclass
+class _Sample:
+    __slots__ = ("ts", "latency_ms", "status")
+    ts: float
+    latency_ms: float
+    status: int
+
+
+class SLOObserver:
+    """Thread-safe rolling histogram keyed by route."""
+
+    def __init__(self, window_seconds: int = WINDOW_SECONDS) -> None:
+        self._window = window_seconds
+        self._samples: dict[str, list[_Sample]] = {}
+        self._lock = threading.Lock()
+
+    def record(self, route: str, latency_ms: float, status: int) -> None:
+        if route not in TRACKED_ROUTES:
+            return
+        now = time.time()
+        with self._lock:
+            bucket = self._samples.setdefault(route, [])
+            bucket.append(_Sample(now, latency_ms, status))
+            self._evict_locked(bucket, now)
+
+    def _evict_locked(self, bucket: list[_Sample], now: float) -> None:
+        cutoff = now - self._window
+        # bucket is append-only in time order, so binary search is safe.
+        idx = bisect.bisect_left([s.ts for s in bucket], cutoff)
+        if idx > 0:
+            del bucket[:idx]
+
+    def snapshot(self) -> dict[str, dict]:
+        """
+        Return a dict of `{route: {count, p50, p95, p99, error_rate}}`.
+        Empty buckets are returned with null percentiles so the shape is stable.
+        """
+        now = time.time()
+        out: dict[str, dict] = {}
+        with self._lock:
+            for route in TRACKED_ROUTES:
+                bucket = self._samples.get(route, [])
+                self._evict_locked(bucket, now)
+                out[route] = _summarize(bucket)
+        return out
+
+    def reset(self) -> None:
+        """Testing helper — clears all buckets."""
+        with self._lock:
+            self._samples.clear()
+
+
+def _percentile(sorted_values: list[float], pct: float) -> float | None:
+    if not sorted_values:
+        return None
+    # Nearest-rank percentile — good enough for dashboard-level reporting.
+    k = max(0, min(len(sorted_values) - 1, int(round(pct / 100.0 * (len(sorted_values) - 1)))))
+    return round(sorted_values[k], 2)
+
+
+def _summarize(samples: Iterable[_Sample]) -> dict:
+    samples = list(samples)
+    count = len(samples)
+    if count == 0:
+        return {
+            "count": 0,
+            "p50_ms": None,
+            "p95_ms": None,
+            "p99_ms": None,
+            "error_rate": None,
+        }
+    latencies = sorted(s.latency_ms for s in samples)
+    errors = sum(1 for s in samples if s.status >= 500)
+    return {
+        "count": count,
+        "p50_ms": _percentile(latencies, 50),
+        "p95_ms": _percentile(latencies, 95),
+        "p99_ms": _percentile(latencies, 99),
+        "error_rate": round(errors / count, 4),
+    }
+
+
+# Module-level singleton used by the request-logging middleware + the
+# /metrics/slo endpoint. Tests can call `slo_observer.reset()` between cases.
+slo_observer = SLOObserver()

--- a/docs/SLOs.md
+++ b/docs/SLOs.md
@@ -1,0 +1,163 @@
+# Service Level Objectives — reporium-api
+
+Status: **draft** (Phase 4 of the 2026-03 Reporium audit, tracked in issue #226)
+
+This document defines the first formal SLOs for `reporium-api`. They are
+deliberately loose enough that we are not paging on noise today, but tight
+enough that a real regression shows up. The targets will tighten once we have
+30 days of baseline data from Cloud Monitoring + the `/metrics/slo` endpoint.
+
+## Targets
+
+| # | Route / Signal | Objective | Window | Measured by |
+|---|----------------|-----------|--------|-------------|
+| 1 | `GET /health` | p95 latency < 500 ms, availability > 99.9% | 30 d | Cloud Run request metrics + [`app/main.py` `/health`](../app/main.py) (line ~263) |
+| 2 | `GET /library/full` | p95 latency < 2 s (cached response), cache hit rate > 95% | 30 d | Cache metrics in [`app/routers/library_full.py`](../app/routers/library_full.py) (line ~1329) |
+| 3 | `POST /intelligence/ask` | p95 latency < 15 s (warm), p99 < 25 s | 30 d | Request log latencies emitted by [`app/routers/intelligence.py`](../app/routers/intelligence.py) (`latency_ms` fields) |
+| 4 | `POST /intelligence/nl-filter` | p95 latency < 3 s | 30 d | Request logs from [`app/routers/nl_filter.py`](../app/routers/nl_filter.py) (line ~141) |
+| 5 | Error budget (all 5xx) | 5xx rate < 1% | 30 d | Cloud Run request metrics, broken out per route |
+| 6 | Golden-set answer quality | score >= 0.7 on `tests/test_intelligence_quality.py` | per-PR | CI job in `.github/workflows/dev-test.yml` |
+
+## Measurement
+
+Until a full metrics backend is wired (Prometheus / Cloud Monitoring custom
+metrics), live values come from two sources:
+
+1. **Cloud Run built-in metrics** — request count, latency distribution, and
+   5xx count per revision. Dashboards live under the `reporium-api` Cloud Run
+   service in the `reporium-prod` GCP project.
+2. **In-memory rolling histogram** — see [`app/slo_observer.py`](../app/slo_observer.py).
+   The request-logging middleware in `app/main.py` records every request
+   against a 24h rolling window keyed by route. Live values are exposed via
+   `GET /metrics/slo`, which compares the current p50/p95/p99/error-rate for
+   each tracked route against the targets in the `_SLO_TARGETS` dict in
+   [`app/routers/platform.py`](../app/routers/platform.py).
+
+   **Limitations**: single-process, single-instance. On Cloud Run with >1
+   instance the values are per-instance only. Treat it as a smoke-level view,
+   not a source of truth. A Prometheus / Cloud Monitoring backend is tracked
+   separately (see Gaps below).
+
+## Breach actions
+
+| SLO | Breach threshold | Action |
+|-----|------------------|--------|
+| 1 — `/health` | Any 30-min window with p95 > 500 ms or availability < 99.9% | Page on-call via Cloud Monitoring alert policy. Check DB connection pool, Cloud Run revision status. |
+| 2 — `/library/full` | p95 > 2 s or hit rate < 95% for 1 h | Slack `#reporium-alerts`. Investigate Redis health + cold cache after deploys. |
+| 3 — `/intelligence/ask` | p95 > 15 s or p99 > 25 s for 1 h (warm traffic) | Slack `#reporium-alerts`. Check Anthropic API status, embedding model warm-up, DB pgvector query plan. |
+| 4 — `/intelligence/nl-filter` | p95 > 3 s for 1 h | Slack `#reporium-alerts`. Check LLM fast-path latency, regex fallback rate. |
+| 5 — Error budget | > 1% 5xx over rolling 30 d | Freeze feature deploys; reliability work takes priority until budget recovers. |
+| 6 — Quality gate | Golden-set score < 0.7 on any PR | Block merge. The failing PR author investigates prompt / retrieval regression. |
+
+## Sentry wiring — current state
+
+**Status: NOT WIRED.** Issue [#24](https://github.com/perditioinc/reporium-api/issues/24)
+was closed on 2026-03-24 with a comment stating *"Sentry initialized in
+main.py; guarded by SENTRY_DSN env var"*, but as of this document:
+
+- `sentry_sdk` does not appear in [`requirements.txt`](../requirements.txt).
+- `sentry_sdk.init(...)` does not appear anywhere in `app/`.
+- There is no `SENTRY_DSN` reference in the codebase or in `cloudbuild.yaml` /
+  `deploy/`.
+
+### What is needed to actually close #24
+
+1. Add `sentry-sdk[fastapi]` to `requirements.txt`.
+2. Initialize in `app/main.py` *before* `FastAPI(...)` is constructed:
+   ```python
+   import sentry_sdk
+   from sentry_sdk.integrations.fastapi import FastApiIntegration
+   from sentry_sdk.integrations.starlette import StarletteIntegration
+
+   _sentry_dsn = os.environ.get("SENTRY_DSN")
+   if _sentry_dsn:
+       sentry_sdk.init(
+           dsn=_sentry_dsn,
+           environment=os.environ.get("ENVIRONMENT", "prod"),
+           release=os.environ.get("APP_VERSION"),
+           traces_sample_rate=0.1,
+           profiles_sample_rate=0.1,
+           integrations=[StarletteIntegration(), FastApiIntegration()],
+       )
+   ```
+3. Plumb `SENTRY_DSN` through GCP Secret Manager (same pattern as
+   `INGESTION_API_KEY` and `ANTHROPIC_API_KEY`) and expose it to the Cloud Run
+   revision in `deploy/` / `cloudbuild.yaml`.
+4. Configure a Cloud Monitoring uptime check on `/health` with a 2-failures
+   alert policy pointing at on-call email + Slack webhook.
+
+A separate PR will implement the above. This PR only documents the gap so
+that the reopened issue has a clear definition of done.
+
+## Golden-set quality gate — current state
+
+Location: [`tests/test_intelligence_quality.py`](../tests/test_intelligence_quality.py)
+
+**What the test suite asserts today:**
+
+- Response structure: `answer`, `sources`, `model`, `tokens_used`,
+  `question`, `answered_at` are all present; `tokens_used.total` equals
+  input + output.
+- `answer` is a non-empty string and matches the mocked Anthropic response
+  text exactly.
+- `sources` list is ordered by `relevance_score` descending.
+- Each source has `name`, `owner`, `relevance_score` (float),
+  `integration_tags` (list).
+- `model` field contains the string "claude".
+- Empty question → 422.
+- No matching repos → still returns 200 with an answer.
+
+**CI wiring:** `.github/workflows/dev-test.yml` runs `pytest tests/ -v` on
+push-to-dev, and `.github/workflows/test.yml` runs it on PR-to-main. The
+golden-set tests are part of `tests/` and run on every such trigger.
+
+**Gap — quality scoring:** the suite does NOT yet compute a numeric quality
+score, and there is no `score >= 0.7` assertion. It is a *structural* golden
+set, not a *semantic* one. To close this gap we need to:
+
+1. Add a small scored rubric (e.g. 0.4 for mentioning both langchain and
+   llama_index, 0.3 for citing at least 2 sources, 0.3 for correct ordering).
+2. Assert total score >= 0.7 and emit the score to the CI log for trending.
+3. Optionally plug into an LLM-as-judge against a frozen reference answer.
+
+This PR intentionally does **not** modify the test logic. The scoring rubric
+should land as a follow-up once the rubric is reviewed.
+
+**CI trigger gap:** both workflows currently run on `pull_request: branches
+[main]`, not `[dev]`. PRs targeting `dev` (this one included) do not run the
+quality gate. Adding `dev` to the PR trigger list is a 1-line change that
+should ride along with the scoring rubric PR.
+
+## Live endpoint — `GET /metrics/slo`
+
+Returns a JSON document of the form:
+
+```json
+{
+  "window_seconds": 86400,
+  "source": "in_memory_histogram",
+  "generated_at": "2026-04-04T12:34:56+00:00",
+  "routes": {
+    "/health": {
+      "target": {"p95_ms": 500, "max_error_rate": 0.001},
+      "observed": {"count": 1234, "p50_ms": 18.2, "p95_ms": 42.7, "p99_ms": 88.1, "error_rate": 0.0},
+      "status": "ok",
+      "breaches": []
+    },
+    ...
+  }
+}
+```
+
+`status` is one of `ok`, `breach`, or `no_data`. The endpoint is unauthenticated
+(read-only, no PII). If that changes we should move it behind `verify_api_key`.
+
+## Gaps (not in this PR)
+
+- [ ] Sentry is not actually wired — #24 was closed prematurely.
+- [ ] No Cloud Monitoring uptime check on `/health`.
+- [ ] No alert policies — nothing pages on SLO breach today.
+- [ ] `/metrics/slo` is per-instance; no cross-instance aggregation.
+- [ ] Golden-set test has no numeric quality score or `>= 0.7` assertion.
+- [ ] CI workflows do not run on PRs to `dev`.
+- [ ] No 30-day baseline data yet — targets above may tighten once we have it.

--- a/tests/test_slo_metrics.py
+++ b/tests/test_slo_metrics.py
@@ -1,0 +1,102 @@
+"""Tests for the /metrics/slo endpoint and the underlying in-memory observer."""
+import pytest
+
+from app.slo_observer import SLOObserver, slo_observer
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — SLOObserver
+# ---------------------------------------------------------------------------
+
+
+def test_observer_records_tracked_routes_only():
+    obs = SLOObserver()
+    obs.record("/health", 42.0, 200)
+    obs.record("/some/untracked/route", 999.0, 200)
+
+    snap = obs.snapshot()
+    assert snap["/health"]["count"] == 1
+    # Untracked routes must not appear in the snapshot at all
+    assert "/some/untracked/route" not in snap
+
+
+def test_observer_percentiles_and_error_rate():
+    obs = SLOObserver()
+    # 100 samples, latencies 1..100 ms, 5 of them 5xx
+    for i in range(1, 101):
+        status = 500 if i <= 5 else 200
+        obs.record("/health", float(i), status)
+
+    snap = obs.snapshot()["/health"]
+    assert snap["count"] == 100
+    # Nearest-rank p95 on [1..100] is ~95
+    assert snap["p95_ms"] is not None
+    assert 90 <= snap["p95_ms"] <= 100
+    assert snap["error_rate"] == 0.05
+
+
+def test_observer_empty_snapshot_has_stable_shape():
+    obs = SLOObserver()
+    snap = obs.snapshot()
+    for route in ("/health", "/library/full", "/intelligence/ask", "/intelligence/nl-filter"):
+        assert route in snap
+        assert snap[route]["count"] == 0
+        assert snap[route]["p95_ms"] is None
+        assert snap[route]["error_rate"] is None
+
+
+# ---------------------------------------------------------------------------
+# Endpoint test — /metrics/slo
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_metrics_slo_endpoint_returns_expected_shape(client):
+    # Reset the shared observer so this test is deterministic regardless of
+    # test ordering.
+    slo_observer.reset()
+
+    # Inject a handful of samples so at least one route reports data.
+    for latency in (100.0, 120.0, 140.0, 160.0, 200.0):
+        slo_observer.record("/health", latency, 200)
+
+    resp = await client.get("/metrics/slo")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["window_seconds"] == 24 * 60 * 60
+    assert data["source"] == "in_memory_histogram"
+    assert "generated_at" in data
+
+    routes = data["routes"]
+    for expected in ("/health", "/library/full", "/intelligence/ask", "/intelligence/nl-filter"):
+        assert expected in routes
+        entry = routes[expected]
+        assert "target" in entry
+        assert "observed" in entry
+        assert "status" in entry
+        assert "breaches" in entry
+
+    # /health had 5 samples well under the 500ms target → ok
+    health = routes["/health"]
+    assert health["observed"]["count"] == 5
+    assert health["status"] == "ok"
+    assert health["breaches"] == []
+
+    # Routes with no traffic must report no_data, not breach
+    assert routes["/library/full"]["status"] == "no_data"
+
+
+@pytest.mark.asyncio
+async def test_metrics_slo_endpoint_flags_breaches(client):
+    slo_observer.reset()
+
+    # Record latencies well above the 500ms /health target
+    for latency in (900.0, 1100.0, 1300.0, 1500.0, 1700.0):
+        slo_observer.record("/health", latency, 200)
+
+    resp = await client.get("/metrics/slo")
+    assert resp.status_code == 200
+    health = resp.json()["routes"]["/health"]
+    assert health["status"] == "breach"
+    assert any("p95" in b for b in health["breaches"])


### PR DESCRIPTION
## Summary

Phase 4 of the 2026-03 Reporium audit (tracking epic #226): define formal SLOs for reporium-api, audit what is actually wired for alerting, and add a lightweight in-process SLO snapshot endpoint.

- **docs/SLOs.md** — formal targets + breach actions for `/health`, `/library/full`, `/intelligence/ask`, `/intelligence/nl-filter`, 5xx error budget, and the golden-set quality gate. Each SLO links to the endpoint in the code and specifies how it is measured.
- **`GET /metrics/slo`** (new) — returns live 24h p50/p95/p99/error-rate per tracked route from an in-memory rolling histogram (`app/slo_observer.py`), flagging any breaches against the targets in the doc. Request-logging middleware records samples automatically.
- **Sentry audit** — issue #24 was closed 2026-03-24 with a comment claiming Sentry was initialized, but `sentry_sdk` is not in requirements.txt and no init call exists. Documented in full (required code, Secret Manager wiring, Cloud Monitoring uptime check) so the reopened issue has a clear definition of done. No Sentry code added in this PR per the audit brief.
- **Golden-set gate audit** — `tests/test_intelligence_quality.py` currently asserts structure only (non-empty answer, correct source ordering, schema fields). There is no numeric score or `>= 0.7` assertion today. Logic is unchanged in this PR; the gap and proposed rubric are documented.

## What's done

- [x] `docs/SLOs.md` with targets, measurement, breach actions, links to code
- [x] `app/slo_observer.py` — thread-safe in-memory rolling 24h histogram
- [x] `GET /metrics/slo` endpoint in `app/routers/platform.py`
- [x] Middleware in `app/main.py` records request samples into the observer
- [x] `tests/test_slo_metrics.py` — 5 tests (observer math + endpoint ok/no_data/breach paths)
- [x] Sentry wiring state documented (what's there = nothing; what's needed = spelled out)
- [x] Golden-set test state documented (what's asserted vs. what's missing)
- [x] Full suite: 230 passed, 2 skipped

## What's still a gap (not in this PR)

- [ ] **Sentry is not actually wired.** Issue #24 should be reopened. Needs `sentry-sdk[fastapi]` dependency, `sentry_sdk.init()` in `main.py`, `SENTRY_DSN` plumbed through Secret Manager + `cloudbuild.yaml`.
- [ ] **No Cloud Monitoring uptime check** on `/health`; no alert policies exist. Nothing pages on SLO breach today.
- [ ] **`/metrics/slo` is per-instance only** — on Cloud Run with >1 instance, values reflect a single revision pod. A Prometheus / Cloud Monitoring custom-metrics backend is needed for cross-instance aggregation.
- [ ] **Golden-set quality gate has no numeric score** and no `>= 0.7` assertion. Proposed rubric documented in `docs/SLOs.md`; needs a follow-up PR.
- [ ] **CI workflows trigger on PRs to `main`, not `dev`.** This PR (base = `dev`) does not run the quality gate tests in CI until merged. 1-line fix tracked as part of the follow-up.
- [ ] **No 30-day baseline data** — targets may tighten once Cloud Monitoring has trended history.

Refs #226.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>