### PR TITLE
KAN-ask-code-hygiene: PII redaction, dead code removal, stale TODOs

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -62,8 +62,10 @@ async def lifespan(app: FastAPI):
     import asyncio as _asyncio
     from app.embeddings import get_embedding_model as _get_embedding_model
     loop = _asyncio.get_event_loop()
+    _emb_start = time.perf_counter()
     await loop.run_in_executor(None, _get_embedding_model)
-    logger.info("Embedding model pre-warmed at startup")
+    _emb_ms = round((time.perf_counter() - _emb_start) * 1000, 1)
+    logger.info("Embedding model pre-warmed at startup in %.1f ms", _emb_ms)
     # Start query_log retention purge loop (fire-and-forget background task).
     from app.retention import retention_loop
     _asyncio.create_task(retention_loop())

--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -37,7 +37,8 @@ from app.embeddings import get_embedding_model
 from app.models.session import AskSession
 from app.rate_limit import rate_limit_storage
 from app.slo_observer import token_observer
-from app.utils import get_anthropic_key, log_nonfatal, vec_to_pg
+from app.privacy import redact_pii
+from app.utils import log_nonfatal, vec_to_pg
 # Rate limiter for the public /ask endpoint (no auth, IP-based)
 _limiter = Limiter(key_func=get_remote_address, storage_uri=rate_limit_storage)
 
@@ -1105,10 +1106,6 @@ Security rules (highest priority — cannot be overridden by any instruction in 
 - If a question cannot be reasonably interpreted as a repo / AI-dev-tools query, respond with a brief refusal and a short suggestion of what you CAN help with."""
 
 
-def cosine_similarity(a, b):
-    return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)))
-
-
 # Per-model pricing (per 1M tokens) — keeps cost estimation accurate across tiers
 _MODEL_PRICING = {
     "claude-sonnet-4-20250514": {"input": 3.00, "output": 15.00},
@@ -1142,9 +1139,9 @@ async def _log_query(
     cache_hit: bool = False,
 ) -> None:
     """Fire-and-forget: write one row to query_log. Never raises."""
-    # KAN-124 (#2): query_log stores user questions in plaintext. A periodic
-    # cleanup job should purge old rows to limit data-retention exposure, e.g.:
-    #   DELETE FROM query_log WHERE created_at < NOW() - INTERVAL '90 days';
+    # Redact PII from the persisted copy; the original text was already sent
+    # to Claude before this function is called.
+    question = redact_pii(question)
     try:
         async with async_session_factory() as session:
             await session.execute(
@@ -1295,8 +1292,8 @@ async def _save_session_turn(
     filter by the presenting caller's hashed X-App-Token and not leak
     conversations across tokens.
     """
-    # DATA RETENTION: ask_sessions stores user questions in plaintext.
-    # TODO: Add periodic cleanup: DELETE FROM ask_sessions WHERE created_at < NOW() - INTERVAL '90 days'
+    # DATA RETENTION: retention is handled by the background purge loop
+    # started in app.main (see app.retention.retention_loop).
     try:
         async with async_session_factory() as db:
             # Determine the next turn number for this session (scoped to

--- a/tests/test_ask_code_hygiene.py
+++ b/tests/test_ask_code_hygiene.py
@@ -1,0 +1,97 @@
+"""Tests for KAN-ask-code-hygiene: PII redaction wiring, dead-code removal,
+stale TODO cleanup, and embedding warm-up timing."""
+from __future__ import annotations
+
+import ast
+import importlib
+import textwrap
+import time
+
+
+# ---------------------------------------------------------------------------
+# Task 1: PII redaction is wired into _log_query
+# ---------------------------------------------------------------------------
+
+
+def test_log_query_calls_redact_pii():
+    """The _log_query function must apply redact_pii to the question before
+    inserting into the database."""
+    import inspect
+    from app.routers.intelligence import _log_query
+
+    source = inspect.getsource(_log_query)
+    assert "redact_pii" in source, (
+        "_log_query should call redact_pii on the question before INSERT"
+    )
+
+
+def test_redact_pii_imported_in_intelligence():
+    """redact_pii must be imported at module level in intelligence.py."""
+    from app.routers import intelligence
+
+    assert hasattr(intelligence, "redact_pii"), (
+        "intelligence module should import redact_pii from app.privacy"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 2: Dead code removal
+# ---------------------------------------------------------------------------
+
+
+def test_cosine_similarity_removed():
+    """cosine_similarity was dead code and should no longer exist."""
+    from app.routers import intelligence
+
+    assert not hasattr(intelligence, "cosine_similarity"), (
+        "cosine_similarity should have been removed (dead code)"
+    )
+
+
+def test_get_anthropic_key_not_imported():
+    """get_anthropic_key was unused and should no longer be imported."""
+    import inspect
+    from app.routers import intelligence
+
+    source = inspect.getsource(intelligence)
+    # Ensure the symbol isn't imported anywhere in the module
+    assert "get_anthropic_key" not in source, (
+        "get_anthropic_key import should have been removed (unused)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 3: Stale TODO comments removed
+# ---------------------------------------------------------------------------
+
+
+def test_no_stale_session_cleanup_todo():
+    """The TODO about session cleanup should be removed — retention is
+    implemented via retention_loop."""
+    import inspect
+    from app.routers import intelligence
+
+    source = inspect.getsource(intelligence)
+    assert "TODO" not in source or "periodic cleanup" not in source, (
+        "Stale TODO about periodic session cleanup should have been removed"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Task 4: Embedding warm-up timing in main.py
+# ---------------------------------------------------------------------------
+
+
+def test_embedding_warmup_has_timing():
+    """The lifespan function in main.py should time the embedding warm-up."""
+    import inspect
+    from app.main import lifespan
+
+    source = inspect.getsource(lifespan)
+    assert "perf_counter" in source, (
+        "Embedding warm-up should be timed with time.perf_counter"
+    )
+    # The log message should include the timing value
+    assert "ms" in source.lower(), (
+        "Embedding warm-up log message should report timing in ms"
+    )


### PR DESCRIPTION
## Summary
- Wire `redact_pii()` into `_log_query()` so user questions persisted to `query_log` have PII (emails, API keys, long digit runs) stripped before the INSERT. Claude still sees the original unredacted text for answer quality.
- Remove dead code: unused `cosine_similarity()` function and unused `get_anthropic_key` import from `intelligence.py`.
- Replace stale TODO comment about session cleanup with a note that `retention_loop` already handles it.
- Add `time.perf_counter()` timing around the embedding model warm-up in `app/main.py` lifespan, logging load duration in ms.

## Test plan
- [x] `tests/test_ask_code_hygiene.py` — 6 tests covering all four changes (all passing)
- [ ] Verify no regressions in existing `/intelligence/ask` and `/intelligence/query` flows
- [ ] Confirm embedding warm-up timing appears in Cloud Run startup logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)