### PR TITLE
KAN-ask-cache: deeper prompt caching, query normalization, context hygiene

### DIFF
--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -209,13 +209,70 @@ _ROUTE_TEMPORAL = re.compile(
 )
 
 
+_QUERY_SYNONYMS = {
+    "llm": "large language model",
+    "llms": "large language models",
+    "vs": "versus",
+    "w/": "with",
+    "repo": "repository",
+    "repos": "repositories",
+    "ml": "machine learning",
+    "ai": "artificial intelligence",
+}
+
+# Compile once: whole-word match with optional trailing punctuation that shouldn't
+# block the match (e.g. "LLM?" → "llm" before trailing punctuation stripping).
+_SYNONYM_PATTERN = re.compile(
+    r"\b(" + "|".join(re.escape(k) for k in _QUERY_SYNONYMS.keys()) + r")\b",
+    re.IGNORECASE,
+)
+_TRAILING_PUNCT = re.compile(r"[\.\?\!,;]+$")
+_WHITESPACE_RUN = re.compile(r"\s+")
+
+
+def _normalize_question(text: str) -> str:
+    """
+    Normalize a user question for cache lookup and embedding generation.
+
+    Steps:
+      1. Lowercase
+      2. Strip leading/trailing whitespace
+      3. Collapse internal whitespace runs to single spaces
+      4. Remove trailing punctuation (. ? ! , ;)
+      5. Expand common synonyms via whole-word substitution
+
+    The normalized form is used ONLY for cache-key hashing and semantic-cache
+    embedding lookups. The original question is still shown in the Claude prompt
+    and logged verbatim.
+
+    Idempotent: _normalize_question(_normalize_question(x)) == _normalize_question(x).
+    """
+    if not text:
+        return ""
+    # 1 + 2: lowercase + strip
+    s = text.strip().lower()
+    # 3: collapse whitespace
+    s = _WHITESPACE_RUN.sub(" ", s)
+    # 4: strip trailing punctuation (may have trailing spaces again after)
+    s = _TRAILING_PUNCT.sub("", s).strip()
+    # 5: synonym expansion (whole-word, case-insensitive — already lowercased)
+    def _sub(match: re.Match) -> str:
+        return _QUERY_SYNONYMS[match.group(1).lower()]
+    s = _SYNONYM_PATTERN.sub(_sub, s)
+    # Collapse again in case expansion introduced extra spaces
+    s = _WHITESPACE_RUN.sub(" ", s).strip()
+    return s
+
+
 async def _try_smart_route(question: str, db: AsyncSession) -> dict | None:
     """
     Attempt to answer the question with a pure SQL query.
     Returns a dict with {"answer": str, "sources": list, "route": str} or None.
     Results are cached in Redis for 5 minutes.
     """
-    cache_key = f"smart_route:{hashlib.md5(question.lower().strip().encode()).hexdigest()}"
+    # Use normalized form for the cache key so trivial variants
+    # ("What is an LLM?" vs "what is an llm") share a cached result.
+    cache_key = f"smart_route:{hashlib.md5(_normalize_question(question).encode()).hexdigest()}"
     cached = await cache.get(cache_key)
     if cached:
         cached["cache_hit"] = True
@@ -885,6 +942,52 @@ def _truncate(value: str | None, max_len: int = _MAX_CONTENT_LEN) -> str | None:
         return None
     return value[:max_len]
 
+
+# KAN-ask-cache: max chars per repo description in the prompt sources block.
+# Tight budget — the task spec mandates 240 chars per repo description.
+_SOURCES_DESCRIPTION_MAX = 240
+
+
+def _build_sources_block(repos: list[dict]) -> str:
+    """
+    Build the <repos> block sent to Claude in the user message.
+
+    Context hygiene (KAN-ask-cache): only these fields are included per repo:
+      - name
+      - owner
+      - primary_category
+      - stars
+      - description (truncated to _SOURCES_DESCRIPTION_MAX chars)
+
+    Deliberately excluded (to minimize cached-sources input tokens and avoid
+    leaking noisy data into the context window):
+      - readme_summary, problem_solved
+      - language, license_spdx, activity_score
+      - has_tests, has_ci, relevance_score
+      - forked_from, secondary_category lists
+      - embedding arrays
+      - created_at / updated_at / last_push_at timestamps
+    """
+    parts: list[str] = []
+    for i, repo in enumerate(repos, 1):
+        name = repo.get("name") or ""
+        owner = repo.get("owner") or ""
+        category = repo.get("primary_category")
+        stars = repo.get("stars") or 0
+        description = repo.get("description") or ""
+        if description:
+            description = description[:_SOURCES_DESCRIPTION_MAX]
+        repo_lines = [f"name: {owner}/{name}" if owner else f"name: {name}",
+                      f"stars: {stars}"]
+        if category:
+            repo_lines.append(f"category: {category}")
+        if description:
+            repo_lines.append(f"description: {description}")
+        parts.append(
+            f"<repo index=\"{i}\">\n" + "\n".join(repo_lines) + "\n</repo>"
+        )
+    return "\n\n".join(parts)
+
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/intelligence", tags=["Intelligence"])
@@ -1034,13 +1137,32 @@ async def _load_session_turns(session_id: str, db: AsyncSession) -> list[dict]:
         log_nonfatal("_load_session_turns", session_id=session_id)
         return []
 
-    # Rows are newest-first; reverse to oldest-first for correct message order
+    # Rows are newest-first. Build oldest-first (user, assistant) pairs.
+    # KAN-ask-cache: session memory compaction — keep only the MOST RECENT
+    # turn verbatim; older turns collapse the assistant answer to an 80-char
+    # preview prefixed with "[prior: ...]". The user question stays intact
+    # (it's usually short and carries the semantic signal). This cuts session
+    # history size by ~60–70% for 3-turn sessions while preserving continuity.
+    ordered_rows = list(reversed(rows))  # oldest-first
     turns: list[dict] = []
-    for row in reversed(rows):
-        turns.append({"role": "user", "content": row.question})
-        turns.append({"role": "assistant", "content": row.answer})
+    last_idx = len(ordered_rows) - 1
+    for idx, row in enumerate(ordered_rows):
+        q = row.question or ""
+        a = row.answer or ""
+        if idx == last_idx:
+            # Most recent turn — verbatim
+            turns.append({"role": "user", "content": q})
+            turns.append({"role": "assistant", "content": a})
+        else:
+            # Older turn — compact assistant side to an 80-char prior-preview
+            preview = a.strip().replace("\n", " ")[:80]
+            turns.append({"role": "user", "content": q})
+            turns.append({
+                "role": "assistant",
+                "content": f"[prior: {preview}]" if preview else "[prior: (no answer)]",
+            })
 
-    # KAN-197: Cap session history at ~2000 tokens (~8000 chars) to prevent runaway costs
+    # KAN-197: Cap session history at ~2000 tokens (~8000 chars) as a safety net
     MAX_SESSION_CHARS = 8000
     total_chars = 0
     capped_history: list[dict] = []
@@ -1545,7 +1667,10 @@ async def _prepare_query(
         )
 
     # 0b. Redis fast-path cache — check before embedding/pgvector (much faster)
-    redis_cache_key = f"llm_response:{hashlib.md5(question.lower().strip().encode()).hexdigest()}"
+    # Normalized form collapses whitespace/casing/synonym variants so
+    # "What is an LLM?" and "what is a large language model" share a cache row.
+    normalized_question = _normalize_question(question)
+    redis_cache_key = f"llm_response:{hashlib.md5(normalized_question.encode()).hexdigest()}"
     redis_cached = await cache.get(redis_cache_key)
     if redis_cached is not None:
         logger.info("ask: Redis cache hit for question")
@@ -1572,7 +1697,10 @@ async def _prepare_query(
 
     # 1. Embed the question — model is pre-warmed at startup so this is fast.
     # Issue #208: Embedding is computed once per request in _prepare_query().
-    query_embedding = embed_model.encode(question)
+    # KAN-ask-cache: embed the NORMALIZED form so semantic cache hits tolerate
+    # whitespace/case/synonym variance. Original question is still used in the
+    # Claude prompt and logged verbatim.
+    query_embedding = embed_model.encode(normalized_question)
 
     # 2. Semantic cache check
     cached = await _find_semantic_cache_hit(db, question_embedding=query_embedding)
@@ -1653,44 +1781,16 @@ async def _prepare_query(
     scored.sort(key=lambda r: r["similarity"], reverse=True)
     top_for_answer = scored[:top_k]
 
-    # 4. Build context for Claude
-    context_parts = []
-    for i, repo in enumerate(top_for_answer, 1):
-        upstream = repo["forked_from"] or f"{repo['owner']}/{repo['name']}"
-        desc = _truncate(repo["description"])
-        readme = _truncate(repo["readme_summary"])
-        problem = _truncate(repo["problem_solved"])
-        parts = [f"name: {upstream}", f"stars: {repo['stars'] or 0}"]
-        if desc:
-            parts.append(f"description: {desc}")
-        if readme:
-            parts.append(f"summary: {readme}")
-        if problem:
-            parts.append(f"problem_solved: {problem}")
-        category = repo.get("primary_category")
-        language = repo.get("language")
-        license_spdx = repo.get("license_spdx")
-        activity = repo.get("activity_score")
-        has_tests = repo.get("has_tests")
-        has_ci = repo.get("has_ci")
-        if category:
-            parts.append(f"category: {category}")
-        if language:
-            parts.append(f"language: {language}")
-        if license_spdx:
-            parts.append(f"license: {license_spdx}")
-        if activity is not None:
-            parts.append(f"activity_score: {activity}")
-        if has_tests is not None:
-            parts.append(f"has_tests: {has_tests}")
-        if has_ci is not None:
-            parts.append(f"has_ci: {has_ci}")
-        parts.append(f"relevance_score: {repo['similarity']:.4f}")
-        context_parts.append(
-            f"<repo index=\"{i}\">\n" + "\n".join(parts) + "\n</repo>"
-        )
-
-    context = "\n\n".join(context_parts)
+    # 4. Build context for Claude — KAN-ask-cache: context hygiene
+    # Only these fields are sent (per-repo): name, owner, primary_category,
+    # stars, description (truncated to 240 chars). Removed from the prompt:
+    # readme_summary, problem_solved, language, license_spdx, activity_score,
+    # has_tests, has_ci, relevance_score, forked_from, secondary categories,
+    # embedding arrays, timestamps. These fields were previously contributing
+    # ~350–500 tokens per repo; trimming to essentials saves ~60–70% of the
+    # sources block size (estimate: ~1.5–2.5k input tokens saved per call at
+    # top_k=5) and lets the cached-sources block compress more consistently.
+    context = _build_sources_block(top_for_answer)
 
     # 5. Knowledge graph edges for related repos (with per-repo Redis caching)
     if top_for_answer:
@@ -1877,12 +1977,16 @@ async def _run_query(
 
     client = _get_client()
 
-    user_prompt = (
-        f"Answer the following question using only the repo data provided below.\n\n"
-        f"<question>{req.question}</question>\n\n"
-        f"<repos>\n{qctx.context_text}\n</repos>\n\n"
-        f"Cite repos by their upstream name. If the context is insufficient, say so."
+    # KAN-ask-cache: split the user message into two content blocks so that the
+    # large <sources> block is cached separately from the (per-request) question.
+    # Session history messages go BEFORE the cached sources so they don't
+    # invalidate the cache key (they change per session).
+    sources_content_block = (
+        "Answer the following question using only the repo data provided below. "
+        "Cite repos by their upstream name. If the context is insufficient, say so.\n\n"
+        f"<sources>\n{qctx.context_text}\n</sources>"
     )
+    question_content_block = f"<question>{req.question}</question>"
 
     loop = asyncio.get_event_loop()
 
@@ -1898,7 +2002,20 @@ async def _run_query(
                 }],
                 messages=[
                     *qctx.session_history,
-                    {"role": "user", "content": user_prompt},
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": sources_content_block,
+                                "cache_control": {"type": "ephemeral"},
+                            },
+                            {
+                                "type": "text",
+                                "text": question_content_block,
+                            },
+                        ],
+                    },
                 ],
             )
 
@@ -2122,11 +2239,15 @@ async def intelligence_ask_stream(
 
             anthropic_client = _get_client()
 
-            user_prompt = (
-                f"Here are the most relevant repos from the library:\n\n{qctx.context_text}\n\n"
-                f"Question: {req.question}\n\n"
-                "Please answer the question based on the repos above."
+            # KAN-ask-cache: same two-block structure as the non-streaming path.
+            # The <sources> block is marked for ephemeral caching; the question
+            # is NOT cached. Session history precedes the cached block.
+            sources_content_block = (
+                "Here are the most relevant repos from the library. "
+                "Please answer the user's question based on the repos below.\n\n"
+                f"<sources>\n{qctx.context_text}\n</sources>"
             )
+            question_content_block = f"<question>{req.question}</question>"
 
             full_answer = ""
             input_tokens = 0
@@ -2144,7 +2265,20 @@ async def intelligence_ask_stream(
                         }],
                         messages=[
                             *qctx.session_history,
-                            {"role": "user", "content": user_prompt},
+                            {
+                                "role": "user",
+                                "content": [
+                                    {
+                                        "type": "text",
+                                        "text": sources_content_block,
+                                        "cache_control": {"type": "ephemeral"},
+                                    },
+                                    {
+                                        "type": "text",
+                                        "text": question_content_block,
+                                    },
+                                ],
+                            },
                         ],
                     )
 

--- a/tests/test_ask_context_hygiene.py
+++ b/tests/test_ask_context_hygiene.py
@@ -1,0 +1,113 @@
+"""
+KAN-ask-cache: Tests for context hygiene in _build_sources_block.
+
+The sources block sent to Claude must contain ONLY these per-repo fields:
+  - name, owner, primary_category, stars, description (truncated to 240 chars)
+
+Excluded for cost/noise reasons:
+  - readme_summary, problem_solved
+  - language, license_spdx, activity_score
+  - has_tests, has_ci, relevance_score
+  - forked_from, secondary_category lists
+  - embedding arrays
+  - created_at / updated_at / last_push_at timestamps
+"""
+from app.routers.intelligence import _build_sources_block, _SOURCES_DESCRIPTION_MAX
+
+
+def _mock_repo():
+    return {
+        "name": "langchain",
+        "owner": "langchain-ai",
+        "primary_category": "LLM Framework",
+        "stars": 95000,
+        "description": "Build LLM applications with composable primitives.",
+        # Fields that MUST be filtered out:
+        "readme_summary": "LangChain is a framework for developing applications powered by language models. It enables applications that are context-aware and reason.",
+        "problem_solved": "Orchestrating LLM pipelines and connecting them to external tools.",
+        "language": "Python",
+        "license_spdx": "MIT",
+        "activity_score": 98,
+        "has_tests": True,
+        "has_ci": True,
+        "similarity": 0.9234,
+        "forked_from": None,
+        "secondary_categories": ["Tooling", "Agents"],
+        "embedding_vec": [0.1] * 384,
+        "created_at": "2022-10-01T00:00:00Z",
+        "updated_at": "2026-03-20T00:00:00Z",
+        "integration_tags": ["openai", "anthropic"],
+    }
+
+
+def test_sources_block_includes_required_fields():
+    block = _build_sources_block([_mock_repo()])
+    assert "langchain" in block
+    assert "langchain-ai" in block
+    assert "LLM Framework" in block
+    assert "95000" in block
+    assert "Build LLM applications" in block
+
+
+def test_sources_block_excludes_secondary_fields():
+    block = _build_sources_block([_mock_repo()])
+    # Heavy fields that used to live in the prompt
+    assert "readme_summary" not in block
+    assert "LangChain is a framework for developing" not in block  # full README summary text
+    assert "problem_solved" not in block
+    assert "Orchestrating LLM pipelines" not in block
+    assert "language:" not in block
+    assert "Python" not in block
+    assert "license:" not in block
+    assert "MIT" not in block
+    assert "activity_score" not in block
+    assert "has_tests" not in block
+    assert "has_ci" not in block
+    assert "relevance_score" not in block
+    assert "0.9234" not in block
+    assert "secondary_categories" not in block
+    assert "Tooling" not in block
+    assert "embedding" not in block
+    assert "created_at" not in block
+    assert "updated_at" not in block
+    assert "2026-03-20" not in block
+    assert "integration_tags" not in block
+
+
+def test_description_truncated_to_240_chars():
+    repo = _mock_repo()
+    repo["description"] = "x" * 500
+    block = _build_sources_block([repo])
+    # The truncation is 240 chars on the description field specifically
+    assert "x" * _SOURCES_DESCRIPTION_MAX in block
+    assert "x" * (_SOURCES_DESCRIPTION_MAX + 1) not in block
+
+
+def test_empty_repo_list_produces_empty_block():
+    assert _build_sources_block([]) == ""
+
+
+def test_multiple_repos_numbered():
+    repos = [_mock_repo(), {**_mock_repo(), "name": "llamaindex", "owner": "run-llama"}]
+    block = _build_sources_block(repos)
+    assert 'index="1"' in block
+    assert 'index="2"' in block
+    assert "langchain" in block
+    assert "llamaindex" in block
+
+
+def test_missing_optional_fields_are_omitted():
+    # If primary_category or description are None/missing, they just aren't
+    # emitted — no "category: None" or "description: None" noise.
+    repo = {
+        "name": "tiny",
+        "owner": "me",
+        "stars": 0,
+        "primary_category": None,
+        "description": None,
+    }
+    block = _build_sources_block([repo])
+    assert "tiny" in block
+    assert "None" not in block
+    assert "category:" not in block
+    assert "description:" not in block

--- a/tests/test_ask_memory.py
+++ b/tests/test_ask_memory.py
@@ -241,13 +241,24 @@ async def test_ask_with_session_id_prepends_history_to_claude(client: AsyncClien
     # The messages array should have: prior user, prior assistant, current user
     # (prior rows are reversed: newest-first from DB → oldest-first in messages)
     # With 1 row returned (the prior turn), messages = [user, assistant, current_user]
+    # KAN-ask-cache: the current user message now uses a structured content list
+    # with two text blocks: <sources> (cached) + <question> (not cached).
     assert len(captured_messages) >= 3
     assert captured_messages[0]["role"] == "user"
     assert captured_messages[0]["content"] == "What is LangChain?"
     assert captured_messages[1]["role"] == "assistant"
     assert "LangChain" in captured_messages[1]["content"]
     assert captured_messages[-1]["role"] == "user"
-    assert "RAG" in captured_messages[-1]["content"]
+    current_content = captured_messages[-1]["content"]
+    # New two-block structured content (sources + question)
+    assert isinstance(current_content, list)
+    joined = " ".join(block.get("text", "") for block in current_content)
+    assert "RAG" in joined
+    # Exactly one block should carry ephemeral cache_control (the sources block)
+    cached_blocks = [b for b in current_content if b.get("cache_control")]
+    assert len(cached_blocks) == 1
+    assert cached_blocks[0]["cache_control"] == {"type": "ephemeral"}
+    assert "<sources>" in cached_blocks[0]["text"]
 
 
 @pytest.mark.asyncio

--- a/tests/test_ask_query_normalization.py
+++ b/tests/test_ask_query_normalization.py
@@ -1,0 +1,87 @@
+"""
+KAN-ask-cache: Tests for _normalize_question query normalization.
+
+The normalized form is used for both the smart-route/redis cache key and the
+semantic-cache embedding lookup, so trivial variants ("What is an LLM?" vs
+"what is a large language model") collapse to the same cache entry. The
+original question is still passed to Claude verbatim.
+"""
+from app.routers.intelligence import _normalize_question
+
+
+def test_whitespace_is_collapsed():
+    assert _normalize_question("what   is\tan\n  llm") == "what is an large language model"
+
+
+def test_leading_and_trailing_whitespace_stripped():
+    assert _normalize_question("   hello world   ") == "hello world"
+
+
+def test_case_insensitivity():
+    assert _normalize_question("WHAT IS RAG") == _normalize_question("what is rag")
+    assert _normalize_question("WHAT IS RAG") == "what is rag"
+
+
+def test_trailing_punctuation_stripped():
+    assert _normalize_question("hello world!") == "hello world"
+    assert _normalize_question("hello world?") == "hello world"
+    assert _normalize_question("hello world.") == "hello world"
+    assert _normalize_question("hello world;") == "hello world"
+    assert _normalize_question("hello world,") == "hello world"
+    # Multiple trailing punctuation characters
+    assert _normalize_question("hello world?!") == "hello world"
+
+
+def test_internal_punctuation_preserved():
+    # Only TRAILING punctuation is stripped — internal punctuation stays
+    assert "," in _normalize_question("hello, world today")
+
+
+def test_synonym_expansion_llm():
+    assert _normalize_question("what is an LLM?") == "what is an large language model"
+
+
+def test_synonym_expansion_multiple():
+    out = _normalize_question("show me ML repos vs AI repos")
+    # "ml" -> "machine learning", "repos" -> "repositories", "vs" -> "versus", "ai" -> "artificial intelligence"
+    assert "machine learning" in out
+    assert "artificial intelligence" in out
+    assert "versus" in out
+    assert "repositories" in out
+
+
+def test_synonym_whole_word_only():
+    # "repository" should NOT match "repo" synonym (whole-word match only).
+    # The real risk: inside an unrelated word like "llama" — must not match "ml".
+    out = _normalize_question("llama training")
+    assert "llama" in out
+    # "llama" should not be corrupted by "ml" → "machine learning" substitution
+    assert "machine learning training" not in out
+
+
+def test_idempotency():
+    inputs = [
+        "What is an LLM?",
+        "   show ME  ml repos vs ai repos!!!",
+        "hello world",
+        "",
+        "Simple question",
+        "repo vs ml",
+    ]
+    for inp in inputs:
+        once = _normalize_question(inp)
+        twice = _normalize_question(once)
+        assert once == twice, f"Not idempotent for {inp!r}: {once!r} -> {twice!r}"
+
+
+def test_empty_and_whitespace_only():
+    assert _normalize_question("") == ""
+    assert _normalize_question("   ") == ""
+
+
+def test_variants_collapse_to_same_key():
+    # The primary value prop — trivial variants share a cache entry.
+    v1 = _normalize_question("What is an LLM?")
+    v2 = _normalize_question("what  is  an  llm")
+    v3 = _normalize_question("WHAT IS AN LLM!")
+    assert v1 == v2 == v3


### PR DESCRIPTION
## Summary

Highest-impact `$0` change to `/intelligence/ask` cost efficiency. Tightens the prompt so the large `<sources>` block caches separately from the question, collapses trivial query variants to the same cache entry, and strips noisy per-repo fields from the context window.

## Deliverables

### 1. Ephemeral prompt caching on the retrieved sources block
Both Claude call sites (non-streaming `_run_query` and streaming `intelligence_ask_stream`) now send the user message as a structured two-block content list:

```python
"content": [
    {"type": "text", "text": "<sources>...</sources>", "cache_control": {"type": "ephemeral"}},
    {"type": "text", "text": "<question>...</question>"},  # not cached
]
```

Session history messages precede the cached sources block so they don't invalidate the cache key (they change per session).

### 2. Query normalization
New `_normalize_question()` helper: lowercase, whitespace collapse, trailing-punct strip, synonym expansion (`llm`/`ml`/`ai`/`vs`/`w/`/`repo`). Used for:
- smart-route Redis cache key hash
- `/ask` Redis fast-path cache key hash
- semantic-cache embedding lookup

The original question is still shown to Claude and logged verbatim. `"What is an LLM?"`, `"what is an llm"`, and `"WHAT IS AN LLM!"` now collapse to the same cache row.

### 3. Context hygiene
New `_build_sources_block()` emits ONLY these per-repo fields:
- `name`, `owner`, `primary_category`, `stars`, `description` (truncated to 240 chars)

Removed from the prompt context:
- `readme_summary`, `problem_solved`
- `language`, `license_spdx`, `activity_score`
- `has_tests`, `has_ci`, `relevance_score`
- `forked_from`, secondary categories, embedding arrays, timestamps

### 4. Session memory compaction
`_load_session_turns` now keeps the most recent turn verbatim and replaces older-turn assistant answers with an 80-char `[prior: ...]` preview. User questions stay intact.

## Estimated token savings per cache-miss call (top_k=5)

| Change | Input tokens saved | Conditions |
|---|---|---|
| Sources hygiene | ~1.5k–2.5k | Every call, unconditionally |
| Sources block cache hit | ~1.5k billed at ~10% rate | Same retrieved repo set + same normalized question within ~5 min |
| Session compaction (3-turn) | ~600–1k | Sessions with >=2 turns of history |

**Honest bounds:** the ephemeral sources cache only hits when the same repo set + normalized question reappears within the ~5-minute cache window, so real-world savings depend heavily on query repetition. The context hygiene savings apply to every call. Query normalization widens the semantic-cache hit rate by an unknown but plausibly double-digit percent for casual user traffic.

## Tests

Before: 236 passed / 2 skipped on `origin/dev`
After: **253 passed / 2 skipped** (17 new tests)

- `tests/test_ask_query_normalization.py` (11 tests: whitespace, case, punctuation, synonyms, idempotency, cache-key collapse)
- `tests/test_ask_context_hygiene.py` (6 tests: required fields present, excluded fields absent, 240-char truncation, numbered multi-repo, None-handling)
- `tests/test_ask_memory.py` updated for the new structured user-message format (asserts two content blocks with one ephemeral `cache_control`)

No existing tests disabled. No new dependencies. No new DB tables.

## Test plan

- [ ] Deploy to staging and verify `/intelligence/ask` still returns correct answers
- [ ] Confirm Anthropic usage reports show `cache_read_input_tokens` on repeat queries (non-zero means the sources cache is being hit)
- [ ] Spot-check that logged `question` in `query_log` still matches what users typed (normalization must not leak into logs)
- [ ] Exercise a multi-turn session and confirm older turns show the `[prior: ...]` compaction while the latest turn is verbatim

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>