### PR TITLE
KAN-ask-observability: error PII scrub, phase-level latency logging

### DIFF
--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -1754,6 +1754,11 @@ class QueryContext:
     route_label: str | None
     embedding_candidates: int = 0
     redis_cache_key: str = ""
+    # Phase-level latency breakdown (milliseconds), set by _prepare_query
+    t_smart_ms: float = 0.0
+    t_embed_ms: float = 0.0
+    t_search_ms: float = 0.0
+    t_context_ms: float = 0.0
 
 
 async def _prepare_query(
@@ -2082,6 +2087,10 @@ async def _prepare_query(
         route_label=None,
         embedding_candidates=len(scored),
         redis_cache_key=redis_cache_key,
+        t_smart_ms=(t_smart - t0) * 1000,
+        t_embed_ms=(t_embed - t_smart) * 1000,
+        t_search_ms=(t_search - t_embed) * 1000,
+        t_context_ms=(t_context - t_search) * 1000,
     )
 
 
@@ -2141,6 +2150,12 @@ async def _run_query(
             question_embedding=np.array(qctx.query_embedding) if qctx.query_embedding else None,
             cache_hit=cached.get("cache_hit", False),
         )).add_done_callback(_task_done_callback)
+        total_ms = int((time.monotonic() - _started_at) * 1000)
+        logger.info(
+            "ask latency breakdown: total=%dms smart=%dms embed=%dms search=%dms context=%dms claude=%dms model=%s cached=%s",
+            total_ms, int(qctx.t_smart_ms), int(qctx.t_embed_ms), int(qctx.t_search_ms),
+            int(qctx.t_context_ms), 0, qctx.model, True,
+        )
         return response
 
     # KAN-ask-output-caps: low-similarity early-exit guard. If retrieval
@@ -2238,6 +2253,7 @@ async def _run_query(
                 ],
             )
 
+    _t_claude_start = time.monotonic()
     try:
         message = await asyncio.wait_for(
             loop.run_in_executor(None, _call_claude),
@@ -2254,6 +2270,8 @@ async def _run_query(
                 "Please try again in a moment."
             ),
         )
+    _t_claude_end = time.monotonic()
+    claude_ms = int((_t_claude_end - _t_claude_start) * 1000)
 
     answer = message.content[0].text
     tokens_used = {
@@ -2351,6 +2369,13 @@ async def _run_query(
         asyncio.create_task(
             _save_session_turn(effective_session_id, req.question, answer, token_hash)
         ).add_done_callback(_task_done_callback)
+
+    total_ms = int((time.monotonic() - _started_at) * 1000)
+    logger.info(
+        "ask latency breakdown: total=%dms smart=%dms embed=%dms search=%dms context=%dms claude=%dms model=%s cached=%s",
+        total_ms, int(qctx.t_smart_ms), int(qctx.t_embed_ms), int(qctx.t_search_ms),
+        int(qctx.t_context_ms), claude_ms, qctx.model, False,
+    )
 
     return response
 
@@ -2491,6 +2516,12 @@ async def intelligence_ask_stream(
                     question_embedding=np.array(qctx.query_embedding) if qctx.query_embedding else None,
                     cache_hit=cached.get("cache_hit", False),
                 )).add_done_callback(_task_done_callback)
+                total_ms = int((time.monotonic() - _started_at) * 1000)
+                logger.info(
+                    "ask latency breakdown: total=%dms smart=%dms embed=%dms search=%dms context=%dms claude=%dms model=%s cached=%s",
+                    total_ms, int(qctx.t_smart_ms), int(qctx.t_embed_ms), int(qctx.t_search_ms),
+                    int(qctx.t_context_ms), 0, qctx.model, True,
+                )
                 return
 
             # KAN-ask-output-caps: low-similarity early-exit guard for the
@@ -2625,6 +2656,7 @@ async def intelligence_ask_stream(
                         token_queue.put(("error", str(e)))
 
             # Run the blocking streamer in a thread
+            _t_claude_start = time.monotonic()
             future = loop.run_in_executor(None, _run_stream)
 
             while True:
@@ -2695,6 +2727,13 @@ async def intelligence_ask_stream(
                         asyncio.create_task(
                             _save_session_turn(req.session_id, req.question, full_answer, token_hash)
                         ).add_done_callback(_task_done_callback)
+                    _stream_claude_ms = int((time.monotonic() - _t_claude_start) * 1000)
+                    _stream_total_ms = int((time.monotonic() - _started_at) * 1000)
+                    logger.info(
+                        "ask latency breakdown: total=%dms smart=%dms embed=%dms search=%dms context=%dms claude=%dms model=%s cached=%s",
+                        _stream_total_ms, int(qctx.t_smart_ms), int(qctx.t_embed_ms), int(qctx.t_search_ms),
+                        int(qctx.t_context_ms), _stream_claude_ms, qctx.model, False,
+                    )
                     break
                 elif event_type == "error":
                     yield f"data: {json.dumps({'type': 'error', 'message': payload})}\n\n"
@@ -2809,7 +2848,7 @@ async def compare_repos(
         )
         row = result.mappings().first()
         if row is None:
-            raise HTTPException(status_code=404, detail=f"Repo '{repo_name}' not found")
+            raise HTTPException(status_code=404, detail="Repo not found")
         rows.append(dict(row))
 
     def _repo_dict(r: dict) -> dict:
@@ -2914,7 +2953,7 @@ async def repo_ecosystem(
     )
     center_row = center.mappings().first()
     if center_row is None:
-        raise HTTPException(status_code=404, detail=f"Repo '{name}' not found")
+        raise HTTPException(status_code=404, detail="Repo not found")
 
     center_id = center_row["id"]
 
@@ -3089,7 +3128,7 @@ async def category_leaders(
             "commits_30d": m["commits_last_30_days"],
         })
     if not rows:
-        raise HTTPException(status_code=404, detail=f"No repos found for category '{category}'")
+        raise HTTPException(status_code=404, detail="No repos found for the specified category")
     return {"category": category, "repos": rows}
 
 

--- a/tests/test_ask_observability.py
+++ b/tests/test_ask_observability.py
@@ -1,0 +1,205 @@
+"""Tests for KAN-ask-observability: PII scrub from error messages and phase-level latency logging."""
+from __future__ import annotations
+
+import logging
+import re
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from fastapi import HTTPException
+
+
+# ---------------------------------------------------------------------------
+# 1. Error messages must NOT contain user-supplied strings
+# ---------------------------------------------------------------------------
+
+
+class TestErrorMessagePIIScrub:
+    """Verify that HTTPException detail messages in intelligence.py never echo
+    user-supplied input (repo names, category names, search terms)."""
+
+    def _collect_http_exceptions(self, source_lines: list[str]) -> list[str]:
+        """Extract all `detail=` values from HTTPException raises in source."""
+        details = []
+        in_exception = False
+        detail_buf = ""
+        for line in source_lines:
+            stripped = line.strip()
+            if "raise HTTPException" in stripped or "HTTPException(" in stripped:
+                in_exception = True
+                detail_buf = ""
+            if in_exception:
+                detail_buf += stripped + " "
+                if ")" in stripped:
+                    in_exception = False
+                    # Extract the detail value
+                    m = re.search(r'detail\s*=\s*(.+?)(?:\s*[,)])', detail_buf)
+                    if m:
+                        details.append(m.group(1))
+        return details
+
+    def test_no_fstring_in_error_details(self):
+        """No HTTPException detail should use f-strings that interpolate variables."""
+        import inspect
+        from app.routers import intelligence
+
+        source = inspect.getsource(intelligence)
+        # Look for detail=f"..." or detail=f'...' patterns
+        fstring_details = re.findall(r'detail\s*=\s*f["\']', source)
+        assert fstring_details == [], (
+            f"Found {len(fstring_details)} f-string detail(s) in HTTPException raises — "
+            "these may leak user-supplied input. Use static messages instead."
+        )
+
+    def test_repo_not_found_message_is_generic(self):
+        """The 404 'repo not found' message must not contain the repo name."""
+        import inspect
+        from app.routers import intelligence
+
+        source = inspect.getsource(intelligence)
+        # Ensure the old patterns are gone
+        assert "Repo '" not in source or "detail" not in source.split("Repo '")[0][-50:], \
+            "Found 'Repo '<name>' pattern that may leak user input"
+        # Ensure the new generic messages exist
+        assert '"Repo not found"' in source
+        assert '"No repos found for the specified category"' in source
+
+    def test_error_detail_does_not_contain_user_input_examples(self):
+        """Simulate user-supplied strings and ensure they cannot appear in error details."""
+        user_inputs = [
+            "my-secret-repo",
+            "private-category-name",
+            "SELECT * FROM users",
+            "<script>alert('xss')</script>",
+        ]
+        # Read the actual error detail strings from the module
+        import inspect
+        from app.routers import intelligence
+
+        source = inspect.getsource(intelligence)
+        # Collect all detail= string literals
+        detail_literals = re.findall(r'detail\s*=\s*"([^"]*)"', source)
+
+        for detail in detail_literals:
+            for user_input in user_inputs:
+                assert user_input not in detail, (
+                    f"User input '{user_input}' found in error detail: {detail}"
+                )
+
+
+# ---------------------------------------------------------------------------
+# 2. Phase-level latency breakdown logging
+# ---------------------------------------------------------------------------
+
+
+class TestLatencyBreakdownLogging:
+    """Verify that _run_query emits the expected latency breakdown log line."""
+
+    def test_latency_log_pattern_exists_in_source(self):
+        """The latency breakdown log pattern must exist in the source code."""
+        import inspect
+        from app.routers import intelligence
+
+        source = inspect.getsource(intelligence)
+        assert "ask latency breakdown:" in source, (
+            "Expected 'ask latency breakdown:' log pattern not found in intelligence.py"
+        )
+        # Verify it includes all required phase keys
+        for phase in ["total=", "smart=", "embed=", "search=", "context=", "claude=", "model=", "cached="]:
+            assert phase in source, f"Missing phase '{phase}' in latency log pattern"
+
+    def test_latency_log_emitted_on_cache_hit(self, caplog):
+        """On a cache hit, the latency log should be emitted with claude=0ms and cached=True."""
+        from app.routers.intelligence import logger as intel_logger
+
+        # Simulate the log line that would be emitted on a cache hit
+        with caplog.at_level(logging.INFO, logger=intel_logger.name):
+            intel_logger.info(
+                "ask latency breakdown: total=%dms smart=%dms embed=%dms search=%dms context=%dms claude=%dms model=%s cached=%s",
+                42, 5, 10, 15, 12, 0, "smart-route:stats", True,
+            )
+
+        assert any("ask latency breakdown:" in r.message for r in caplog.records)
+        matching = [r for r in caplog.records if "ask latency breakdown:" in r.message]
+        assert len(matching) == 1
+        msg = matching[0].getMessage()
+        assert "claude=0ms" in msg
+        assert "cached=True" in msg
+
+    def test_latency_log_format_non_cache(self, caplog):
+        """On a non-cache path, the log should show actual claude timing and cached=False."""
+        from app.routers.intelligence import logger as intel_logger
+
+        with caplog.at_level(logging.INFO, logger=intel_logger.name):
+            intel_logger.info(
+                "ask latency breakdown: total=%dms smart=%dms embed=%dms search=%dms context=%dms claude=%dms model=%s cached=%s",
+                350, 5, 30, 50, 15, 250, "claude-sonnet-4-20250514", False,
+            )
+
+        matching = [r for r in caplog.records if "ask latency breakdown:" in r.message]
+        assert len(matching) == 1
+        msg = matching[0].getMessage()
+        assert "claude=250ms" in msg
+        assert "cached=False" in msg
+        assert "claude-sonnet-4-20250514" in msg
+
+    def test_query_context_has_timing_fields(self):
+        """QueryContext dataclass must have the phase-level timing fields."""
+        from app.routers.intelligence import QueryContext
+
+        ctx = QueryContext(
+            sources=[],
+            context_text="",
+            model="test",
+            session_history=[],
+            cache_result=None,
+            query_embedding=None,
+            route_label=None,
+            t_smart_ms=5.0,
+            t_embed_ms=10.0,
+            t_search_ms=15.0,
+            t_context_ms=12.0,
+        )
+        assert ctx.t_smart_ms == 5.0
+        assert ctx.t_embed_ms == 10.0
+        assert ctx.t_search_ms == 15.0
+        assert ctx.t_context_ms == 12.0
+
+    def test_query_context_timing_defaults_to_zero(self):
+        """QueryContext timing fields should default to 0.0."""
+        from app.routers.intelligence import QueryContext
+
+        ctx = QueryContext(
+            sources=[],
+            context_text="",
+            model="test",
+            session_history=[],
+            cache_result=None,
+            query_embedding=None,
+            route_label=None,
+        )
+        assert ctx.t_smart_ms == 0.0
+        assert ctx.t_embed_ms == 0.0
+        assert ctx.t_search_ms == 0.0
+        assert ctx.t_context_ms == 0.0
+
+    def test_cache_hit_log_includes_all_phases(self):
+        """Verify the log message format includes all 6 timing phases plus model and cached flag."""
+        import re
+        pattern = re.compile(
+            r"ask latency breakdown: "
+            r"total=\d+ms "
+            r"smart=\d+ms "
+            r"embed=\d+ms "
+            r"search=\d+ms "
+            r"context=\d+ms "
+            r"claude=\d+ms "
+            r"model=\S+ "
+            r"cached=(True|False)"
+        )
+        test_msg = (
+            "ask latency breakdown: total=42ms smart=5ms embed=10ms "
+            "search=15ms context=12ms claude=0ms model=smart-route:stats cached=True"
+        )
+        assert pattern.search(test_msg), "Log message does not match expected pattern"


### PR DESCRIPTION
## Summary
- **PII scrub**: Replaced 3 `HTTPException` f-strings that echoed user-supplied repo names and category names with generic static messages, preventing PII leakage in error responses
- **Phase-level latency logging**: Added timing breakdown across all major phases (`smart`, `embed`, `search`, `context`, `claude`) in both `_run_query` (non-streaming) and `event_generator` (streaming). Cache hits log `claude=0ms, cached=True`
- **Tests**: 9 new tests in `tests/test_ask_observability.py` verifying no f-string details remain, generic error messages are used, and the latency log pattern is correctly structured

## Test plan
- [x] All 9 new tests pass (`pytest tests/test_ask_observability.py`)
- [ ] Verify error responses for `/compare`, `/graph`, `/category-health` no longer echo user input
- [ ] Confirm `ask latency breakdown:` log lines appear in staging logs for both cache-hit and LLM paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)