### PR TITLE
KAN-metrics-auth: optional admin-key gate on observability endpoints (closes #236)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,3 +22,7 @@ GITHUB_SHA=
 # Optional model/webhook integrations
 ANTHROPIC_API_KEY=
 GITHUB_WEBHOOK_SECRET=
+
+# Optional: when set to 1, requires X-Admin-Key header on /metrics/* and /audit/status.
+# Leave unset for open metrics (default — matches pre-#236 behavior).
+METRICS_REQUIRE_AUTH=

--- a/app/auth.py
+++ b/app/auth.py
@@ -65,6 +65,33 @@ async def require_admin_key(
         raise HTTPException(status_code=403, detail="Invalid admin key")
 
 
+async def require_metrics_access(
+    x_admin_key: str | None = Security(_ADMIN_KEY_HEADER),
+) -> None:
+    """
+    Feature-flagged admin-key gate for observability endpoints.
+
+    When ``METRICS_REQUIRE_AUTH=1`` is set, this dependency enforces the same
+    X-Admin-Key semantics as :func:`require_admin_key`. When the env var is
+    unset or empty, this is a no-op so the /metrics/* and /audit/status
+    endpoints stay open — matching pre-#236 behavior for backward compat.
+
+    Closes #236.
+    """
+    if os.getenv("METRICS_REQUIRE_AUTH", "").strip() != "1":
+        return  # gate disabled — endpoints stay open (default)
+    admin_key = os.getenv("ADMIN_API_KEY", "")
+    if not admin_key:
+        if _IS_PRODUCTION:
+            logger.error("METRICS_REQUIRE_AUTH=1 but ADMIN_API_KEY not set")
+            raise HTTPException(status_code=500, detail="Server misconfiguration")
+        return  # Dev mode with flag on but no key — allow
+    if not _secrets_equal(x_admin_key, admin_key):
+        raise HTTPException(
+            status_code=403, detail="Admin key required for metrics endpoints"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Ingest key - protects ingest pipeline endpoints (POST /ingest/*)
 # Accept both X-Ingest-Key and the legacy X-Admin-Key for backward compatibility.

--- a/app/routers/platform.py
+++ b/app/routers/platform.py
@@ -9,7 +9,7 @@ from slowapi.util import get_remote_address
 from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.auth import require_ingest_key, verify_api_key
+from app.auth import require_ingest_key, require_metrics_access, verify_api_key
 from app.config import settings
 from app.database import get_db
 from app.models.repo import Repo, RepoAIDevSkill, RepoCategory
@@ -33,7 +33,10 @@ router = APIRouter(tags=["Platform"])
 
 
 @router.get("/metrics/latest", response_model=dict)
-async def metrics_latest(db: AsyncSession = Depends(get_db)) -> dict:
+async def metrics_latest(
+    db: AsyncSession = Depends(get_db),
+    _gate: None = Depends(require_metrics_access),
+) -> dict:
     """Platform metrics for reporium-metrics to consume."""
     total = (await db.execute(select(func.count(Repo.id)))).scalar_one()
 
@@ -72,7 +75,10 @@ async def metrics_latest(db: AsyncSession = Depends(get_db)) -> dict:
 
 
 @router.get("/audit/status", response_model=dict)
-async def audit_status(db: AsyncSession = Depends(get_db)) -> dict:
+async def audit_status(
+    db: AsyncSession = Depends(get_db),
+    _gate: None = Depends(require_metrics_access),
+) -> dict:
     """Platform health for reporium-roadmap to consume."""
     db_ok = False
     try:
@@ -100,7 +106,9 @@ async def audit_status(db: AsyncSession = Depends(get_db)) -> dict:
 
 
 @router.get("/metrics/slo", response_model=dict)
-async def metrics_slo() -> dict:
+async def metrics_slo(
+    _gate: None = Depends(require_metrics_access),
+) -> dict:
     """
     Live 24h SLO snapshot for the routes documented in docs/SLOs.md.
 
@@ -171,7 +179,10 @@ def _spend_status(total_usd: float, budget_usd: float) -> str:
 
 @router.get("/metrics/spend", response_model=dict)
 @_limiter.limit("30/minute")
-async def metrics_spend(request: Request) -> dict:
+async def metrics_spend(
+    request: Request,
+    _gate: None = Depends(require_metrics_access),
+) -> dict:
     """
     Live 24h LLM token-spend snapshot for cost observability.
 

--- a/tests/test_metrics_auth_gate.py
+++ b/tests/test_metrics_auth_gate.py
@@ -1,0 +1,89 @@
+"""
+Tests for the optional admin-key gate on observability endpoints (#236).
+
+The gate is controlled by the ``METRICS_REQUIRE_AUTH`` env var:
+  - unset / empty  -> endpoints stay open (pre-#236 behavior)
+  - "1"            -> X-Admin-Key header required
+
+Covers ``app.auth.require_metrics_access`` directly and the /metrics/slo
+endpoint end-to-end via the TestClient fixture in conftest.
+"""
+import pytest
+from fastapi import HTTPException
+
+from app.auth import require_metrics_access
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — require_metrics_access dependency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_require_metrics_access_noop_when_flag_unset(monkeypatch):
+    monkeypatch.delenv("METRICS_REQUIRE_AUTH", raising=False)
+    monkeypatch.setenv("ADMIN_API_KEY", "secret-key")
+    # No header, no flag -> must be a no-op (no exception).
+    assert await require_metrics_access(x_admin_key=None) is None
+
+
+@pytest.mark.asyncio
+async def test_require_metrics_access_noop_when_flag_empty(monkeypatch):
+    monkeypatch.setenv("METRICS_REQUIRE_AUTH", "")
+    monkeypatch.setenv("ADMIN_API_KEY", "secret-key")
+    assert await require_metrics_access(x_admin_key=None) is None
+
+
+@pytest.mark.asyncio
+async def test_require_metrics_access_403_when_flag_set_no_header(monkeypatch):
+    monkeypatch.setenv("METRICS_REQUIRE_AUTH", "1")
+    monkeypatch.setenv("ADMIN_API_KEY", "secret-key")
+    with pytest.raises(HTTPException) as exc_info:
+        await require_metrics_access(x_admin_key=None)
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_require_metrics_access_403_when_flag_set_wrong_key(monkeypatch):
+    monkeypatch.setenv("METRICS_REQUIRE_AUTH", "1")
+    monkeypatch.setenv("ADMIN_API_KEY", "secret-key")
+    with pytest.raises(HTTPException) as exc_info:
+        await require_metrics_access(x_admin_key="nope")
+    assert exc_info.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_require_metrics_access_passes_with_correct_key(monkeypatch):
+    monkeypatch.setenv("METRICS_REQUIRE_AUTH", "1")
+    monkeypatch.setenv("ADMIN_API_KEY", "secret-key")
+    # Must not raise and must return None.
+    assert await require_metrics_access(x_admin_key="secret-key") is None
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — /metrics/slo end-to-end
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_metrics_slo_open_when_flag_unset(client, monkeypatch):
+    """Backward-compat: gate off by default, endpoint stays open."""
+    monkeypatch.delenv("METRICS_REQUIRE_AUTH", raising=False)
+    resp = await client.get("/metrics/slo")
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_metrics_slo_403_when_flag_set_no_header(client, monkeypatch):
+    monkeypatch.setenv("METRICS_REQUIRE_AUTH", "1")
+    monkeypatch.setenv("ADMIN_API_KEY", "secret-key")
+    resp = await client.get("/metrics/slo")
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_metrics_slo_200_when_flag_set_correct_key(client, monkeypatch):
+    monkeypatch.setenv("METRICS_REQUIRE_AUTH", "1")
+    monkeypatch.setenv("ADMIN_API_KEY", "secret-key")
+    resp = await client.get("/metrics/slo", headers={"X-Admin-Key": "secret-key"})
+    assert resp.status_code == 200


### PR DESCRIPTION
## Summary

Closes #236.

Adds an **opt-in** admin-key gate to the four currently-unauthenticated observability endpoints flagged in the security audit:

- `GET /metrics/slo`
- `GET /metrics/spend`
- `GET /metrics/latest`
- `GET /audit/status`

The gate is controlled by a new env var `METRICS_REQUIRE_AUTH`:

- **Unset / empty** (default) — endpoints stay open. Fully backward compatible with pre-#236 behavior; existing dashboards and sibling repos (reporium-metrics, reporium-roadmap) keep working with zero changes.
- **`METRICS_REQUIRE_AUTH=1`** — endpoints require `X-Admin-Key` header matching `ADMIN_API_KEY`, with the same timing-safe comparison (`_secrets_equal`) used by `require_admin_key` and the rest of the auth module after #242.

`GET /health` is intentionally left unauthenticated — it remains the only freely-probeable liveness endpoint.

### Implementation notes

- New dependency `require_metrics_access` in `app/auth.py` reuses the existing `_ADMIN_KEY_HEADER` and `_secrets_equal` helpers — no duplicated secret-comparison logic.
- Wired via `Depends(require_metrics_access)` on the four endpoints in `app/routers/platform.py`. No other endpoints touched.
- `.env.example` documents the new flag.
- Dev-mode ergonomics preserved: with `METRICS_REQUIRE_AUTH=1` set but `ADMIN_API_KEY` unset, the gate no-ops in non-production (matching `require_admin_key` dev-mode behavior); in production it returns 500 misconfig.

### Rollout

This PR **ships the capability but does not flip the flag on**. To enable in Cloud Run when dashboards are ready:

```
gcloud run services update reporium-api --region=us-central1   --set-env-vars=METRICS_REQUIRE_AUTH=1
```

## Test plan

New file `tests/test_metrics_auth_gate.py` (8 tests, all green):

Unit tests on `require_metrics_access`:
- [x] No-op when `METRICS_REQUIRE_AUTH` is unset
- [x] No-op when `METRICS_REQUIRE_AUTH` is empty string
- [x] 403 when flag set and no header provided
- [x] 403 when flag set and wrong key provided
- [x] Passes (returns None) when flag set and correct key provided

Integration tests via `AsyncClient` fixture:
- [x] `/metrics/slo` returns 200 without header when flag unset (backward compat)
- [x] `/metrics/slo` returns 403 when flag set and no header
- [x] `/metrics/slo` returns 200 when flag set and correct `X-Admin-Key` header

Full-suite result: 277 passed, 20 pre-existing failures (all in `test_intelligence.py` prompt-injection parametrizations, unrelated to this change — same failure set exists on `dev` baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)