### PR TITLE
feat: graph optimization — caching, repo_edges removal, model fix

### DIFF
--- a/app/models/repo.py
+++ b/app/models/repo.py
@@ -207,7 +207,7 @@ class RepoEmbedding(Base):
     )
     # Stored as JSON array; pgvector column handled at DB level via migration
     embedding: Mapped[str | None] = mapped_column(Text)
-    model: Mapped[str] = mapped_column(Text, nullable=False, default="nomic-embed-text")
+    model: Mapped[str] = mapped_column(Text, nullable=False, default="all-MiniLM-L6-v2")
     generated_at: Mapped[datetime] = mapped_column(
         TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
     )

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -384,7 +384,7 @@ async def backfill_embeddings(
                 await db.execute(text(
                     """
                     INSERT INTO repo_embeddings (repo_id, embedding, model, generated_at, embedding_vec)
-                    VALUES (:repo_id, :embedding, 'nomic-embed-text', NOW(), CAST(:embedding_vec AS vector))
+                    VALUES (:repo_id, :embedding, 'all-MiniLM-L6-v2', NOW(), CAST(:embedding_vec AS vector))
                     ON CONFLICT (repo_id) DO UPDATE
                         SET embedding = EXCLUDED.embedding,
                             embedding_vec = EXCLUDED.embedding_vec,

--- a/app/routers/graph.py
+++ b/app/routers/graph.py
@@ -7,17 +7,21 @@ become graph edges, giving full coverage across the entire library.
 
 Previously read from a static `repo_edges` table populated by a naive
 category-matching script.  The new approach uses the existing 384-dim
-nomic-embed-text embeddings and the HNSW index for fast ANN queries.
+all-MiniLM-L6-v2 embeddings and the HNSW index for fast ANN queries.
 """
 
 from fastapi import APIRouter, Depends, Query, Request
+from fastapi.responses import JSONResponse
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.cache import cache
 from app.database import get_db
 from app.rate_limit import rate_limit_storage
+
+CACHE_TTL_GRAPH_EDGES = 3600  # 1 hr
 
 router = APIRouter(tags=["Graph"])
 _limiter = Limiter(key_func=get_remote_address, storage_uri=rate_limit_storage)
@@ -39,6 +43,14 @@ async def get_graph_edges(
     Each repo is connected to its top-K nearest neighbours above the
     similarity threshold.  Edges are SIMILAR_TO with weight = similarity.
     """
+    # --- Redis cache check ---
+    cache_key = f"graph_edges:{limit}:{min_similarity}:{neighbours}"
+    cached = await cache.get(cache_key)
+    if cached is not None:
+        response = JSONResponse(content=cached)
+        response.headers["Cache-Control"] = "public, max-age=3600"
+        return response
+
     # Use a CTE to find top-K neighbours per repo via HNSW index.
     # The <=> operator returns cosine distance; 1 - distance = similarity.
     # We lateral-join to get the K nearest neighbours per repo efficiently.
@@ -156,7 +168,7 @@ async def get_graph_edges(
     """))
     count_row = counts.fetchone()
 
-    return {
+    result_payload = {
         "total": len(edges),
         "total_repos": len(repo_ids),
         "total_public_repos": count_row.total_public if count_row else 0,
@@ -164,3 +176,10 @@ async def get_graph_edges(
         "edgeTypes": ["SIMILAR_TO"],
         "edges": edges,
     }
+
+    # Store in Redis cache
+    await cache.set(cache_key, result_payload, ttl=CACHE_TTL_GRAPH_EDGES)
+
+    response = JSONResponse(content=result_payload)
+    response.headers["Cache-Control"] = "public, max-age=3600"
+    return response

--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -931,30 +931,37 @@ async def _try_smart_route_inner(question: str, db: AsyncSession) -> dict | None
                 }
         # Fall through to LLM if repo not found
 
-    # --- Dependency/relationship queries ---
+    # --- Dependency/relationship queries (pgvector similarity) ---
     m = _ROUTE_DEPENDENCY.search(q)
     if m:
         target_name = m.group(1).strip().lower()
         result = await db.execute(text("""
-            SELECT r_src.name, r_src.owner,
-                   COALESCE(r_src.parent_stars, r_src.stargazers_count, 0) as stars,
-                   r_src.primary_category, r_src.description,
-                   e.edge_type
-            FROM repo_edges e
-            JOIN repos r_tgt ON r_tgt.id = e.target_repo_id
-            JOIN repos r_src ON r_src.id = e.source_repo_id
-            WHERE r_src.is_private = false
-              AND LOWER(r_tgt.name) = :target_name
-              AND e.edge_type IN ('DEPENDS_ON', 'EXTENDS', 'FORK_OF')
-            ORDER BY COALESCE(r_src.parent_stars, r_src.stargazers_count, 0) DESC
+            SELECT r2.name, r2.owner,
+                   COALESCE(r2.parent_stars, r2.stargazers_count, 0) as stars,
+                   r2.primary_category, r2.description,
+                   1 - (e1.embedding_vec <=> e2.embedding_vec) AS similarity
+            FROM repos r1
+            JOIN repo_embeddings e1 ON e1.repo_id = r1.id
+            CROSS JOIN LATERAL (
+                SELECT e2_inner.repo_id, e2_inner.embedding_vec
+                FROM repo_embeddings e2_inner
+                WHERE e2_inner.repo_id != r1.id
+                ORDER BY e1.embedding_vec <=> e2_inner.embedding_vec
+                LIMIT 10
+            ) e2
+            JOIN repos r2 ON r2.id = e2.repo_id AND r2.is_private = false
+            WHERE LOWER(r1.name) = :target_name
+              AND r1.is_private = false
+              AND 1 - (e1.embedding_vec <=> e2.embedding_vec) >= 0.4
+            ORDER BY COALESCE(r2.parent_stars, r2.stargazers_count, 0) DESC
             LIMIT 10
         """), {"target_name": target_name})
         rows = result.fetchall()
         if rows:
-            parts = [f"- **{r.owner}/{r.name}** ({r.edge_type.lower().replace('_', ' ')}) — {r.stars:,} stars" for r in rows]
+            parts = [f"- **{r.owner}/{r.name}** (similar, score {r.similarity:.2f}) — {r.stars:,} stars" for r in rows]
             return {
-                "answer": f"Repos that depend on, extend, or fork **{target_name}** ({len(rows)} shown):\n\n" + "\n".join(parts),
-                "sources": [{"name": r.name, "owner": r.owner, "stars": r.stars, "relevance_score": 1.0, "description": r.description, "forked_from": None, "problem_solved": None, "integration_tags": []} for r in rows],
+                "answer": f"Repos related to **{target_name}** ({len(rows)} shown):\n\n" + "\n".join(parts),
+                "sources": [{"name": r.name, "owner": r.owner, "stars": r.stars, "relevance_score": round(float(r.similarity), 4), "description": r.description, "forked_from": None, "problem_solved": None, "integration_tags": []} for r in rows],
                 "route": "dependency_search",
             }
 
@@ -1973,29 +1980,35 @@ async def _prepare_query(
             else:
                 uncached_ids.append(rid)
 
-        # Query DB only for uncached repo edges
+        # Query DB only for uncached repo edges (pgvector similarity)
         new_edges: dict[str, list[dict]] = {}
         if uncached_ids:
             edge_result = await db.execute(
                 text("""
-                    SELECT e.edge_type, e.weight, e.evidence,
-                           e.source_repo_id::text as source_id,
-                           e.target_repo_id::text as target_id,
-                           r1.name as source_name, r1.forked_from as source_upstream,
-                           r2.name as target_name, r2.forked_from as target_upstream
-                    FROM repo_edges e
-                    JOIN repos r1 ON r1.id = e.source_repo_id
-                    JOIN repos r2 ON r2.id = e.target_repo_id
-                    WHERE e.source_repo_id::text = ANY(:ids)
-                       OR e.target_repo_id::text = ANY(:ids)
-                    LIMIT 20;
+                    SELECT e1.repo_id::text AS source_id,
+                           e2.repo_id::text AS target_id,
+                           r1.name AS source_name, r1.forked_from AS source_upstream,
+                           r2.name AS target_name, r2.forked_from AS target_upstream,
+                           1 - (e1.embedding_vec <=> e2.embedding_vec) AS similarity
+                    FROM repo_embeddings e1
+                    CROSS JOIN LATERAL (
+                        SELECT e2_inner.repo_id, e2_inner.embedding_vec
+                        FROM repo_embeddings e2_inner
+                        WHERE e2_inner.repo_id != e1.repo_id
+                        ORDER BY e1.embedding_vec <=> e2_inner.embedding_vec
+                        LIMIT 4
+                    ) e2
+                    JOIN repos r1 ON r1.id = e1.repo_id
+                    JOIN repos r2 ON r2.id = e2.repo_id
+                    WHERE e1.repo_id::text = ANY(:ids)
+                      AND 1 - (e1.embedding_vec <=> e2.embedding_vec) >= 0.4
                 """),
                 {"ids": uncached_ids},
             )
             edge_rows = edge_result.fetchall()
             for er in edge_rows:
                 edge_data = {
-                    "edge_type": er.edge_type,
+                    "edge_type": "SIMILAR_TO",
                     "source_name": er.source_upstream or er.source_name,
                     "target_name": er.target_upstream or er.target_name,
                 }
@@ -2957,21 +2970,28 @@ async def repo_ecosystem(
 
     center_id = center_row["id"]
 
-    # Level 1: edges touching center repo
+    # Level 1: nearest neighbours of center repo (pgvector similarity)
     level1_result = await db.execute(
         text("""
-            SELECT e.edge_type,
+            SELECT 'SIMILAR_TO' AS edge_type,
                    r1.name as source_name, r1.id::text as source_id,
                    COALESCE(r1.parent_stars, r1.stargazers_count, 0) as source_stars,
                    r1.primary_category as source_category,
                    r2.name as target_name, r2.id::text as target_id,
                    COALESCE(r2.parent_stars, r2.stargazers_count, 0) as target_stars,
                    r2.primary_category as target_category
-            FROM repo_edges e
-            JOIN repos r1 ON r1.id = e.source_repo_id
-            JOIN repos r2 ON r2.id = e.target_repo_id
-            WHERE (e.source_repo_id::text = :cid OR e.target_repo_id::text = :cid)
-              AND r1.is_private = false AND r2.is_private = false
+            FROM repo_embeddings e1
+            CROSS JOIN LATERAL (
+                SELECT e2_inner.repo_id, e2_inner.embedding_vec
+                FROM repo_embeddings e2_inner
+                WHERE e2_inner.repo_id != e1.repo_id
+                ORDER BY e1.embedding_vec <=> e2_inner.embedding_vec
+                LIMIT 8
+            ) e2
+            JOIN repos r1 ON r1.id = e1.repo_id AND r1.is_private = false
+            JOIN repos r2 ON r2.id = e2.repo_id AND r2.is_private = false
+            WHERE e1.repo_id::text = :cid
+              AND 1 - (e1.embedding_vec <=> e2.embedding_vec) >= 0.4
         """),
         {"cid": center_id},
     )
@@ -2996,23 +3016,30 @@ async def repo_ecosystem(
                     "category": r[f"{prefix}_category"],
                 }
 
-    # Level 2: edges touching level-1 repos (excluding center)
+    # Level 2: nearest neighbours of level-1 repos (excluding center)
     if connected_ids:
         level2_result = await db.execute(
             text("""
-                SELECT e.edge_type,
+                SELECT 'SIMILAR_TO' AS edge_type,
                        r1.name as source_name, r1.id::text as source_id,
                        COALESCE(r1.parent_stars, r1.stargazers_count, 0) as source_stars,
                        r1.primary_category as source_category,
                        r2.name as target_name, r2.id::text as target_id,
                        COALESCE(r2.parent_stars, r2.stargazers_count, 0) as target_stars,
                        r2.primary_category as target_category
-                FROM repo_edges e
-                JOIN repos r1 ON r1.id = e.source_repo_id
-                JOIN repos r2 ON r2.id = e.target_repo_id
-                WHERE (e.source_repo_id::text = ANY(:ids) OR e.target_repo_id::text = ANY(:ids))
-                  AND e.source_repo_id::text != :cid AND e.target_repo_id::text != :cid
-                  AND r1.is_private = false AND r2.is_private = false
+                FROM repo_embeddings e1
+                CROSS JOIN LATERAL (
+                    SELECT e2_inner.repo_id, e2_inner.embedding_vec
+                    FROM repo_embeddings e2_inner
+                    WHERE e2_inner.repo_id != e1.repo_id
+                    ORDER BY e1.embedding_vec <=> e2_inner.embedding_vec
+                    LIMIT 8
+                ) e2
+                JOIN repos r1 ON r1.id = e1.repo_id AND r1.is_private = false
+                JOIN repos r2 ON r2.id = e2.repo_id AND r2.is_private = false
+                WHERE e1.repo_id::text = ANY(:ids)
+                  AND e1.repo_id::text != :cid AND e2.repo_id::text != :cid
+                  AND 1 - (e1.embedding_vec <=> e2.embedding_vec) >= 0.4
             """),
             {"ids": list(connected_ids), "cid": center_id},
         )

--- a/migrations/versions/024_add_repo_embeddings_repo_id_btree_index.py
+++ b/migrations/versions/024_add_repo_embeddings_repo_id_btree_index.py
@@ -1,0 +1,34 @@
+"""Add btree index on repo_embeddings(repo_id).
+
+The repo_embeddings table is joined by repo_id in every graph and similarity
+query.  The primary key already covers exact lookups, but an explicit btree
+index ensures the planner can use it for range scans, ANY() filters, and
+lateral joins without ambiguity.
+
+Revision ID: 024
+Revises: 023
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "024"
+down_revision = "023"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "idx_repo_embeddings_repo_id",
+        "repo_embeddings",
+        ["repo_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_repo_embeddings_repo_id",
+        table_name="repo_embeddings",
+    )

--- a/tests/test_graph_optimization.py
+++ b/tests/test_graph_optimization.py
@@ -1,0 +1,302 @@
+"""
+Tests for graph optimization changes:
+- Redis caching on /graph/edges
+- Cache-Control header on /graph/edges
+- Model name consistency (all-MiniLM-L6-v2)
+- Migration 024 structure
+"""
+
+import importlib
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.database import get_db
+from app.main import app
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_edge_row(
+    source_name="repo-a",
+    target_name="repo-b",
+    similarity=0.82,
+):
+    row = MagicMock()
+    row.similarity = similarity
+    row.source_name = source_name
+    row.source_owner = "org"
+    row.source_description = f"{source_name} desc"
+    row.source_category = "ai-agents"
+    row.target_name = target_name
+    row.target_owner = "org"
+    row.target_description = f"{target_name} desc"
+    row.target_category = "rag-retrieval"
+    return row
+
+
+def _make_counts_row(total_public=100, with_embeddings=80):
+    row = MagicMock()
+    row.total_public = total_public
+    row.with_embeddings = with_embeddings
+    return row
+
+
+def _override_db_multi(call_results: list):
+    call_idx = 0
+
+    async def _execute(*args, **kwargs):
+        nonlocal call_idx
+        result = MagicMock()
+        if call_idx < len(call_results):
+            data = call_results[call_idx]
+            call_idx += 1
+        else:
+            data = []
+        if isinstance(data, list):
+            result.fetchall.return_value = data
+            result.fetchone.return_value = data[0] if data else None
+        else:
+            result.fetchall.return_value = [data]
+            result.fetchone.return_value = data
+        return result
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(side_effect=_execute)
+
+    async def _override():
+        yield mock_db
+
+    return mock_db, _override
+
+
+# ---------------------------------------------------------------------------
+# Task 1: Redis caching on /graph/edges
+# ---------------------------------------------------------------------------
+
+class TestGraphEdgesCaching:
+
+    @pytest.mark.asyncio
+    async def test_cache_miss_computes_and_stores(self):
+        """On cache miss, endpoint should compute edges and store in Redis."""
+        edge_rows = [_make_edge_row("a", "b", 0.9)]
+        counts_row = _make_counts_row()
+        _, db_override = _override_db_multi([edge_rows, counts_row])
+        app.dependency_overrides[get_db] = db_override
+
+        try:
+            with patch("app.routers.graph.cache") as mock_cache:
+                mock_cache.get = AsyncMock(return_value=None)
+                mock_cache.set = AsyncMock()
+
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.get("/graph/edges")
+
+                assert resp.status_code == 200
+                body = resp.json()
+                assert body["total"] == 1
+                assert body["edges"][0]["edgeType"] == "SIMILAR_TO"
+
+                # Verify cache.set was called with TTL=3600
+                mock_cache.set.assert_called_once()
+                call_args = mock_cache.set.call_args
+                assert call_args[1].get("ttl") == 3600 or call_args[0][2] == 3600
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    @pytest.mark.asyncio
+    async def test_cache_hit_returns_cached(self):
+        """On cache hit, endpoint should return cached data without DB query."""
+        cached_payload = {
+            "total": 2,
+            "total_repos": 3,
+            "total_public_repos": 100,
+            "repos_with_embeddings": 80,
+            "edgeTypes": ["SIMILAR_TO"],
+            "edges": [{"edgeType": "SIMILAR_TO", "weight": 0.85}],
+        }
+
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock()
+
+        async def _db_override():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = _db_override
+
+        try:
+            with patch("app.routers.graph.cache") as mock_cache:
+                mock_cache.get = AsyncMock(return_value=cached_payload)
+
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.get("/graph/edges")
+
+                assert resp.status_code == 200
+                assert resp.json()["total"] == 2
+                # DB should NOT have been called
+                mock_db.execute.assert_not_called()
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    @pytest.mark.asyncio
+    async def test_cache_control_header_on_miss(self):
+        """Response should include Cache-Control: public, max-age=3600."""
+        edge_rows = [_make_edge_row()]
+        counts_row = _make_counts_row()
+        _, db_override = _override_db_multi([edge_rows, counts_row])
+        app.dependency_overrides[get_db] = db_override
+
+        try:
+            with patch("app.routers.graph.cache") as mock_cache:
+                mock_cache.get = AsyncMock(return_value=None)
+                mock_cache.set = AsyncMock()
+
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.get("/graph/edges")
+
+                assert resp.status_code == 200
+                assert resp.headers.get("cache-control") == "public, max-age=3600"
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    @pytest.mark.asyncio
+    async def test_cache_control_header_on_hit(self):
+        """Cache-Control header should also be present on cache hits."""
+        cached_payload = {"total": 0, "edges": [], "edgeTypes": ["SIMILAR_TO"],
+                          "total_repos": 0, "total_public_repos": 0, "repos_with_embeddings": 0}
+
+        async def _db_override():
+            yield AsyncMock()
+
+        app.dependency_overrides[get_db] = _db_override
+
+        try:
+            with patch("app.routers.graph.cache") as mock_cache:
+                mock_cache.get = AsyncMock(return_value=cached_payload)
+
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.get("/graph/edges")
+
+                assert resp.headers.get("cache-control") == "public, max-age=3600"
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    @pytest.mark.asyncio
+    async def test_cache_key_includes_params(self):
+        """Cache key must include limit, min_similarity, and neighbours."""
+        _, db_override = _override_db_multi([[], _make_counts_row()])
+        app.dependency_overrides[get_db] = db_override
+
+        try:
+            with patch("app.routers.graph.cache") as mock_cache:
+                mock_cache.get = AsyncMock(return_value=None)
+                mock_cache.set = AsyncMock()
+
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.get(
+                        "/graph/edges",
+                        params={"limit": 100, "min_similarity": 0.7, "neighbours": 5},
+                    )
+
+                assert resp.status_code == 200
+                # Check the cache key used
+                cache_get_key = mock_cache.get.call_args[0][0]
+                assert "100" in cache_get_key
+                assert "0.7" in cache_get_key
+                assert "5" in cache_get_key
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+
+# ---------------------------------------------------------------------------
+# Task 2: No repo_edges references remain in intelligence.py
+# ---------------------------------------------------------------------------
+
+class TestRepoEdgesRemoved:
+
+    def test_no_repo_edges_in_intelligence(self):
+        """intelligence.py should not reference the dead repo_edges table."""
+        import inspect
+        from app.routers import intelligence
+        source = inspect.getsource(intelligence)
+        assert "repo_edges" not in source, (
+            "Found 'repo_edges' reference in intelligence.py — "
+            "all queries should use pgvector similarity via repo_embeddings"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Task 3: Migration 024 structure
+# ---------------------------------------------------------------------------
+
+class TestMigration024:
+
+    def test_migration_metadata(self):
+        """Migration 024 should have correct revision chain."""
+        mod = importlib.import_module(
+            "migrations.versions.024_add_repo_embeddings_repo_id_btree_index"
+        )
+        assert mod.revision == "024"
+        assert mod.down_revision == "023"
+
+    def test_migration_has_upgrade_and_downgrade(self):
+        mod = importlib.import_module(
+            "migrations.versions.024_add_repo_embeddings_repo_id_btree_index"
+        )
+        assert callable(mod.upgrade)
+        assert callable(mod.downgrade)
+
+    def test_migration_index_name(self):
+        """upgrade() should create idx_repo_embeddings_repo_id."""
+        import inspect
+        mod = importlib.import_module(
+            "migrations.versions.024_add_repo_embeddings_repo_id_btree_index"
+        )
+        src = inspect.getsource(mod.upgrade)
+        assert "idx_repo_embeddings_repo_id" in src
+        assert "repo_embeddings" in src
+
+
+# ---------------------------------------------------------------------------
+# Task 4: Model name consistency
+# ---------------------------------------------------------------------------
+
+class TestModelNameConsistency:
+
+    def test_embedding_model_is_minilm(self):
+        """The embedding model singleton should load all-MiniLM-L6-v2."""
+        import inspect
+        from app import embeddings
+        source = inspect.getsource(embeddings)
+        assert "all-MiniLM-L6-v2" in source
+        assert "nomic-embed-text" not in source
+
+    def test_repo_embedding_model_default(self):
+        """RepoEmbedding ORM model default should be all-MiniLM-L6-v2."""
+        from app.models.repo import RepoEmbedding
+        # Check the column default
+        col = RepoEmbedding.__table__.columns["model"]
+        assert col.default.arg == "all-MiniLM-L6-v2"
+
+    def test_admin_insert_uses_correct_model(self):
+        """admin.py should insert embeddings with all-MiniLM-L6-v2."""
+        import inspect
+        from app.routers import admin
+        source = inspect.getsource(admin)
+        # Should use the correct model name in INSERT
+        assert "all-MiniLM-L6-v2" in source
+        # Should NOT use the old name
+        assert "nomic-embed-text" not in source


### PR DESCRIPTION
## Summary
- **Redis caching on /graph/edges**: Cache key from `limit:min_similarity:neighbours` params, TTL=3600s, `Cache-Control: public, max-age=3600` response header on both hits and misses
- **Remove dead `repo_edges` references in intelligence.py**: Replaced 4 queries (dependency search, LLM context edges, ecosystem level-1 and level-2 graph) with pgvector HNSW cosine similarity via `repo_embeddings`
- **Migration 024**: Adds btree index `idx_repo_embeddings_repo_id` on `repo_embeddings(repo_id)` for faster lateral joins and ANY() filters (revision 024, down_revision 023)
- **Fix model name mismatch**: Changed `nomic-embed-text` to `all-MiniLM-L6-v2` in ORM default (`app/models/repo.py`) and admin INSERT (`app/routers/admin.py`) to match the actual model loaded in `app/embeddings.py`

## Test plan
- [x] 12 new tests in `tests/test_graph_optimization.py` — all passing
- [ ] Verify /graph/edges returns `Cache-Control` header in staging
- [ ] Verify intelligence /ask dependency queries still return relevant results
- [ ] Run migration 024 on staging DB and confirm index creation
- [ ] Confirm no `repo_edges` table references remain in application code

🤖 Generated with [Claude Code](https://claude.com/claude-code)