### PR TITLE
KAN-ask-timeout: embedding timeout guard, streaming timeout alignment

### DIFF
--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -1815,7 +1815,44 @@ async def _prepare_query(
     # KAN-ask-cache: embed the NORMALIZED form so semantic cache hits tolerate
     # whitespace/case/synonym variance. Original question is still used in the
     # Claude prompt and logged verbatim.
-    query_embedding = embed_model.encode(normalized_question)
+    # KAN-ask-timeout: guard against embedding model hangs (e.g. model not loaded,
+    # huge input, or CPU contention on Cloud Run cold starts).
+    try:
+        query_embedding = await asyncio.wait_for(
+            asyncio.get_event_loop().run_in_executor(
+                None, lambda: embed_model.encode(normalized_question)
+            ),
+            timeout=5.0,
+        )
+    except asyncio.TimeoutError:
+        logger.warning(
+            "Embedding generation timed out after 5s for question (len=%d)",
+            len(normalized_question),
+        )
+        query_embedding = None  # fall through — return early-exit "not enough data"
+
+    # If embedding failed, return a graceful early-exit response so the caller
+    # doesn't proceed to pgvector search (which requires a valid embedding).
+    if query_embedding is None:
+        return QueryContext(
+            sources=[],
+            context_text="",
+            model="embedding-timeout",
+            session_history=[],
+            cache_result={
+                "answer": (
+                    "I'm sorry, I wasn't able to process your question quickly enough. "
+                    "Please try again in a moment."
+                ),
+                "sources": [],
+                "tokens_used": {"input": 0, "output": 0, "total": 0},
+                "cache_source": None,
+                "cache_hit": False,
+            },
+            query_embedding=None,
+            route_label=None,
+            redis_cache_key=redis_cache_key,
+        )
 
     # 2. Semantic cache check
     cached = await _find_semantic_cache_hit(db, question_embedding=query_embedding)
@@ -2591,7 +2628,7 @@ async def intelligence_ask_stream(
                 try:
                     item = await loop.run_in_executor(
                         None,
-                        lambda: token_queue.get(timeout=35),
+                        lambda: token_queue.get(timeout=_CLAUDE_TIMEOUT_S),
                     )
                 except queue.Empty:
                     yield f"data: {json.dumps({'type': 'error', 'message': 'Stream timed out'})}\n\n"

--- a/tests/test_ask_timeout_hardening.py
+++ b/tests/test_ask_timeout_hardening.py
@@ -1,0 +1,134 @@
+"""
+KAN-ask-timeout: Tests for embedding timeout guard and streaming timeout
+alignment in /intelligence/ask.
+
+Covers:
+  1. Embedding timeout: when embed_model.encode() hangs, _prepare_query returns
+     a graceful early-exit response instead of blocking indefinitely.
+  2. Streaming/non-streaming Claude call timeout alignment: both paths use the
+     same _CLAUDE_TIMEOUT_S constant.
+"""
+import asyncio
+import inspect
+import re
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+import pytest
+
+from app.routers import intelligence as intel
+from app.routers.intelligence import _CLAUDE_TIMEOUT_S
+
+
+# ---------------------------------------------------------------------------
+# 1. Embedding timeout guard
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_embedding_timeout_returns_graceful_response():
+    """When embed_model.encode() takes longer than 5s, _prepare_query must
+    return a QueryContext with model='embedding-timeout' and a user-friendly
+    answer instead of raising or hanging."""
+
+    def _slow_encode(text):
+        """Simulate a hanging embedding model."""
+        time.sleep(10)
+        return np.zeros(384, dtype=np.float32)
+
+    mock_model = MagicMock()
+    mock_model.encode = _slow_encode
+
+    mock_db = AsyncMock()
+
+    with (
+        patch.object(intel, "get_embedding_model", return_value=mock_model),
+        patch.object(intel, "_try_smart_route", new_callable=AsyncMock, return_value=None),
+        patch.object(intel, "cache", new_callable=MagicMock) as mock_cache,
+    ):
+        mock_cache.get = AsyncMock(return_value=None)
+
+        start = time.monotonic()
+        ctx = await intel._prepare_query(
+            question="What is the best testing framework?",
+            session_id=None,
+            top_k=5,
+            db=mock_db,
+        )
+        elapsed = time.monotonic() - start
+
+        # Must complete well under 10s (the sleep duration) — proves timeout fired
+        assert elapsed < 8, f"Took {elapsed:.1f}s, expected < 8s (timeout should fire at 5s)"
+
+        # Must return a graceful early-exit, not raise
+        assert ctx.model == "embedding-timeout"
+        assert ctx.cache_result is not None
+        assert "sorry" in ctx.cache_result["answer"].lower() or "try again" in ctx.cache_result["answer"].lower()
+        assert ctx.query_embedding is None
+        assert ctx.sources == []
+
+
+@pytest.mark.asyncio
+async def test_embedding_success_returns_normal_context():
+    """When embedding completes quickly, _prepare_query should proceed normally
+    (no early exit)."""
+
+    fake_embedding = np.random.rand(384).astype(np.float32)
+
+    mock_model = MagicMock()
+    mock_model.encode = MagicMock(return_value=fake_embedding)
+
+    mock_db = AsyncMock()
+
+    with (
+        patch.object(intel, "get_embedding_model", return_value=mock_model),
+        patch.object(intel, "_try_smart_route", new_callable=AsyncMock, return_value=None),
+        patch.object(intel, "cache", new_callable=MagicMock) as mock_cache,
+        patch.object(intel, "_find_semantic_cache_hit", new_callable=AsyncMock, return_value=("cached answer", [], "test-model")),
+    ):
+        mock_cache.get = AsyncMock(return_value=None)
+
+        ctx = await intel._prepare_query(
+            question="What repos use Python?",
+            session_id=None,
+            top_k=5,
+            db=mock_db,
+        )
+
+        # Should NOT be the timeout path
+        assert ctx.model != "embedding-timeout"
+        # Should have hit the semantic cache
+        assert ctx.cache_result is not None
+        assert ctx.cache_result["cache_source"] == "semantic"
+
+
+# ---------------------------------------------------------------------------
+# 2. Streaming / non-streaming timeout alignment
+# ---------------------------------------------------------------------------
+
+def test_streaming_queue_timeout_uses_claude_timeout_constant():
+    """The streaming path's token_queue.get(timeout=...) must use the same
+    _CLAUDE_TIMEOUT_S constant as the non-streaming path, not a hard-coded
+    value."""
+    source = inspect.getsource(intel)
+
+    # Find the non-streaming timeout — should reference _CLAUDE_TIMEOUT_S
+    assert "timeout=_CLAUDE_TIMEOUT_S" in source, (
+        "Non-streaming path should use _CLAUDE_TIMEOUT_S"
+    )
+
+    # The streaming queue.get call should also use _CLAUDE_TIMEOUT_S, not a
+    # hard-coded 35 (the old value)
+    assert "token_queue.get(timeout=35)" not in source, (
+        "Streaming path should not use hard-coded 35s timeout"
+    )
+    assert "token_queue.get(timeout=_CLAUDE_TIMEOUT_S)" in source, (
+        "Streaming path should reference _CLAUDE_TIMEOUT_S for consistency"
+    )
+
+
+def test_claude_timeout_value_is_30():
+    """Both paths should use 30s to match Cloud Run headroom budget."""
+    assert _CLAUDE_TIMEOUT_S == 30, (
+        f"_CLAUDE_TIMEOUT_S should be 30, got {_CLAUDE_TIMEOUT_S}"
+    )


### PR DESCRIPTION
## Summary
- **Embedding timeout guard**: Wraps `embed_model.encode()` in `asyncio.wait_for` with a 5-second timeout and `run_in_executor`, preventing indefinite hangs on Cloud Run cold starts or CPU contention. On timeout, returns a graceful early-exit response (`model="embedding-timeout"`) instead of blocking.
- **Streaming timeout alignment**: Changes the streaming `token_queue.get(timeout=35)` to use the shared `_CLAUDE_TIMEOUT_S` constant (30s), matching the non-streaming path for consistency.
- **Tests**: Adds `tests/test_ask_timeout_hardening.py` covering embedding timeout degradation and timeout constant alignment.

## Test plan
- [ ] `pytest tests/test_ask_timeout_hardening.py` passes
- [ ] Verify embedding timeout test completes in <8s (proves 5s timeout fires)
- [ ] Verify streaming timeout alignment test confirms no hard-coded 35s remains
- [ ] Manual smoke test: `/ask` still returns answers when embedding is fast
- [ ] Edge case: confirm timeout response is well-formed JSON with expected fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)