### PR TITLE
KAN-ask-reliability: connection pool sizing, fire-and-forget error logging, startup env validation

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -14,6 +14,9 @@ engine = create_async_engine(
     settings.database_url,
     echo=settings.environment == "development",
     pool_pre_ping=True,
+    pool_size=20,
+    max_overflow=10,
+    pool_recycle=3600,
 )
 
 async_session_factory = async_sessionmaker(engine, expire_on_commit=False)

--- a/app/main.py
+++ b/app/main.py
@@ -49,6 +49,11 @@ logger = logging.getLogger(__name__)
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # Startup env validation: warn loudly if APP_API_TOKEN is missing in production.
+    _env = os.environ.get("ENV") or os.environ.get("ENVIRONMENT") or ""
+    if _env.lower() == "production" and not os.environ.get("APP_API_TOKEN"):
+        logger.critical("APP_API_TOKEN not set in production — /ask endpoint will reject all requests")
+
     await cache.connect()
     await check_db_connection()
     # Pre-warm the sentence-transformers model so the first /search/semantic

--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -1070,6 +1070,16 @@ def _build_sources_block(repos: list[dict]) -> str:
 
 logger = logging.getLogger(__name__)
 
+
+def _task_done_callback(task: asyncio.Task) -> None:
+    """Log exceptions from fire-and-forget background tasks."""
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc:
+        logger.warning("Background task %s failed: %s", task.get_name(), exc, exc_info=False)
+
+
 router = APIRouter(prefix="/intelligence", tags=["Intelligence"])
 
 # Timeout (seconds) for the synchronous Anthropic API call.
@@ -2093,7 +2103,7 @@ async def _run_query(
             model=qctx.model,
             question_embedding=np.array(qctx.query_embedding) if qctx.query_embedding else None,
             cache_hit=cached.get("cache_hit", False),
-        ))
+        )).add_done_callback(_task_done_callback)
         return response
 
     # KAN-ask-output-caps: low-similarity early-exit guard. If retrieval
@@ -2124,7 +2134,7 @@ async def _run_query(
                 "tokens_used": {"input": 0, "output": 0, "total": 0},
                 "model": "early-exit",
                 "negative": True,
-            }, ttl=300))
+            }, ttl=300)).add_done_callback(_task_done_callback)
         asyncio.create_task(_log_query(
             question=req.question,
             answer=_EARLY_EXIT_ANSWER,
@@ -2136,7 +2146,7 @@ async def _run_query(
             model="early-exit",
             question_embedding=None,
             cache_hit=False,
-        ))
+        )).add_done_callback(_task_done_callback)
         return early_response
 
     # Daily cost cap check — reject before calling Claude if budget exhausted
@@ -2270,10 +2280,10 @@ async def _run_query(
     }
     if _negative:
         _cache_payload["negative"] = True
-        asyncio.create_task(cache.set(qctx.redis_cache_key, _cache_payload, ttl=60))
+        asyncio.create_task(cache.set(qctx.redis_cache_key, _cache_payload, ttl=60)).add_done_callback(_task_done_callback)
         logger.info("ask: negative-cached low-quality answer (len=%d)", len(answer or ""))
     else:
-        asyncio.create_task(cache.set(qctx.redis_cache_key, _cache_payload, ttl=1800))
+        asyncio.create_task(cache.set(qctx.redis_cache_key, _cache_payload, ttl=1800)).add_done_callback(_task_done_callback)
 
     # Fire-and-forget — log after response is built, never blocks the caller.
     # For negative/low-quality answers, log with NULL embedding so the row is
@@ -2295,7 +2305,7 @@ async def _run_query(
         latency_ms=int((time.monotonic() - _started_at) * 1000),
         model=qctx.model,
         question_embedding=_log_embedding,
-    ))
+    )).add_done_callback(_task_done_callback)
 
     # Save this turn to the session store so future turns can reference it
     # (KAN-158). Skip persisting negative answers so follow-ups don't start
@@ -2303,7 +2313,7 @@ async def _run_query(
     if effective_session_id and not _negative:
         asyncio.create_task(
             _save_session_turn(effective_session_id, req.question, answer, token_hash)
-        )
+        ).add_done_callback(_task_done_callback)
 
     return response
 
@@ -2443,7 +2453,7 @@ async def intelligence_ask_stream(
                     model=qctx.model,
                     question_embedding=np.array(qctx.query_embedding) if qctx.query_embedding else None,
                     cache_hit=cached.get("cache_hit", False),
-                ))
+                )).add_done_callback(_task_done_callback)
                 return
 
             # KAN-ask-output-caps: low-similarity early-exit guard for the
@@ -2470,7 +2480,7 @@ async def intelligence_ask_stream(
                         "tokens_used": {"input": 0, "output": 0, "total": 0},
                         "model": "early-exit",
                         "negative": True,
-                    }, ttl=300))
+                    }, ttl=300)).add_done_callback(_task_done_callback)
                 asyncio.create_task(_log_query(
                     question=req.question,
                     answer=_EARLY_EXIT_ANSWER,
@@ -2482,7 +2492,7 @@ async def intelligence_ask_stream(
                     model="early-exit",
                     question_embedding=None,
                     cache_hit=False,
-                ))
+                )).add_done_callback(_task_done_callback)
                 return
 
             # Emit sources before generation starts
@@ -2623,10 +2633,10 @@ async def intelligence_ask_stream(
                     }
                     if _stream_negative:
                         _stream_payload["negative"] = True
-                        asyncio.create_task(cache.set(qctx.redis_cache_key, _stream_payload, ttl=60))
+                        asyncio.create_task(cache.set(qctx.redis_cache_key, _stream_payload, ttl=60)).add_done_callback(_task_done_callback)
                         logger.info("ask/stream: negative-cached low-quality answer (len=%d)", len(full_answer or ""))
                     else:
-                        asyncio.create_task(cache.set(qctx.redis_cache_key, _stream_payload, ttl=1800))
+                        asyncio.create_task(cache.set(qctx.redis_cache_key, _stream_payload, ttl=1800)).add_done_callback(_task_done_callback)
                     # Fire-and-forget log
                     _stream_log_embedding = (
                         None
@@ -2641,13 +2651,13 @@ async def intelligence_ask_stream(
                         latency_ms=int((time.monotonic() - _started_at) * 1000),
                         model=qctx.model,
                         question_embedding=_stream_log_embedding,
-                    ))
+                    )).add_done_callback(_task_done_callback)
                     # Save turn to session for multi-turn continuity (KAN-158).
                     # Skip negative answers so follow-ups don't start from "I don't know".
                     if req.session_id and full_answer and not _stream_negative:
                         asyncio.create_task(
                             _save_session_turn(req.session_id, req.question, full_answer, token_hash)
-                        )
+                        ).add_done_callback(_task_done_callback)
                     break
                 elif event_type == "error":
                     yield f"data: {json.dumps({'type': 'error', 'message': payload})}\n\n"

--- a/tests/test_reliability_hardening.py
+++ b/tests/test_reliability_hardening.py
@@ -1,0 +1,109 @@
+"""Tests for KAN-ask-reliability hardening changes.
+
+Covers:
+- Database connection pool sizing
+- Fire-and-forget task exception callback
+- (Startup env validation is tested implicitly via the lifespan check)
+"""
+
+import asyncio
+import logging
+
+import pytest
+
+
+class TestPoolSizing:
+    """Verify the async engine is configured with explicit pool parameters."""
+
+    def test_pool_size_is_set(self):
+        from app.database import engine
+
+        pool = engine.pool
+        assert pool.size() == 20, f"Expected pool_size=20, got {pool.size()}"
+
+    def test_max_overflow_is_set(self):
+        from app.database import engine
+
+        pool = engine.pool
+        assert pool._max_overflow == 10, f"Expected max_overflow=10, got {pool._max_overflow}"
+
+    def test_pool_recycle_is_set(self):
+        from app.database import engine
+
+        pool = engine.pool
+        assert pool._recycle == 3600, f"Expected pool_recycle=3600, got {pool._recycle}"
+
+    def test_pool_pre_ping_is_enabled(self):
+        from app.database import engine
+
+        assert engine.pool._pre_ping is True, "pool_pre_ping should be True"
+
+
+class TestTaskDoneCallback:
+    """Verify _task_done_callback logs warnings for failed tasks and stays silent for successful ones."""
+
+    def test_logs_warning_for_failed_task(self, caplog):
+        from app.routers.intelligence import _task_done_callback
+
+        async def _failing():
+            raise RuntimeError("boom")
+
+        async def _run():
+            task = asyncio.create_task(_failing())
+            try:
+                await task
+            except RuntimeError:
+                pass
+            with caplog.at_level(logging.WARNING, logger="app.routers.intelligence"):
+                _task_done_callback(task)
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+        assert any("boom" in record.message for record in caplog.records), (
+            "Expected a warning log containing 'boom'"
+        )
+        assert any("Background task" in record.message for record in caplog.records), (
+            "Expected log message to mention 'Background task'"
+        )
+
+    def test_no_log_for_successful_task(self, caplog):
+        from app.routers.intelligence import _task_done_callback
+
+        async def _ok():
+            return 42
+
+        async def _run():
+            task = asyncio.create_task(_ok())
+            await task
+            with caplog.at_level(logging.WARNING, logger="app.routers.intelligence"):
+                _task_done_callback(task)
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+        warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert len(warning_records) == 0, (
+            f"Expected no warning logs for a successful task, got: {warning_records}"
+        )
+
+    def test_no_log_for_cancelled_task(self, caplog):
+        from app.routers.intelligence import _task_done_callback
+
+        async def _slow():
+            await asyncio.sleep(100)
+
+        async def _run():
+            task = asyncio.create_task(_slow())
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            with caplog.at_level(logging.WARNING, logger="app.routers.intelligence"):
+                _task_done_callback(task)
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+        warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
+        assert len(warning_records) == 0, (
+            f"Expected no warning logs for a cancelled task, got: {warning_records}"
+        )


### PR DESCRIPTION
## Summary
- **Connection pool sizing**: Set `pool_size=20`, `max_overflow=10`, `pool_recycle=3600` on the SQLAlchemy async engine to handle Cloud Run concurrency=200 safely (default was 5 connections).
- **Fire-and-forget task error logging**: Added `_task_done_callback` to all 14 `asyncio.create_task()` calls in `intelligence.py` so background task exceptions are logged as warnings instead of being silently swallowed.
- **Startup env validation**: Added a lifespan check that logs a CRITICAL warning if `APP_API_TOKEN` is not set when running in production, so misconfigured deploys are immediately visible in logs.

Standalone reliability improvement — no issue to close.

## Test plan
- [ ] Verify `tests/test_reliability_hardening.py` passes: pool sizing assertions, callback warning/no-warning assertions
- [ ] Confirm existing tests still pass (no behavioural changes to task logic)
- [ ] Deploy to staging and verify structured logs show the pool config and no spurious warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)