### PR TITLE
KAN-ask-quality: numeric golden-set gate for /intelligence/ask

### DIFF
--- a/.github/workflows/ask-quality-gate.yml
+++ b/.github/workflows/ask-quality-gate.yml
@@ -1,0 +1,50 @@
+name: Ask Quality Gate
+on:
+  push:
+    branches: [dev, main]
+  pull_request:
+    branches: [dev, main]
+
+permissions:
+  contents: read
+
+jobs:
+  ask-quality-gate:
+    runs-on: ubuntu-latest
+    # Skip gracefully on forks / environments without the required secret.
+    if: ${{ github.event.pull_request.head.repo.fork == false || github.event_name == 'push' }}
+
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: reporium_test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    env:
+      DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/reporium_test
+      REDIS_URL: ""
+      INGESTION_API_KEY: test-api-key
+      GH_USERNAME: testuser
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Run numeric golden-set gate for /intelligence/ask
+        if: ${{ env.ANTHROPIC_API_KEY != '' }}
+        run: |
+          pip install -r requirements.txt
+          pip install pytest pytest-asyncio==0.24.0 httpx pyyaml
+          pytest tests/test_ask_golden_numeric.py -v -s

--- a/tests/golden_set_ask.yaml
+++ b/tests/golden_set_ask.yaml
@@ -1,0 +1,375 @@
+# Golden set for /intelligence/ask numeric quality gate.
+#
+# Each entry drives one real call to the /intelligence/ask handler with a
+# controlled DB fixture (so we own the retrieved context) and a real Anthropic
+# model call (so we measure actual answer quality + token cost).
+#
+# Fields:
+#   question            — the user prompt sent to /intelligence/ask
+#   expected_themes     — substrings (case-insensitive) we expect in the answer
+#   expected_repos      — "owner/name" entries we expect to appear in sources
+#                         (optional — omit / leave empty for no repo check)
+#   difficulty          — simple | medium | complex (metadata only; the handler
+#                         routes internally via smart_route / Haiku / Sonnet)
+#   max_tokens_soft_budget — soft cap on total tokens for this single call,
+#                            summed across the suite for a global budget check
+#   fixture_repos       — the repos loaded into the mocked DB for this call
+#                         (owner, name, description, problem_solved, similarity,
+#                          stars, integration_tags)
+#   skip                — optional: if true the entry is excluded from the run
+#                         (used for entries that must return 422 / non-200)
+#   expect_status       — optional: non-200 status the call must return; when
+#                         set, quality scoring is skipped and the status check
+#                         is the only pass criterion
+#
+# Coverage:
+#   1–4   simple definitional single-repo questions
+#   5–8   medium multi-repo comparative questions
+#   9–12  category / list questions
+#   13–15 conversational / reasoning
+#   16–18 edge cases (empty / too short / too long / injection)
+
+- question: "What is PyTorch used for?"
+  expected_themes: ["pytorch", "deep learning", "tensor"]
+  expected_repos: ["pytorch/pytorch"]
+  difficulty: simple
+  max_tokens_soft_budget: 3500
+  fixture_repos:
+    - owner: pytorch
+      name: pytorch
+      description: "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
+      problem_solved: "Flexible deep learning framework with dynamic computation graphs"
+      similarity: 0.94
+      stars: 78000
+      integration_tags: [pytorch, deep-learning, gpu, tensor]
+
+- question: "What does LangChain do?"
+  expected_themes: ["langchain", "llm", "chain"]
+  expected_repos: ["langchain-ai/langchain"]
+  difficulty: simple
+  max_tokens_soft_budget: 3500
+  fixture_repos:
+    - owner: langchain-ai
+      name: langchain
+      description: "Build context-aware reasoning applications with LLMs"
+      problem_solved: "Orchestrating LLMs with tools, memory, and retrieval"
+      similarity: 0.95
+      stars: 88000
+      integration_tags: [llm, rag, agents, langchain]
+
+- question: "What is FastAPI?"
+  expected_themes: ["fastapi", "python", "api"]
+  expected_repos: ["tiangolo/fastapi"]
+  difficulty: simple
+  max_tokens_soft_budget: 3500
+  fixture_repos:
+    - owner: tiangolo
+      name: fastapi
+      description: "FastAPI framework, high performance, easy to learn, fast to code, ready for production"
+      problem_solved: "Modern async Python web APIs with type hints"
+      similarity: 0.93
+      stars: 72000
+      integration_tags: [python, api, async, web-framework]
+
+- question: "What is Weaviate?"
+  expected_themes: ["vector", "database", "weaviate"]
+  expected_repos: ["weaviate/weaviate"]
+  difficulty: simple
+  max_tokens_soft_budget: 3500
+  fixture_repos:
+    - owner: weaviate
+      name: weaviate
+      description: "Weaviate is an open-source vector database"
+      problem_solved: "Store and search vector embeddings at scale"
+      similarity: 0.95
+      stars: 10000
+      integration_tags: [vector-database, embeddings, search]
+
+- question: "Compare LangChain and LlamaIndex for RAG applications."
+  expected_themes: ["langchain", "llamaindex", "rag", "retrieval"]
+  expected_repos: ["langchain-ai/langchain", "run-llama/llama_index"]
+  difficulty: medium
+  max_tokens_soft_budget: 4500
+  fixture_repos:
+    - owner: langchain-ai
+      name: langchain
+      description: "Build context-aware reasoning applications with LLMs"
+      problem_solved: "Orchestrating LLMs with tools, memory, and retrieval"
+      similarity: 0.93
+      stars: 88000
+      integration_tags: [llm, rag, agents]
+    - owner: run-llama
+      name: llama_index
+      description: "LlamaIndex is a data framework for LLM applications"
+      problem_solved: "Connecting LLMs to external data sources"
+      similarity: 0.91
+      stars: 33000
+      integration_tags: [rag, llm, data]
+
+- question: "Which is better for production NLP pipelines, Haystack or LangChain?"
+  expected_themes: ["haystack", "langchain", "production"]
+  expected_repos: ["deepset-ai/haystack", "langchain-ai/langchain"]
+  difficulty: medium
+  max_tokens_soft_budget: 4500
+  fixture_repos:
+    - owner: deepset-ai
+      name: haystack
+      description: "Open-source LLM framework to build production-ready NLP applications"
+      problem_solved: "End-to-end NLP pipelines with RAG support"
+      similarity: 0.90
+      stars: 15000
+      integration_tags: [rag, nlp, search]
+    - owner: langchain-ai
+      name: langchain
+      description: "Build context-aware reasoning applications with LLMs"
+      problem_solved: "Orchestrating LLMs with tools, memory, and retrieval"
+      similarity: 0.88
+      stars: 88000
+      integration_tags: [llm, rag, agents]
+
+- question: "Compare Pinecone and Weaviate as vector databases."
+  expected_themes: ["pinecone", "weaviate", "vector"]
+  expected_repos: ["weaviate/weaviate"]
+  difficulty: medium
+  max_tokens_soft_budget: 4500
+  fixture_repos:
+    - owner: weaviate
+      name: weaviate
+      description: "Weaviate is an open-source vector database"
+      problem_solved: "Store and search vector embeddings at scale"
+      similarity: 0.93
+      stars: 10000
+      integration_tags: [vector-database, embeddings, search]
+    - owner: pinecone-io
+      name: pinecone-python-client
+      description: "Official Pinecone Python client for the managed vector database"
+      problem_solved: "Managed vector search service"
+      similarity: 0.89
+      stars: 800
+      integration_tags: [vector-database, managed, embeddings]
+
+- question: "Compare PyTorch and TensorFlow for deep learning research."
+  expected_themes: ["pytorch", "tensorflow", "deep learning"]
+  expected_repos: ["pytorch/pytorch", "tensorflow/tensorflow"]
+  difficulty: medium
+  max_tokens_soft_budget: 4500
+  fixture_repos:
+    - owner: pytorch
+      name: pytorch
+      description: "Tensors and Dynamic neural networks in Python with strong GPU acceleration"
+      problem_solved: "Flexible deep learning framework with dynamic computation graphs"
+      similarity: 0.94
+      stars: 78000
+      integration_tags: [pytorch, deep-learning, gpu]
+    - owner: tensorflow
+      name: tensorflow
+      description: "An Open Source Machine Learning Framework for Everyone"
+      problem_solved: "Production-scale machine learning with static and dynamic graphs"
+      similarity: 0.92
+      stars: 182000
+      integration_tags: [tensorflow, deep-learning, ml]
+
+- question: "Show me vector database repositories."
+  expected_themes: ["vector", "database", "embedding"]
+  expected_repos: ["weaviate/weaviate", "qdrant/qdrant", "chroma-core/chroma"]
+  difficulty: medium
+  max_tokens_soft_budget: 4500
+  fixture_repos:
+    - owner: weaviate
+      name: weaviate
+      description: "Weaviate is an open-source vector database"
+      problem_solved: "Store and search vector embeddings at scale"
+      similarity: 0.95
+      stars: 10000
+      integration_tags: [vector-database, embeddings]
+    - owner: qdrant
+      name: qdrant
+      description: "Qdrant - High-performance, massive-scale Vector Database"
+      problem_solved: "Neural search engine with filtering and payloads"
+      similarity: 0.94
+      stars: 19000
+      integration_tags: [vector-database, rust, search]
+    - owner: chroma-core
+      name: chroma
+      description: "the AI-native open-source embedding database"
+      problem_solved: "Simple embedding store for LLM apps"
+      similarity: 0.92
+      stars: 13000
+      integration_tags: [vector-database, embeddings, python]
+
+- question: "List repositories related to LLM agent frameworks."
+  expected_themes: ["agent", "llm", "framework"]
+  expected_repos: ["langchain-ai/langchain", "microsoft/autogen"]
+  difficulty: medium
+  max_tokens_soft_budget: 4500
+  fixture_repos:
+    - owner: langchain-ai
+      name: langchain
+      description: "Build context-aware reasoning applications with LLMs"
+      problem_solved: "Orchestrating LLMs with tools, memory, and retrieval"
+      similarity: 0.92
+      stars: 88000
+      integration_tags: [llm, rag, agents]
+    - owner: microsoft
+      name: autogen
+      description: "A programming framework for agentic AI"
+      problem_solved: "Multi-agent conversational AI orchestration"
+      similarity: 0.91
+      stars: 26000
+      integration_tags: [agents, llm, multi-agent]
+    - owner: joaomdmoura
+      name: crewai
+      description: "Framework for orchestrating role-playing, autonomous AI agents"
+      problem_solved: "Role-based multi-agent collaboration"
+      similarity: 0.89
+      stars: 18000
+      integration_tags: [agents, llm, orchestration]
+
+- question: "What repositories support Retrieval Augmented Generation?"
+  expected_themes: ["retrieval", "rag", "generation"]
+  expected_repos: ["langchain-ai/langchain", "run-llama/llama_index"]
+  difficulty: medium
+  max_tokens_soft_budget: 4500
+  fixture_repos:
+    - owner: langchain-ai
+      name: langchain
+      description: "Build context-aware reasoning applications with LLMs"
+      problem_solved: "Orchestrating LLMs with tools, memory, and retrieval"
+      similarity: 0.93
+      stars: 88000
+      integration_tags: [llm, rag, agents]
+    - owner: run-llama
+      name: llama_index
+      description: "LlamaIndex is a data framework for LLM applications"
+      problem_solved: "Connecting LLMs to external data sources"
+      similarity: 0.92
+      stars: 33000
+      integration_tags: [rag, llm, data]
+
+- question: "Show me Python web frameworks."
+  expected_themes: ["python", "web", "framework"]
+  expected_repos: ["tiangolo/fastapi", "pallets/flask"]
+  difficulty: medium
+  max_tokens_soft_budget: 4500
+  fixture_repos:
+    - owner: tiangolo
+      name: fastapi
+      description: "FastAPI framework, high performance, easy to learn"
+      problem_solved: "Modern async Python web APIs with type hints"
+      similarity: 0.93
+      stars: 72000
+      integration_tags: [python, api, web-framework, async]
+    - owner: pallets
+      name: flask
+      description: "The Python micro framework for building web applications"
+      problem_solved: "Minimal WSGI web framework"
+      similarity: 0.90
+      stars: 66000
+      integration_tags: [python, web-framework, wsgi]
+    - owner: django
+      name: django
+      description: "The Web framework for perfectionists with deadlines"
+      problem_solved: "Batteries-included Python web framework"
+      similarity: 0.88
+      stars: 76000
+      integration_tags: [python, web-framework, orm]
+
+- question: "Why would I choose an open-source vector database over a managed one?"
+  expected_themes: ["open-source", "managed", "cost"]
+  expected_repos: ["weaviate/weaviate", "qdrant/qdrant"]
+  difficulty: complex
+  max_tokens_soft_budget: 5000
+  fixture_repos:
+    - owner: weaviate
+      name: weaviate
+      description: "Weaviate is an open-source vector database"
+      problem_solved: "Self-hosted vector search with no vendor lock-in"
+      similarity: 0.92
+      stars: 10000
+      integration_tags: [vector-database, open-source, self-hosted]
+    - owner: qdrant
+      name: qdrant
+      description: "Qdrant - High-performance, massive-scale Vector Database"
+      problem_solved: "Self-hostable high-performance vector search"
+      similarity: 0.91
+      stars: 19000
+      integration_tags: [vector-database, open-source, rust]
+
+- question: "Which repositories would help me build a multi-agent code review bot?"
+  expected_themes: ["agent", "code", "review"]
+  expected_repos: ["microsoft/autogen", "joaomdmoura/crewai"]
+  difficulty: complex
+  max_tokens_soft_budget: 5000
+  fixture_repos:
+    - owner: microsoft
+      name: autogen
+      description: "A programming framework for agentic AI"
+      problem_solved: "Multi-agent conversational AI orchestration"
+      similarity: 0.92
+      stars: 26000
+      integration_tags: [agents, llm, multi-agent]
+    - owner: joaomdmoura
+      name: crewai
+      description: "Framework for orchestrating role-playing, autonomous AI agents"
+      problem_solved: "Role-based multi-agent collaboration"
+      similarity: 0.91
+      stars: 18000
+      integration_tags: [agents, llm, orchestration]
+    - owner: langchain-ai
+      name: langchain
+      description: "Build context-aware reasoning applications with LLMs"
+      problem_solved: "Orchestrating LLMs with tools, memory, and retrieval"
+      similarity: 0.86
+      stars: 88000
+      integration_tags: [llm, agents, tools]
+
+- question: "Explain the trade-offs between fine-tuning and RAG for domain adaptation."
+  expected_themes: ["fine-tun", "rag", "retrieval"]
+  expected_repos: ["langchain-ai/langchain"]
+  difficulty: complex
+  max_tokens_soft_budget: 5000
+  fixture_repos:
+    - owner: langchain-ai
+      name: langchain
+      description: "Build context-aware reasoning applications with LLMs"
+      problem_solved: "RAG pipelines for grounding LLM output in domain data"
+      similarity: 0.89
+      stars: 88000
+      integration_tags: [llm, rag, agents]
+    - owner: huggingface
+      name: peft
+      description: "PEFT: State-of-the-art Parameter-Efficient Fine-Tuning"
+      problem_solved: "Efficient fine-tuning of large language models"
+      similarity: 0.88
+      stars: 15000
+      integration_tags: [fine-tuning, llm, peft]
+
+# ---------------------------------------------------------------------------
+# Edge cases — these assert HTTP behavior rather than quality scores.
+# ---------------------------------------------------------------------------
+
+- question: ""
+  difficulty: simple
+  max_tokens_soft_budget: 0
+  expect_status: 422
+  fixture_repos: []
+
+- question: "ab"
+  difficulty: simple
+  max_tokens_soft_budget: 0
+  expect_status: 422
+  fixture_repos: []
+
+- question: >-
+    This is a deliberately over-long question designed to exceed the
+    500-character maximum enforced by the QueryRequest schema so that the
+    golden-set harness verifies the endpoint rejects overly long input.
+    Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+    tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+    veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+    commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+    velit esse cillum dolore eu fugiat nulla pariatur.
+  difficulty: simple
+  max_tokens_soft_budget: 0
+  expect_status: 422
+  fixture_repos: []

--- a/tests/test_ask_golden_numeric.py
+++ b/tests/test_ask_golden_numeric.py
@@ -1,0 +1,360 @@
+"""
+Numeric golden-set quality gate for POST /intelligence/ask.
+
+This test exists so that cost-cutting PRs (prompt trimming, model downgrades,
+top_k reductions, caching tweaks, etc.) can be validated against a stable
+numeric quality threshold rather than only response-shape assertions.
+
+How it works
+------------
+1. Loads ``tests/golden_set_ask.yaml`` — a handcrafted set of 15-18 Q&A pairs
+   grounded in the real Reporium corpus.
+2. For each entry we:
+     - Build a mocked DB session that returns the entry's ``fixture_repos``
+       from the pgvector similarity query and empty results for the semantic
+       cache lookup and the knowledge-graph edge query (mirroring the pattern
+       in ``tests/test_intelligence_quality.py``).
+     - Patch the embedding model to a zero vector (mocked DB means the vector
+       is never actually used server-side).
+     - Call the real ``/intelligence/ask`` handler via ``AsyncClient``, which
+       triggers a **real** Anthropic call (Haiku/Sonnet as the router chooses).
+     - Score the returned answer with ``_score_entry``.
+3. Asserts:
+     - Average ``quality_score`` across all scored entries is ``>= 0.7``.
+     - Total tokens across the suite is ``<= 1.2x`` the sum of per-entry
+       ``max_tokens_soft_budget`` values.
+     - Every ``expect_status`` edge case returns the expected HTTP code.
+
+Scoring weights (per entry) — ``quality_score`` in ``[0, 1]``:
+    0.5 * fraction of ``expected_themes`` substrings present (case-insensitive)
+    0.3 * fraction of ``expected_repos`` present in ``sources``
+          (full credit if ``expected_repos`` is empty/omitted)
+    0.2 * answer-length band score (1.0 inside [50, 2000] chars, graded
+          penalty outside)
+
+The 0.7 threshold was chosen as a pragmatic floor:
+- A perfect theme hit (0.5) + full-credit repo check (0.3) already clears 0.8.
+- 0.7 allows ~one missing theme per answer while still flagging regressions
+  where the model drops a required concept or the prompt loses the source
+  grounding entirely.
+- It is intentionally below what a healthy production run should score
+  (~0.85+) so cost-cutting tweaks have room to move without flapping, but
+  cannot silently gut answer quality.
+
+Running
+-------
+Requires ``ANTHROPIC_API_KEY`` in the environment. Skips automatically if
+unset (e.g. on forks without secrets).
+
+    pytest tests/test_ask_golden_numeric.py -v
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from pathlib import Path
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+import yaml
+from httpx import ASGITransport, AsyncClient
+
+pytestmark = pytest.mark.skipif(
+    not os.getenv("ANTHROPIC_API_KEY"),
+    reason="ANTHROPIC_API_KEY not set — golden-set numeric gate requires live Claude access",
+)
+
+
+GOLDEN_SET_PATH = Path(__file__).parent / "golden_set_ask.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Fixture / mocking helpers (mirrored from test_intelligence_quality.py)
+# ---------------------------------------------------------------------------
+
+def _make_db_row(entry: dict[str, Any]) -> MagicMock:
+    row = MagicMock()
+    row.id = str(uuid.uuid4())
+    row.name = entry["name"]
+    row.owner = entry["owner"]
+    row.forked_from = f"{entry['owner']}/{entry['name']}"
+    row.description = entry.get("description") or ""
+    row.parent_stars = entry.get("stars", 100)
+    row.readme_summary = entry.get("readme_summary") or f"Summary for {entry['name']}"
+    row.problem_solved = entry.get("problem_solved") or ""
+    row.integration_tags = entry.get("integration_tags") or []
+    row.dependencies = entry.get("dependencies") or []
+    row.similarity = float(entry.get("similarity", 0.85))
+    return row
+
+
+def _make_mock_db(rows: list[MagicMock]) -> AsyncMock:
+    """Three-call mock: semantic-cache miss, similarity fetchall, edges fetchall."""
+    cache_result = MagicMock()
+    cache_result.first.return_value = None
+
+    sim_result = MagicMock()
+    sim_result.fetchall.return_value = rows
+
+    edges_result = MagicMock()
+    edges_result.fetchall.return_value = []
+
+    mock_db = AsyncMock()
+    # The handler may execute additional queries (logging, session turns, etc).
+    # We return a permissive default after the three expected calls so nothing
+    # downstream raises StopIteration.
+    default_result = MagicMock()
+    default_result.fetchall.return_value = []
+    default_result.first.return_value = None
+
+    call_sequence = [cache_result, sim_result, edges_result]
+
+    async def _execute(*_args, **_kwargs):
+        if call_sequence:
+            return call_sequence.pop(0)
+        return default_result
+
+    mock_db.execute = AsyncMock(side_effect=_execute)
+    mock_db.commit = AsyncMock()
+    return mock_db
+
+
+def _patch_embedding_model():
+    import numpy as np
+    mock_model = MagicMock()
+    mock_model.encode.return_value = np.zeros(384)
+    return patch("app.routers.intelligence.get_embedding_model", return_value=mock_model)
+
+
+def _patch_log_query():
+    return patch("app.routers.intelligence._log_query", new_callable=AsyncMock)
+
+
+def _patch_create_task():
+    def _noop_create_task(coro, *args, **kwargs):
+        try:
+            coro.close()
+        except Exception:
+            pass
+        return MagicMock()
+
+    return patch("app.routers.intelligence.asyncio.create_task", side_effect=_noop_create_task)
+
+
+# ---------------------------------------------------------------------------
+# Test client (session-scoped, no real DB)
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture(scope="session")
+async def client_no_db():
+    from app.main import app
+    from app.database import check_db_connection  # noqa: F401
+
+    with patch("app.main.check_db_connection", new_callable=AsyncMock):
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test", timeout=120.0
+        ) as ac:
+            yield ac
+
+
+# ---------------------------------------------------------------------------
+# Scoring
+# ---------------------------------------------------------------------------
+
+def _score_entry(entry: dict[str, Any], answer: str, sources: list[dict]) -> float:
+    """Return a quality score in [0, 1] for a single golden-set answer."""
+    answer_lower = (answer or "").lower()
+
+    # Theme coverage (0.5 weight)
+    themes = entry.get("expected_themes") or []
+    if themes:
+        hits = sum(1 for t in themes if str(t).lower() in answer_lower)
+        theme_score = hits / len(themes)
+    else:
+        theme_score = 1.0
+
+    # Repo coverage (0.3 weight)
+    expected_repos = entry.get("expected_repos") or []
+    if expected_repos:
+        source_slugs = {
+            f"{(s.get('owner') or '').lower()}/{(s.get('name') or '').lower()}"
+            for s in sources
+        }
+        hits = sum(1 for r in expected_repos if str(r).lower() in source_slugs)
+        repo_score = hits / len(expected_repos)
+    else:
+        repo_score = 1.0
+
+    # Length band (0.2 weight) — full credit inside [50, 2000] chars
+    length = len(answer or "")
+    if 50 <= length <= 2000:
+        length_score = 1.0
+    elif length < 50:
+        length_score = max(0.0, length / 50.0)
+    else:  # length > 2000
+        # Graded penalty: 1.0 at 2000, 0.0 at 4000+
+        length_score = max(0.0, 1.0 - (length - 2000) / 2000.0)
+
+    return 0.5 * theme_score + 0.3 * repo_score + 0.2 * length_score
+
+
+# ---------------------------------------------------------------------------
+# Main gate
+# ---------------------------------------------------------------------------
+
+def _load_golden_set() -> list[dict[str, Any]]:
+    with GOLDEN_SET_PATH.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, list):
+        raise ValueError(f"{GOLDEN_SET_PATH} must contain a YAML list")
+    return [e for e in data if not e.get("skip")]
+
+
+@pytest.mark.asyncio
+async def test_ask_golden_set_numeric_gate(client_no_db: AsyncClient):
+    """Aggregate numeric quality gate for /intelligence/ask."""
+    from app.main import app
+    from app.database import get_db
+
+    golden_set = _load_golden_set()
+    assert len(golden_set) >= 15, (
+        f"Golden set must contain >= 15 entries, got {len(golden_set)}"
+    )
+
+    scored_results: list[dict[str, Any]] = []
+    status_results: list[dict[str, Any]] = []
+    total_tokens = 0
+    total_budget = 0
+
+    for idx, entry in enumerate(golden_set, start=1):
+        question = entry.get("question", "")
+        expect_status = entry.get("expect_status")
+        budget = int(entry.get("max_tokens_soft_budget") or 0)
+
+        rows = [_make_db_row(r) for r in (entry.get("fixture_repos") or [])]
+        mock_db = _make_mock_db(rows)
+
+        async def _override_db():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = _override_db
+
+        try:
+            with (
+                _patch_embedding_model(),
+                _patch_log_query(),
+                _patch_create_task(),
+            ):
+                response = await client_no_db.post(
+                    "/intelligence/ask",
+                    json={"question": question},
+                )
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+        if expect_status is not None:
+            status_results.append(
+                {
+                    "idx": idx,
+                    "question": (question or "<empty>")[:60],
+                    "expected": expect_status,
+                    "got": response.status_code,
+                    "pass": response.status_code == expect_status,
+                }
+            )
+            continue
+
+        assert response.status_code == 200, (
+            f"[{idx}] Q={question!r} — expected 200, got "
+            f"{response.status_code}: {response.text[:300]}"
+        )
+
+        data = response.json()
+        answer = data.get("answer", "") or ""
+        sources = data.get("sources") or []
+        tokens = data.get("tokens_used") or {}
+        used = int(tokens.get("total") or 0)
+
+        score = _score_entry(entry, answer, sources)
+        total_tokens += used
+        total_budget += budget
+
+        scored_results.append(
+            {
+                "idx": idx,
+                "question": question[:60],
+                "difficulty": entry.get("difficulty", "?"),
+                "score": score,
+                "tokens": used,
+                "budget": budget,
+                "answer_len": len(answer),
+                "pass": score >= 0.5,
+            }
+        )
+
+    # ------------------------------------------------------------------
+    # Summary table — always printed so CI logs surface cost-quality data.
+    # ------------------------------------------------------------------
+    print("\n" + "=" * 90)
+    print("ASK GOLDEN-SET NUMERIC GATE — per-question results")
+    print("=" * 90)
+    print(
+        f"{'#':>3} {'diff':<8} {'score':>6} {'tokens':>7} {'budget':>7} "
+        f"{'len':>5}  question"
+    )
+    print("-" * 90)
+    for r in scored_results:
+        marker = "OK" if r["pass"] else "FAIL"
+        print(
+            f"{r['idx']:>3} {r['difficulty']:<8} {r['score']:>6.3f} "
+            f"{r['tokens']:>7} {r['budget']:>7} {r['answer_len']:>5}  "
+            f"[{marker}] {r['question']}"
+        )
+
+    if status_results:
+        print("-" * 90)
+        print("Edge-case HTTP status checks")
+        print("-" * 90)
+        for r in status_results:
+            marker = "OK" if r["pass"] else "FAIL"
+            print(
+                f"{r['idx']:>3} expect={r['expected']} got={r['got']:<4} "
+                f"[{marker}] {r['question']}"
+            )
+
+    avg_score = (
+        sum(r["score"] for r in scored_results) / len(scored_results)
+        if scored_results
+        else 0.0
+    )
+    print("-" * 90)
+    print(
+        f"avg_quality_score = {avg_score:.3f}  "
+        f"total_tokens = {total_tokens}  "
+        f"total_budget = {total_budget}  "
+        f"budget_x1.2 = {int(total_budget * 1.2)}"
+    )
+    print("=" * 90)
+
+    # ------------------------------------------------------------------
+    # Assertions
+    # ------------------------------------------------------------------
+    # Edge-case statuses must all match.
+    bad_statuses = [r for r in status_results if not r["pass"]]
+    assert not bad_statuses, f"Edge-case status mismatches: {bad_statuses}"
+
+    assert scored_results, "No scored entries — golden set produced zero quality samples"
+
+    assert avg_score >= 0.7, (
+        f"Average quality_score {avg_score:.3f} < 0.7 threshold. "
+        f"Per-entry: "
+        + ", ".join(f"#{r['idx']}={r['score']:.2f}" for r in scored_results)
+    )
+
+    token_ceiling = int(total_budget * 1.2)
+    assert total_tokens <= token_ceiling, (
+        f"Total tokens {total_tokens} exceeds 1.2x soft budget ceiling "
+        f"({token_ceiling}). Cost regression — investigate before merging."
+    )


### PR DESCRIPTION
## Summary

Adds a numeric quality gate for `POST /intelligence/ask` so future cost-cutting PRs (prompt trimming, model downgrades, `top_k` changes, caching tweaks) can be validated against a stable floor instead of only response-shape assertions.

- `tests/golden_set_ask.yaml` — 18 handcrafted entries (15 scored + 3 HTTP edge cases) covering simple definitional, multi-repo comparative, category listing, reasoning, and injection/length edge cases. Grounded in the real Reporium corpus (PyTorch, LangChain, LlamaIndex, Weaviate, Qdrant, Chroma, AutoGen, CrewAI, FastAPI, Flask, Django, Haystack, Pinecone, TensorFlow, PEFT).
- `tests/test_ask_golden_numeric.py` — loads the YAML, drives the real handler per entry with a mocked DB (so we own the retrieved context) and a real Anthropic call (so we measure actual answer quality and token cost), then scores and aggregates.
- `.github/workflows/ask-quality-gate.yml` — runs the gate on PR / push to `dev` and `main`. Skips gracefully on forks without `ANTHROPIC_API_KEY`.

## What the gate measures

Per entry `quality_score in [0, 1]`:
- `0.5` weight: fraction of `expected_themes` substrings present in the answer (case-insensitive)
- `0.3` weight: fraction of `expected_repos` present in the `sources` list (full credit if none specified)
- `0.2` weight: answer length band — 1.0 inside `[50, 2000]` chars, graded penalty outside

Aggregate assertions:
- `avg(quality_score) >= 0.7`
- `total_tokens <= 1.2 * sum(max_tokens_soft_budget)`
- All `expect_status` edge cases return the expected HTTP code

## Why 0.7

- Perfect theme hit (0.5) + full-credit repo check (0.3) already clears 0.8, so a healthy run should score ~0.85+.
- 0.7 allows roughly one missing theme per answer while still flagging regressions where the model drops a required concept or the prompt loses source grounding entirely.
- Intentionally below healthy production to give cost-cutting tweaks room to move without flapping, but high enough that it cannot silently gut answer quality.

## Test plan

- [x] `pytest tests/test_ask_golden_numeric.py --collect-only` — collects cleanly
- [x] Local run without `ANTHROPIC_API_KEY` — skips gracefully via `skipif`
- [x] Scoring logic smoke test — perfect=1.00, one-theme-miss=0.75, no-repo=0.70, empty-answer=0.30
- [x] YAML validates: 18 entries (15 scored, 3 edge cases)
- [x] Does not modify existing `test_intelligence_quality.py`
- [ ] CI run with `ANTHROPIC_API_KEY` secret — will execute the first end-to-end pass on this PR

Golden-set questions (summary):
1. What is PyTorch used for? (simple, pytorch/pytorch)
2. What does LangChain do? (simple, langchain-ai/langchain)
3. What is FastAPI? (simple, tiangolo/fastapi)
4. What is Weaviate? (simple, weaviate/weaviate)
5. Compare LangChain and LlamaIndex for RAG (medium)
6. Haystack vs LangChain for production NLP (medium)
7. Pinecone vs Weaviate (medium)
8. PyTorch vs TensorFlow for research (medium)
9. Show me vector database repositories (medium, category)
10. List LLM agent frameworks (medium, category)
11. Repositories supporting RAG (medium, category)
12. Python web frameworks (medium, category)
13. Open-source vs managed vector DB tradeoffs (complex, reasoning)
14. Multi-agent code review bot stack (complex, composition)
15. Fine-tuning vs RAG for domain adaptation (complex, reasoning)
16. Empty question → 422 (edge)
17. 2-char question → 422 (edge)
18. >500-char question → 422 (edge)

Co-Authored-By: Claude Opus 4.6