### PR TITLE
KAN-ask-spend: token-spend observer + /metrics/spend endpoint

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -79,6 +79,11 @@ class Settings(BaseSettings):
     # Mode
     environment: str = "development"  # development, production
 
+    # KAN-ask-spend: soft daily budget surfaced via /metrics/spend.
+    # Purely advisory — hard cap still lives in app.cost_tracker (Redis-backed).
+    # Not wired into deploy workflow env vars; defaults are fine for prod.
+    spend_daily_budget_usd: float = 10.0
+
     class Config:
         env_file = ".env"
 

--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -36,6 +36,7 @@ from app.database import async_session_factory, get_db
 from app.embeddings import get_embedding_model
 from app.models.session import AskSession
 from app.rate_limit import rate_limit_storage
+from app.slo_observer import token_observer
 from app.utils import get_anthropic_key, log_nonfatal, vec_to_pg
 # Rate limiter for the public /ask endpoint (no auth, IP-based)
 _limiter = Limiter(key_func=get_remote_address, storage_uri=rate_limit_storage)
@@ -1824,7 +1825,11 @@ async def _prepare_query(
 
 
 async def _run_query(
-    req: QueryRequest, db: AsyncSession, client_ip: str | None = None, session_id: str | None = None
+    req: QueryRequest,
+    db: AsyncSession,
+    client_ip: str | None = None,
+    session_id: str | None = None,
+    route_label: str = "/intelligence/ask",
 ) -> QueryResponse:
     """
     Core intelligence query logic — shared by /query (authed) and /ask (public).
@@ -1842,6 +1847,12 @@ async def _run_query(
     # Handle cache hits (smart route, Redis, or semantic)
     if qctx.cache_result is not None:
         cached = qctx.cache_result
+        # KAN-ask-spend: record cache hits so /metrics/spend can compute hit-rate.
+        # Wrapped so a metrics bug can never break a real request.
+        try:
+            token_observer.record_cache_hit(route_label)
+        except Exception:
+            log_nonfatal("token_observer.record_cache_hit")
         sources = _coerce_cached_sources(cached["sources"])
         response = QueryResponse(
             answer=cached["answer"],
@@ -1930,6 +1941,19 @@ async def _run_query(
     _est_cost = _estimate_cost(message.usage.input_tokens, message.usage.output_tokens, qctx.model)
     await record_cost(_est_cost, model=qctx.model)
 
+    # KAN-ask-spend: per-route token + cost accumulator for /metrics/spend.
+    # Wrapped so a metrics bug can never break a real request.
+    try:
+        token_observer.record_tokens(
+            route=route_label,
+            input_tokens=message.usage.input_tokens,
+            output_tokens=message.usage.output_tokens,
+            usd_cost=_est_cost,
+            model=qctx.model,
+        )
+    except Exception:
+        log_nonfatal("token_observer.record_tokens")
+
     # Build response
     sources = []
     for repo in qctx.sources:
@@ -1998,7 +2022,13 @@ async def intelligence_query(
     Pass ``session_id`` (UUID) in the request body to enable conversational
     memory — the last 3 turns of that session will be prepended to context.
     """
-    return await _run_query(req, db, client_ip=get_remote_address(request), session_id=req.session_id)
+    return await _run_query(
+        req,
+        db,
+        client_ip=get_remote_address(request),
+        session_id=req.session_id,
+        route_label="/intelligence/query",
+    )
 
 
 @router.post("/ask", response_model=QueryResponse)
@@ -2016,7 +2046,13 @@ async def intelligence_ask(
     Pass ``session_id`` (UUID) in the request body to enable conversational
     memory — the last 3 turns of that session will be prepended to context.
     """
-    return await _run_query(req, db, client_ip=get_remote_address(request), session_id=req.session_id)
+    return await _run_query(
+        req,
+        db,
+        client_ip=get_remote_address(request),
+        session_id=req.session_id,
+        route_label="/intelligence/ask",
+    )
 
 
 @router.post("/ask/stream")

--- a/app/routers/nl_filter.py
+++ b/app/routers/nl_filter.py
@@ -34,7 +34,8 @@ from app.cache import cache
 from app.circuit_breaker import anthropic_breaker
 from app.cost_tracker import check_budget, record_cost
 from app.rate_limit import rate_limit_storage
-from app.utils import get_anthropic_key
+from app.slo_observer import token_observer
+from app.utils import get_anthropic_key, log_nonfatal
 
 logger = logging.getLogger(__name__)
 
@@ -153,6 +154,11 @@ async def nl_filter(
     cache_key = f"nl_filter:{hashlib.sha256(body.query.lower().strip().encode()).hexdigest()[:16]}"
     cached = await cache.get(cache_key)
     if cached:
+        # KAN-ask-spend: record cache hit for /metrics/spend hit-rate.
+        try:
+            token_observer.record_cache_hit("/intelligence/nl-filter")
+        except Exception:
+            log_nonfatal("token_observer.record_cache_hit")
         return NLFilterResponse(**cached)
 
     if not await check_budget():
@@ -178,6 +184,17 @@ async def nl_filter(
             response = await asyncio.to_thread(_call_haiku)
         actual_cost = _estimate_cost(response.usage.input_tokens, response.usage.output_tokens, "claude-haiku-4-5")
         await record_cost(actual_cost, model="claude-haiku-4-5")
+        # KAN-ask-spend: per-route token + cost accumulator for /metrics/spend.
+        try:
+            token_observer.record_tokens(
+                route="/intelligence/nl-filter",
+                input_tokens=response.usage.input_tokens,
+                output_tokens=response.usage.output_tokens,
+                usd_cost=actual_cost,
+                model="claude-haiku-4-5",
+            )
+        except Exception:
+            log_nonfatal("token_observer.record_tokens")
         raw = response.content[0].text.strip()
 
         # Strip markdown fences if present

--- a/app/routers/platform.py
+++ b/app/routers/platform.py
@@ -3,14 +3,21 @@
 import os
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
+from slowapi import Limiter
+from slowapi.util import get_remote_address
 from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import require_ingest_key, verify_api_key
+from app.config import settings
 from app.database import get_db
 from app.models.repo import Repo, RepoAIDevSkill, RepoCategory
-from app.slo_observer import slo_observer
+from app.rate_limit import rate_limit_storage
+from app.slo_observer import slo_observer, token_observer
+
+# Shared limiter — matches the pattern used in intelligence.py / nl_filter.py.
+_limiter = Limiter(key_func=get_remote_address, storage_uri=rate_limit_storage)
 
 # SLO targets documented in docs/SLOs.md. These are the thresholds the
 # /metrics/slo endpoint compares live values against. Keeping the dict here
@@ -125,11 +132,74 @@ async def metrics_slo() -> dict:
             "breaches": breaches,
         }
 
+    # KAN-ask-spend: surface a compact cost summary alongside latency/error SLOs
+    # so dashboards pulling /metrics/slo get token spend for free.
+    spend_snapshot = token_observer.get_spend_snapshot()
+    total_usd = spend_snapshot["total"]["usd"]
+    spend_status = _spend_status(total_usd, settings.spend_daily_budget_usd)
+    spend_summary = {
+        "usd_24h": total_usd,
+        "cache_hit_rate": spend_snapshot["total"]["cache_hit_rate"],
+        "status": spend_status,
+    }
+
     return {
         "window_seconds": 24 * 60 * 60,
         "source": "in_memory_histogram",
         "generated_at": datetime.now(timezone.utc).isoformat(),
         "routes": routes,
+        "spend_summary": spend_summary,
+    }
+
+
+def _spend_status(total_usd: float, budget_usd: float) -> str:
+    """
+    Map total spend against the soft daily budget:
+      < 80%  -> ok
+      80-100% -> warning
+      >= 100% -> breach
+    """
+    if budget_usd <= 0:
+        return "ok"
+    ratio = total_usd / budget_usd
+    if ratio >= 1.0:
+        return "breach"
+    if ratio >= 0.8:
+        return "warning"
+    return "ok"
+
+
+@router.get("/metrics/spend", response_model=dict)
+@_limiter.limit("30/minute")
+async def metrics_spend(request: Request) -> dict:
+    """
+    Live 24h LLM token-spend snapshot for cost observability.
+
+    Values come from an in-memory rolling accumulator populated by
+    /intelligence/ask and /intelligence/nl-filter. Same caveat as /metrics/slo:
+    single-process only, intended for dashboards and on-call debugging, NOT a
+    replacement for billing.
+
+    The top-level ``status`` field maps the total 24h spend against the soft
+    daily budget (``SPEND_DAILY_BUDGET_USD``, default $10):
+
+      < 80%    -> ok
+      80-100%  -> warning
+      >= 100%  -> breach
+    """
+    snapshot = token_observer.get_spend_snapshot()
+    budget = settings.spend_daily_budget_usd
+    total = snapshot["total"]
+    status = _spend_status(total["usd"], budget)
+
+    return {
+        "window_seconds": 24 * 60 * 60,
+        "source": "in_memory_accumulator",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "daily_budget_usd": budget,
+        "total": total,
+        "routes": snapshot["routes"],
+        "status": status,
     }
 
 

--- a/app/slo_observer.py
+++ b/app/slo_observer.py
@@ -118,3 +118,178 @@ def _summarize(samples: Iterable[_Sample]) -> dict:
 # Module-level singleton used by the request-logging middleware + the
 # /metrics/slo endpoint. Tests can call `slo_observer.reset()` between cases.
 slo_observer = SLOObserver()
+
+
+# ---------------------------------------------------------------------------
+# KAN-ask-spend: Token / cost observer
+# ---------------------------------------------------------------------------
+#
+# Parallel in-memory accumulator to SLOObserver — tracks LLM token spend per
+# route over a 24h rolling window. Same design principles:
+#   * single-process, in-memory, $0 infra
+#   * thread-safe (single lock like SLOObserver)
+#   * replaced by a proper metrics backend once we have one
+#
+# It also tracks cache hits per route (smart-route / Redis / semantic cache)
+# so /metrics/spend can report a cache hit-rate, which is the single most
+# useful cost-efficiency number we currently lack.
+
+
+@dataclass
+class _SpendSample:
+    __slots__ = ("ts", "input_tokens", "output_tokens", "usd", "model")
+    ts: float
+    input_tokens: int
+    output_tokens: int
+    usd: float
+    model: str
+
+
+@dataclass
+class _CacheSample:
+    __slots__ = ("ts",)
+    ts: float
+
+
+class TokenSpendObserver:
+    """
+    Thread-safe rolling 24h accumulator for LLM token spend per route.
+
+    Unlike SLOObserver we don't restrict to TRACKED_ROUTES — any route that
+    actually spends tokens is worth tracking. In practice this is 2-3 routes
+    (/intelligence/ask, /intelligence/query, /intelligence/nl-filter).
+    """
+
+    def __init__(self, window_seconds: int = WINDOW_SECONDS) -> None:
+        self._window = window_seconds
+        self._spend: dict[str, list[_SpendSample]] = {}
+        self._cache_hits: dict[str, list[_CacheSample]] = {}
+        self._lock = threading.Lock()
+
+    # -- recording ----------------------------------------------------------
+
+    def record_tokens(
+        self,
+        route: str,
+        input_tokens: int,
+        output_tokens: int,
+        usd_cost: float,
+        model: str,
+    ) -> None:
+        now = time.time()
+        with self._lock:
+            bucket = self._spend.setdefault(route, [])
+            bucket.append(
+                _SpendSample(
+                    ts=now,
+                    input_tokens=int(input_tokens or 0),
+                    output_tokens=int(output_tokens or 0),
+                    usd=float(usd_cost or 0.0),
+                    model=model or "unknown",
+                )
+            )
+            self._evict_spend_locked(bucket, now)
+
+    def record_cache_hit(self, route: str) -> None:
+        now = time.time()
+        with self._lock:
+            bucket = self._cache_hits.setdefault(route, [])
+            bucket.append(_CacheSample(now))
+            self._evict_cache_locked(bucket, now)
+
+    # -- eviction -----------------------------------------------------------
+
+    def _evict_spend_locked(self, bucket: list[_SpendSample], now: float) -> None:
+        cutoff = now - self._window
+        idx = bisect.bisect_left([s.ts for s in bucket], cutoff)
+        if idx > 0:
+            del bucket[:idx]
+
+    def _evict_cache_locked(self, bucket: list[_CacheSample], now: float) -> None:
+        cutoff = now - self._window
+        idx = bisect.bisect_left([s.ts for s in bucket], cutoff)
+        if idx > 0:
+            del bucket[:idx]
+
+    # -- snapshot -----------------------------------------------------------
+
+    def get_spend_snapshot(self) -> dict:
+        """
+        Return a dict shaped like:
+            {
+              "routes": {
+                 "<route>": {
+                    "input_tokens": int,
+                    "output_tokens": int,
+                    "usd": float,
+                    "requests": int,
+                    "cache_hits": int,
+                    "cache_hit_rate": float,  # hits / (hits + requests)
+                 },
+                 ...
+              },
+              "total": { same shape, aggregated across routes },
+            }
+        """
+        now = time.time()
+        routes_out: dict[str, dict] = {}
+        tot_in = 0
+        tot_out = 0
+        tot_usd = 0.0
+        tot_reqs = 0
+        tot_hits = 0
+
+        with self._lock:
+            # Union of all routes we've ever seen (either spend or cache).
+            seen_routes = set(self._spend.keys()) | set(self._cache_hits.keys())
+            for route in seen_routes:
+                spend_bucket = self._spend.get(route, [])
+                cache_bucket = self._cache_hits.get(route, [])
+                self._evict_spend_locked(spend_bucket, now)
+                self._evict_cache_locked(cache_bucket, now)
+
+                r_in = sum(s.input_tokens for s in spend_bucket)
+                r_out = sum(s.output_tokens for s in spend_bucket)
+                r_usd = sum(s.usd for s in spend_bucket)
+                r_reqs = len(spend_bucket)
+                r_hits = len(cache_bucket)
+                denom = r_reqs + r_hits
+                hit_rate = (r_hits / denom) if denom > 0 else 0.0
+
+                routes_out[route] = {
+                    "input_tokens": r_in,
+                    "output_tokens": r_out,
+                    "usd": round(r_usd, 6),
+                    "requests": r_reqs,
+                    "cache_hits": r_hits,
+                    "cache_hit_rate": round(hit_rate, 4),
+                }
+                tot_in += r_in
+                tot_out += r_out
+                tot_usd += r_usd
+                tot_reqs += r_reqs
+                tot_hits += r_hits
+
+        total_denom = tot_reqs + tot_hits
+        total_hit_rate = (tot_hits / total_denom) if total_denom > 0 else 0.0
+        return {
+            "routes": routes_out,
+            "total": {
+                "input_tokens": tot_in,
+                "output_tokens": tot_out,
+                "usd": round(tot_usd, 6),
+                "requests": tot_reqs,
+                "cache_hits": tot_hits,
+                "cache_hit_rate": round(total_hit_rate, 4),
+            },
+        }
+
+    def reset(self) -> None:
+        """Testing helper — clears all buckets."""
+        with self._lock:
+            self._spend.clear()
+            self._cache_hits.clear()
+
+
+# Module-level singleton. Like slo_observer, tests can call .reset() between cases.
+token_observer = TokenSpendObserver()

--- a/tests/test_token_spend_metric.py
+++ b/tests/test_token_spend_metric.py
@@ -1,0 +1,263 @@
+"""
+Tests for the token-spend observer, /metrics/spend endpoint, and budget
+guardrail added in KAN-ask-spend.
+"""
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from app.slo_observer import TokenSpendObserver, token_observer
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — TokenSpendObserver
+# ---------------------------------------------------------------------------
+
+
+def test_observer_records_tokens_and_totals():
+    obs = TokenSpendObserver()
+    obs.record_tokens(
+        route="/intelligence/ask",
+        input_tokens=1000,
+        output_tokens=200,
+        usd_cost=0.012,
+        model="claude-sonnet-4-20250514",
+    )
+    obs.record_tokens(
+        route="/intelligence/ask",
+        input_tokens=500,
+        output_tokens=100,
+        usd_cost=0.006,
+        model="claude-sonnet-4-20250514",
+    )
+
+    snap = obs.get_spend_snapshot()
+    route = snap["routes"]["/intelligence/ask"]
+    assert route["input_tokens"] == 1500
+    assert route["output_tokens"] == 300
+    assert route["requests"] == 2
+    assert route["usd"] == pytest.approx(0.018, rel=1e-6)
+
+    total = snap["total"]
+    assert total["input_tokens"] == 1500
+    assert total["output_tokens"] == 300
+    assert total["requests"] == 2
+    assert total["usd"] == pytest.approx(0.018, rel=1e-6)
+
+
+def test_observer_aggregates_across_routes():
+    obs = TokenSpendObserver()
+    obs.record_tokens("/intelligence/ask", 100, 50, 0.005, "claude-sonnet-4-20250514")
+    obs.record_tokens("/intelligence/nl-filter", 200, 20, 0.0004, "claude-haiku-4-5")
+
+    snap = obs.get_spend_snapshot()
+    assert snap["total"]["requests"] == 2
+    assert snap["total"]["input_tokens"] == 300
+    assert snap["total"]["output_tokens"] == 70
+    assert snap["total"]["usd"] == pytest.approx(0.0054, rel=1e-6)
+    assert set(snap["routes"].keys()) == {"/intelligence/ask", "/intelligence/nl-filter"}
+
+
+def test_cache_hit_rate_math():
+    obs = TokenSpendObserver()
+    # 3 real Claude calls, 1 cache hit -> hit rate 1/4 = 0.25
+    for _ in range(3):
+        obs.record_tokens("/intelligence/ask", 100, 50, 0.005, "claude-sonnet-4-20250514")
+    obs.record_cache_hit("/intelligence/ask")
+
+    snap = obs.get_spend_snapshot()
+    route = snap["routes"]["/intelligence/ask"]
+    assert route["cache_hits"] == 1
+    assert route["requests"] == 3
+    assert route["cache_hit_rate"] == pytest.approx(0.25, rel=1e-6)
+    assert snap["total"]["cache_hit_rate"] == pytest.approx(0.25, rel=1e-6)
+
+
+def test_cache_hit_rate_zero_traffic():
+    obs = TokenSpendObserver()
+    snap = obs.get_spend_snapshot()
+    assert snap["total"]["cache_hit_rate"] == 0.0
+    assert snap["routes"] == {}
+
+
+def test_observer_thread_safety_concurrent_record_tokens():
+    obs = TokenSpendObserver()
+    threads = []
+    per_thread = 200
+    n_threads = 10
+
+    def worker():
+        for _ in range(per_thread):
+            obs.record_tokens(
+                "/intelligence/ask",
+                input_tokens=10,
+                output_tokens=5,
+                usd_cost=0.0001,
+                model="claude-sonnet-4-20250514",
+            )
+            obs.record_cache_hit("/intelligence/ask")
+
+    for _ in range(n_threads):
+        t = threading.Thread(target=worker)
+        threads.append(t)
+        t.start()
+    for t in threads:
+        t.join()
+
+    snap = obs.get_spend_snapshot()
+    route = snap["routes"]["/intelligence/ask"]
+    expected_reqs = per_thread * n_threads
+    assert route["requests"] == expected_reqs
+    assert route["cache_hits"] == expected_reqs
+    assert route["input_tokens"] == expected_reqs * 10
+    assert route["output_tokens"] == expected_reqs * 5
+    assert route["usd"] == pytest.approx(expected_reqs * 0.0001, rel=1e-6)
+
+
+def test_observer_reset():
+    obs = TokenSpendObserver()
+    obs.record_tokens("/intelligence/ask", 100, 50, 0.005, "claude-sonnet-4-20250514")
+    obs.record_cache_hit("/intelligence/ask")
+    obs.reset()
+    snap = obs.get_spend_snapshot()
+    assert snap["routes"] == {}
+    assert snap["total"]["requests"] == 0
+    assert snap["total"]["cache_hits"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Budget status transitions
+# ---------------------------------------------------------------------------
+
+
+def test_spend_status_thresholds():
+    from app.routers.platform import _spend_status
+
+    budget = 10.0
+    # Under 80% -> ok
+    assert _spend_status(0.0, budget) == "ok"
+    assert _spend_status(5.0, budget) == "ok"
+    assert _spend_status(7.99, budget) == "ok"
+    # 80% - 100% -> warning
+    assert _spend_status(8.0, budget) == "warning"
+    assert _spend_status(9.5, budget) == "warning"
+    # >= 100% -> breach
+    assert _spend_status(10.0, budget) == "breach"
+    assert _spend_status(15.0, budget) == "breach"
+
+
+def test_spend_status_zero_budget_is_ok():
+    from app.routers.platform import _spend_status
+
+    # A misconfigured zero budget should not crash the endpoint.
+    assert _spend_status(100.0, 0.0) == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Endpoint tests — /metrics/spend
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_metrics_spend_endpoint_shape(client):
+    token_observer.reset()
+
+    token_observer.record_tokens(
+        route="/intelligence/ask",
+        input_tokens=1000,
+        output_tokens=200,
+        usd_cost=0.012,
+        model="claude-sonnet-4-20250514",
+    )
+    token_observer.record_cache_hit("/intelligence/ask")
+
+    resp = await client.get("/metrics/spend")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    assert data["window_seconds"] == 24 * 60 * 60
+    assert data["source"] == "in_memory_accumulator"
+    assert "generated_at" in data
+    assert "daily_budget_usd" in data
+    assert isinstance(data["daily_budget_usd"], float)
+
+    total = data["total"]
+    for key in ("input_tokens", "output_tokens", "usd", "requests", "cache_hits", "cache_hit_rate"):
+        assert key in total
+    assert total["input_tokens"] == 1000
+    assert total["output_tokens"] == 200
+    assert total["requests"] == 1
+    assert total["cache_hits"] == 1
+    assert total["cache_hit_rate"] == pytest.approx(0.5, rel=1e-6)
+
+    assert "/intelligence/ask" in data["routes"]
+    assert data["status"] in {"ok", "warning", "breach"}
+
+
+@pytest.mark.asyncio
+async def test_metrics_spend_status_ok(client):
+    token_observer.reset()
+    # Way under default $10 budget
+    token_observer.record_tokens(
+        "/intelligence/ask", 100, 20, 0.001, "claude-sonnet-4-20250514"
+    )
+    resp = await client.get("/metrics/spend")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+
+@pytest.mark.asyncio
+async def test_metrics_spend_status_warning(client):
+    from app.config import settings
+
+    token_observer.reset()
+    # Push spend to ~85% of budget
+    token_observer.record_tokens(
+        "/intelligence/ask",
+        input_tokens=1,
+        output_tokens=1,
+        usd_cost=settings.spend_daily_budget_usd * 0.85,
+        model="claude-sonnet-4-20250514",
+    )
+    resp = await client.get("/metrics/spend")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "warning"
+
+
+@pytest.mark.asyncio
+async def test_metrics_spend_status_breach(client):
+    from app.config import settings
+
+    token_observer.reset()
+    # Push spend above budget
+    token_observer.record_tokens(
+        "/intelligence/ask",
+        input_tokens=1,
+        output_tokens=1,
+        usd_cost=settings.spend_daily_budget_usd * 1.25,
+        model="claude-sonnet-4-20250514",
+    )
+    resp = await client.get("/metrics/spend")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "breach"
+
+
+@pytest.mark.asyncio
+async def test_metrics_slo_includes_spend_summary(client):
+    """Grafana-style dashboards pulling /metrics/slo should get cost info for free."""
+    token_observer.reset()
+    token_observer.record_tokens(
+        "/intelligence/ask", 100, 20, 0.003, "claude-sonnet-4-20250514"
+    )
+    token_observer.record_cache_hit("/intelligence/ask")
+
+    resp = await client.get("/metrics/slo")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "spend_summary" in data
+    summary = data["spend_summary"]
+    assert summary["usd_24h"] == pytest.approx(0.003, rel=1e-6)
+    assert summary["cache_hit_rate"] == pytest.approx(0.5, rel=1e-6)
+    assert summary["status"] in {"ok", "warning", "breach"}


### PR DESCRIPTION
## Summary
- Adds `TokenSpendObserver` to `app/slo_observer.py` — thread-safe 24h in-memory accumulator tracking input/output tokens, USD cost, request count, and cache hits per route (same design pattern as the existing `SLOObserver`, $0 infra).
- Wires `record_tokens(...)` and `record_cache_hit(...)` into `/intelligence/ask`, `/intelligence/query`, and `/intelligence/nl-filter`. Smart-route / Redis / semantic cache hits increment the cache counter instead of token counters. All recording is wrapped in `try/except log_nonfatal` so a metrics bug can never break a real request.
- New `GET /metrics/spend` endpoint in `app/routers/platform.py` — returns per-route + total spend, cache hit-rate, and an `ok | warning | breach` status computed against the soft daily budget. Rate-limited to 30/min via shared `_limiter`.
- Extends `/metrics/slo` with a top-level `spend_summary` block (`usd_24h`, `cache_hit_rate`, `status`) so existing Grafana-style dashboards pulling that endpoint get cost data for free.
- Adds `spend_daily_budget_usd` (default `10.0`) to `Settings`. Intentionally NOT wired into any deploy workflow env var — the default is fine for prod; override locally if needed.
- `cost_tracker.py` (Redis-backed daily hard cap) was left untouched — its purpose is different (cross-instance enforcement) and already works. The new observer is purely additive for per-route observability.

## Why extend `slo_observer.py` and not `cost_tracker.py`?
`cost_tracker.py` is a Redis-backed global daily hard cap used to reject LLM calls when exhausted. It has no notion of route, token counts, or cache hits. The new observer mirrors `SLOObserver`'s in-memory rolling-window design, which is the right fit for per-route dashboarding and keeps the two concerns cleanly separated (hard cap vs soft guardrail + observability).

## Test plan
- [x] Unit: `TokenSpendObserver` records totals correctly across routes
- [x] Unit: cache hit-rate math (`hits / (hits + requests)`)
- [x] Unit: thread safety — 10 threads x 200 concurrent `record_tokens` + `record_cache_hit` calls
- [x] Unit: budget status transitions (ok < 80% → warning 80-100% → breach >= 100%) and zero-budget safety
- [x] Endpoint: `/metrics/spend` shape, populated totals, per-route bucket
- [x] Endpoint: `/metrics/spend` status transitions (ok / warning / breach)
- [x] Endpoint: `/metrics/slo` now includes `spend_summary`
- [x] Full suite: `pytest tests/` — 249 passed, 2 skipped (baseline 231 + 13 new + pre-existing drift)
- [ ] Manual smoke after deploy: hit `/metrics/spend` on a freshly-started instance and confirm `status: ok` with zero traffic, then verify it populates after an `/intelligence/ask` call

## Notes for reviewer
- No Sentry wiring in this PR — tracked separately as #230.
- Touches `app/routers/intelligence.py` minimally (4 insertions at the already-existing `record_cost` call site) to keep merge surface small against the sibling prompt-caching PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)