### PR TITLE
KAN-governance: API gateway pattern, per-key budgets, auditable sandbox

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,3 +26,8 @@ GITHUB_WEBHOOK_SECRET=
 # Optional: when set to 1, requires X-Admin-Key header on /metrics/* and /audit/status.
 # Leave unset for open metrics (default — matches pre-#236 behavior).
 METRICS_REQUIRE_AUTH=
+
+# KAN-governance: API gateway controls
+AUDIT_ENABLED=0
+PER_KEY_BUDGET_USD=5.0
+PER_KEY_RATE_LIMIT=30

--- a/app/audit.py
+++ b/app/audit.py
@@ -1,0 +1,65 @@
+"""Audit query helpers for the /admin/audit endpoint (KAN-governance).
+
+Provides the database query logic used by the admin router to list and filter
+audit log entries.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.audit_log import AuditLog
+
+
+async def list_audit_logs(
+    session: AsyncSession,
+    *,
+    api_key_hash: str | None = None,
+    endpoint: str | None = None,
+    date_from: date | None = None,
+    date_to: date | None = None,
+    sandbox_only: bool = False,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[dict]:
+    """Return audit log entries matching the given filters."""
+    stmt = select(AuditLog).order_by(AuditLog.timestamp.desc())
+
+    if api_key_hash:
+        stmt = stmt.where(AuditLog.api_key_hash == api_key_hash)
+    if endpoint:
+        stmt = stmt.where(AuditLog.endpoint.ilike(f"%{endpoint}%"))
+    if date_from:
+        stmt = stmt.where(
+            AuditLog.timestamp >= datetime(date_from.year, date_from.month, date_from.day, tzinfo=timezone.utc)
+        )
+    if date_to:
+        dt_to = datetime(date_to.year, date_to.month, date_to.day, 23, 59, 59, tzinfo=timezone.utc)
+        stmt = stmt.where(AuditLog.timestamp <= dt_to)
+    if sandbox_only:
+        stmt = stmt.where(AuditLog.sandbox.is_(True))
+
+    stmt = stmt.offset(offset).limit(limit)
+    result = await session.execute(stmt)
+    rows = result.scalars().all()
+
+    return [
+        {
+            "id": r.id,
+            "timestamp": r.timestamp.isoformat() if r.timestamp else None,
+            "api_key_hash": r.api_key_hash,
+            "endpoint": r.endpoint,
+            "method": r.method,
+            "response_status": r.response_status,
+            "model_used": r.model_used,
+            "tokens_input": r.tokens_input,
+            "tokens_output": r.tokens_output,
+            "cost_usd": r.cost_usd,
+            "latency_ms": r.latency_ms,
+            "sandbox": r.sandbox,
+        }
+        for r in rows
+    ]

--- a/app/governance.py
+++ b/app/governance.py
@@ -1,0 +1,138 @@
+"""Per-key rate limiting and budget enforcement for the API gateway.
+
+Uses Redis for state when available (REDIS_URL set); falls back to in-memory
+dicts for local development.  All public functions are async and safe to call
+even when Redis is down -- they default to *allowing* the request so a Redis
+outage never blocks legitimate traffic.
+
+Environment variables:
+    PER_KEY_RATE_LIMIT  -- max requests per minute per (api_key, route) pair.
+                           Default: 30.
+    PER_KEY_BUDGET_USD  -- daily spend cap per key in USD.  Default: 5.0.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from datetime import date
+
+logger = logging.getLogger(__name__)
+
+# --------------------------------------------------------------------------- #
+# In-memory fallback stores (used when Redis is unavailable)
+# --------------------------------------------------------------------------- #
+
+_mem_rate: dict[str, list[float]] = {}   # key -> list of timestamps
+_mem_budget: dict[str, float] = {}       # key -> accumulated spend today
+
+
+def _per_key_rate_limit() -> int:
+    return int(os.environ.get("PER_KEY_RATE_LIMIT", "30"))
+
+
+def _per_key_budget_usd() -> float:
+    return float(os.environ.get("PER_KEY_BUDGET_USD", "5.0"))
+
+
+# --------------------------------------------------------------------------- #
+# Rate limiting
+# --------------------------------------------------------------------------- #
+
+async def check_rate_limit(api_key: str, route: str) -> bool:
+    """Check per-key rate limit.  Returns True if the request is allowed.
+
+    Uses a sliding-window counter backed by Redis INCR + TTL.  If Redis is
+    unavailable the function falls back to an in-memory list and still
+    enforces the limit within the current process.
+    """
+    limit = _per_key_rate_limit()
+    if limit <= 0:
+        return True  # disabled
+
+    redis_key = f"ratelimit:{api_key}:{route}"
+
+    # --- Try Redis first ---
+    try:
+        from app.cache_redis import redis_cache
+        client = await redis_cache._get_client()
+        if client is not None:
+            pipe = client.pipeline(transaction=True)
+            pipe.incr(redis_key)
+            pipe.expire(redis_key, 60)  # 60-second sliding window
+            results = await pipe.execute()
+            current: int = results[0]
+            return current <= limit
+    except Exception:
+        logger.debug("check_rate_limit: Redis unavailable, using in-memory fallback")
+
+    # --- In-memory fallback ---
+    now = time.monotonic()
+    window = _mem_rate.setdefault(redis_key, [])
+    # Purge entries older than 60s
+    window[:] = [t for t in window if now - t < 60]
+    if len(window) >= limit:
+        return False
+    window.append(now)
+    return True
+
+
+# --------------------------------------------------------------------------- #
+# Budget enforcement
+# --------------------------------------------------------------------------- #
+
+async def check_budget(api_key: str) -> tuple[bool, float]:
+    """Check if *api_key* has remaining daily budget.
+
+    Returns ``(allowed, remaining_usd)``.  ``allowed`` is False when the key
+    has exhausted its daily budget.
+    """
+    budget = _per_key_budget_usd()
+    if budget <= 0:
+        return True, 0.0  # budgeting disabled
+
+    today = date.today().isoformat()
+    redis_key = f"budget:{api_key}:{today}"
+
+    # --- Try Redis first ---
+    try:
+        from app.cache_redis import redis_cache
+        client = await redis_cache._get_client()
+        if client is not None:
+            raw = await client.get(redis_key)
+            spent = float(raw) if raw else 0.0
+            remaining = max(budget - spent, 0.0)
+            return spent < budget, remaining
+    except Exception:
+        logger.debug("check_budget: Redis unavailable, using in-memory fallback")
+
+    # --- In-memory fallback ---
+    spent = _mem_budget.get(redis_key, 0.0)
+    remaining = max(budget - spent, 0.0)
+    return spent < budget, remaining
+
+
+async def record_spend(api_key: str, cost_usd: float) -> None:
+    """Record token spend against the key's daily budget."""
+    if cost_usd <= 0:
+        return
+
+    today = date.today().isoformat()
+    redis_key = f"budget:{api_key}:{today}"
+
+    # --- Try Redis first ---
+    try:
+        from app.cache_redis import redis_cache
+        client = await redis_cache._get_client()
+        if client is not None:
+            pipe = client.pipeline(transaction=True)
+            pipe.incrbyfloat(redis_key, cost_usd)
+            pipe.expire(redis_key, 86_400)  # auto-expire after 24h
+            await pipe.execute()
+            return
+    except Exception:
+        logger.debug("record_spend: Redis unavailable, using in-memory fallback")
+
+    # --- In-memory fallback ---
+    _mem_budget[redis_key] = _mem_budget.get(redis_key, 0.0) + cost_usd

--- a/app/main.py
+++ b/app/main.py
@@ -110,6 +110,12 @@ app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 app.add_middleware(SlowAPIMiddleware)
 app.add_middleware(GZipMiddleware, minimum_size=1000)  # compress responses > 1KB
 
+# KAN-governance: audit middleware (feature-flagged, default OFF)
+if os.environ.get("AUDIT_ENABLED", "0") == "1":
+    from app.middleware.audit import AuditMiddleware  # noqa: E402
+    app.add_middleware(AuditMiddleware)
+    logger.info("Audit middleware enabled (AUDIT_ENABLED=1)")
+
 
 @app.get("/docs", include_in_schema=False)
 async def scalar_docs() -> HTMLResponse:
@@ -201,7 +207,7 @@ app.add_middleware(
     allow_origins=_ALLOWED_ORIGINS,
     allow_origin_regex=r"https://reporium(-[a-z0-9]+)*\.vercel\.app",
     allow_methods=["GET", "POST"],
-    allow_headers=["Authorization", "Content-Type", "X-Admin-Key", "X-Ingest-Key", "X-App-Token", "Accept"],
+    allow_headers=["Authorization", "Content-Type", "X-Admin-Key", "X-Ingest-Key", "X-App-Token", "X-Sandbox", "Accept"],
 )
 
 

--- a/app/middleware/audit.py
+++ b/app/middleware/audit.py
@@ -1,0 +1,110 @@
+"""Audit middleware for the API gateway (KAN-governance).
+
+Intercepts every request and, when auditing is warranted, persists a row to
+the ``audit_logs`` table via a fire-and-forget ``asyncio.create_task``.
+
+Auditing is triggered when:
+  1. The request targets any ``/intelligence/*`` endpoint, OR
+  2. The request carries the ``X-Sandbox: true`` header.
+
+The middleware is feature-flagged behind ``AUDIT_ENABLED=1``.  When the env
+var is absent or ``0`` the middleware is a transparent pass-through.
+
+Privacy: request bodies are truncated to 500 chars and run through
+``privacy.redact_pii`` before storage.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import os
+import time
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+logger = logging.getLogger(__name__)
+
+# Maximum chars of the request body stored in request_summary.
+_MAX_SUMMARY_LEN = 500
+
+
+def _is_audit_enabled() -> bool:
+    return os.environ.get("AUDIT_ENABLED", "0") == "1"
+
+
+def _hash_key(raw: str | None) -> str | None:
+    if not raw:
+        return None
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+class AuditMiddleware(BaseHTTPMiddleware):
+    """Starlette middleware that writes audit log entries asynchronously."""
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        if not _is_audit_enabled():
+            return await call_next(request)
+
+        path = request.url.path
+        is_intelligence = path.startswith("/intelligence")
+        is_sandbox = (request.headers.get("x-sandbox") or "").lower() == "true"
+
+        if not is_intelligence and not is_sandbox:
+            return await call_next(request)
+
+        # Capture timing
+        start = time.perf_counter()
+        response: Response = await call_next(request)
+        latency_ms = round((time.perf_counter() - start) * 1000)
+
+        # Build summary (truncated + redacted)
+        try:
+            body_bytes = await request.body()
+            summary = body_bytes.decode("utf-8", errors="replace")[:_MAX_SUMMARY_LEN]
+        except Exception:
+            summary = ""
+
+        try:
+            from app.privacy import redact_pii
+            summary = redact_pii(summary)
+        except Exception:
+            pass
+
+        # Derive api_key_hash from any of the auth headers
+        raw_key = (
+            request.headers.get("x-app-token")
+            or request.headers.get("x-admin-key")
+            or request.headers.get("authorization", "").removeprefix("Bearer ").strip()
+            or None
+        )
+
+        entry = {
+            "api_key_hash": _hash_key(raw_key),
+            "endpoint": path,
+            "method": request.method,
+            "request_summary": summary if is_sandbox else summary[:200],
+            "response_status": response.status_code,
+            "latency_ms": latency_ms,
+            "sandbox": is_sandbox,
+        }
+
+        asyncio.create_task(_persist_audit(entry))
+        return response
+
+
+async def _persist_audit(entry: dict) -> None:
+    """Fire-and-forget: insert one row into audit_logs."""
+    try:
+        from app.database import async_session_factory
+        from app.models.audit_log import AuditLog
+
+        async with async_session_factory() as session:
+            log = AuditLog(**entry)
+            session.add(log)
+            await session.commit()
+    except Exception:
+        logger.warning("Failed to persist audit log entry", exc_info=True)

--- a/app/models/audit_log.py
+++ b/app/models/audit_log.py
@@ -1,0 +1,33 @@
+"""Audit log ORM model (KAN-governance).
+
+Stores a row for every auditable API request -- all /intelligence/* calls, and
+optionally any request with the X-Sandbox header.
+"""
+
+from datetime import datetime
+
+from sqlalchemy import Boolean, Float, Integer, String, Text, TIMESTAMP
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_logs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    timestamp: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now(), index=True,
+    )
+    api_key_hash: Mapped[str | None] = mapped_column(String(64), index=True)  # SHA-256 of key
+    endpoint: Mapped[str] = mapped_column(String(100), nullable=False)
+    method: Mapped[str] = mapped_column(String(10), nullable=False)
+    request_summary: Mapped[str | None] = mapped_column(Text)  # Truncated/redacted
+    response_status: Mapped[int] = mapped_column(Integer, nullable=False)
+    model_used: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    tokens_input: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    tokens_output: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    cost_usd: Mapped[float | None] = mapped_column(Float, nullable=True)
+    latency_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    sandbox: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from dataclasses import dataclass, field as dc_field
+from datetime import date
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
@@ -1240,3 +1241,39 @@ async def admin_delete_ask_session(
         "ask_sessions RTBF delete: session_id=%s deleted=%d", session_id, count
     )
     return {"deleted": count, "session_id": session_id}
+
+
+# ---------------------------------------------------------------------------
+# Audit log endpoint (KAN-governance)
+# ---------------------------------------------------------------------------
+
+
+@router.get("/admin/audit", dependencies=[Depends(require_admin_key)])
+async def get_audit_logs(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    api_key_hash: str | None = Query(None, description="Filter by SHA-256 of API key"),
+    endpoint: str | None = Query(None, description="Filter by endpoint substring"),
+    date_from: date | None = Query(None, description="Start date (inclusive)"),
+    date_to: date | None = Query(None, description="End date (inclusive)"),
+    sandbox_only: bool = Query(False, description="Only show sandbox entries"),
+    limit: int = Query(50, ge=1, le=200),
+    offset: int = Query(0, ge=0),
+):
+    """List recent audit log entries (admin-key required).
+
+    Returns timestamp, endpoint, model, tokens, cost, latency, and sandbox flag.
+    """
+    from app.audit import list_audit_logs
+
+    entries = await list_audit_logs(
+        db,
+        api_key_hash=api_key_hash,
+        endpoint=endpoint,
+        date_from=date_from,
+        date_to=date_to,
+        sandbox_only=sandbox_only,
+        limit=limit,
+        offset=offset,
+    )
+    return {"entries": entries, "count": len(entries), "limit": limit, "offset": offset}

--- a/migrations/versions/025_create_audit_logs.py
+++ b/migrations/versions/025_create_audit_logs.py
@@ -1,0 +1,60 @@
+"""Create audit_logs table with indexes.
+
+Stores per-request audit entries for governance, cost tracking, and sandbox
+replay.  Indexes on (timestamp) and (api_key_hash, timestamp) support the
+/admin/audit query patterns.
+
+Revision ID: 025
+Revises: 024
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "025"
+down_revision = "024"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "audit_logs",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column(
+            "timestamp",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("api_key_hash", sa.String(64), nullable=True),
+        sa.Column("endpoint", sa.String(100), nullable=False),
+        sa.Column("method", sa.String(10), nullable=False),
+        sa.Column("request_summary", sa.Text, nullable=True),
+        sa.Column("response_status", sa.Integer, nullable=False),
+        sa.Column("model_used", sa.String(50), nullable=True),
+        sa.Column("tokens_input", sa.Integer, nullable=True),
+        sa.Column("tokens_output", sa.Integer, nullable=True),
+        sa.Column("cost_usd", sa.Float, nullable=True),
+        sa.Column("latency_ms", sa.Integer, nullable=True),
+        sa.Column(
+            "sandbox",
+            sa.Boolean,
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+
+    op.create_index("idx_audit_logs_timestamp", "audit_logs", ["timestamp"])
+    op.create_index(
+        "idx_audit_logs_key_ts",
+        "audit_logs",
+        ["api_key_hash", "timestamp"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_audit_logs_key_ts", table_name="audit_logs")
+    op.drop_index("idx_audit_logs_timestamp", table_name="audit_logs")
+    op.drop_table("audit_logs")

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -1,0 +1,279 @@
+"""Tests for KAN-governance: per-key rate limiting, budget enforcement,
+audit log creation, sandbox header detection, and /admin/audit endpoint.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import os
+from datetime import date, datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+# Ensure test env is set before importing app modules
+os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://postgres:postgres@localhost:5432/reporium_test")
+os.environ.setdefault("INGESTION_API_KEY", "test-api-key")
+os.environ.setdefault("REDIS_URL", "")
+os.environ.setdefault("RATELIMIT_ENABLED", "0")
+
+
+# --------------------------------------------------------------------------- #
+# Per-key rate limiting (mock Redis)
+# --------------------------------------------------------------------------- #
+
+
+class TestPerKeyRateLimit:
+    """Tests for app.governance.check_rate_limit."""
+
+    @pytest.mark.asyncio
+    async def test_allows_under_limit(self):
+        """Requests under the per-key limit should be allowed."""
+        from app.governance import check_rate_limit, _mem_rate
+
+        _mem_rate.clear()
+        with patch.dict(os.environ, {"PER_KEY_RATE_LIMIT": "5"}):
+            for _ in range(5):
+                assert await check_rate_limit("key-a", "/test") is True
+
+    @pytest.mark.asyncio
+    async def test_blocks_over_limit(self):
+        """Requests exceeding the per-key limit should be blocked."""
+        from app.governance import check_rate_limit, _mem_rate
+
+        _mem_rate.clear()
+        with patch.dict(os.environ, {"PER_KEY_RATE_LIMIT": "3"}):
+            for _ in range(3):
+                assert await check_rate_limit("key-b", "/test") is True
+            # 4th should be blocked
+            assert await check_rate_limit("key-b", "/test") is False
+
+    @pytest.mark.asyncio
+    async def test_separate_keys_independent(self):
+        """Different API keys should have independent rate limits."""
+        from app.governance import check_rate_limit, _mem_rate
+
+        _mem_rate.clear()
+        with patch.dict(os.environ, {"PER_KEY_RATE_LIMIT": "2"}):
+            assert await check_rate_limit("key-x", "/route") is True
+            assert await check_rate_limit("key-x", "/route") is True
+            assert await check_rate_limit("key-x", "/route") is False
+            # key-y should still be allowed
+            assert await check_rate_limit("key-y", "/route") is True
+
+    @pytest.mark.asyncio
+    async def test_disabled_when_zero(self):
+        """Rate limiting should be disabled when PER_KEY_RATE_LIMIT=0."""
+        from app.governance import check_rate_limit, _mem_rate
+
+        _mem_rate.clear()
+        with patch.dict(os.environ, {"PER_KEY_RATE_LIMIT": "0"}):
+            for _ in range(100):
+                assert await check_rate_limit("key-z", "/test") is True
+
+    @pytest.mark.asyncio
+    async def test_redis_path(self):
+        """When Redis is available, uses INCR+EXPIRE pipeline."""
+        from app.governance import check_rate_limit
+
+        mock_pipe = MagicMock()
+        mock_pipe.incr = MagicMock(return_value=mock_pipe)
+        mock_pipe.expire = MagicMock(return_value=mock_pipe)
+        mock_pipe.execute = AsyncMock(return_value=[1, True])
+
+        mock_client = MagicMock()
+        mock_client.pipeline = MagicMock(return_value=mock_pipe)
+
+        with patch.dict(os.environ, {"PER_KEY_RATE_LIMIT": "30"}):
+            with patch("app.governance.redis_cache", create=True) as mock_rc:
+                # Import inside to use the mock
+                mock_rc._get_client = AsyncMock(return_value=mock_client)
+                with patch("app.cache_redis.redis_cache") as patched:
+                    patched._get_client = AsyncMock(return_value=mock_client)
+                    result = await check_rate_limit("key-redis", "/test")
+                    assert result is True
+
+
+# --------------------------------------------------------------------------- #
+# Per-key budget enforcement
+# --------------------------------------------------------------------------- #
+
+
+class TestPerKeyBudget:
+    """Tests for app.governance.check_budget and record_spend."""
+
+    @pytest.mark.asyncio
+    async def test_budget_allowed_when_under(self):
+        """Spending under budget should be allowed."""
+        from app.governance import check_budget, record_spend, _mem_budget
+
+        _mem_budget.clear()
+        with patch.dict(os.environ, {"PER_KEY_BUDGET_USD": "5.0"}):
+            allowed, remaining = await check_budget("key-budget-a")
+            assert allowed is True
+            assert remaining == 5.0
+
+    @pytest.mark.asyncio
+    async def test_budget_blocked_after_exhausted(self):
+        """Spending over budget should be blocked."""
+        from app.governance import check_budget, record_spend, _mem_budget
+
+        _mem_budget.clear()
+        with patch.dict(os.environ, {"PER_KEY_BUDGET_USD": "1.0"}):
+            await record_spend("key-budget-b", 0.8)
+            allowed, remaining = await check_budget("key-budget-b")
+            assert allowed is True
+            assert remaining == pytest.approx(0.2, abs=0.01)
+
+            await record_spend("key-budget-b", 0.3)
+            allowed, remaining = await check_budget("key-budget-b")
+            assert allowed is False
+            assert remaining == 0.0
+
+    @pytest.mark.asyncio
+    async def test_budget_disabled_when_zero(self):
+        """Budget enforcement should be disabled when PER_KEY_BUDGET_USD=0."""
+        from app.governance import check_budget, _mem_budget
+
+        _mem_budget.clear()
+        with patch.dict(os.environ, {"PER_KEY_BUDGET_USD": "0"}):
+            allowed, remaining = await check_budget("key-budget-c")
+            assert allowed is True
+
+    @pytest.mark.asyncio
+    async def test_record_spend_zero_noop(self):
+        """Recording zero spend should be a no-op."""
+        from app.governance import record_spend, _mem_budget
+
+        _mem_budget.clear()
+        with patch.dict(os.environ, {"PER_KEY_BUDGET_USD": "5.0"}):
+            await record_spend("key-noop", 0.0)
+            today = date.today().isoformat()
+            assert f"budget:key-noop:{today}" not in _mem_budget
+
+
+# --------------------------------------------------------------------------- #
+# Audit log creation
+# --------------------------------------------------------------------------- #
+
+
+class TestAuditLogCreation:
+    """Tests for audit log model and persistence helper."""
+
+    def test_audit_log_model_fields(self):
+        """AuditLog model should have all required columns."""
+        from app.models.audit_log import AuditLog
+
+        columns = {c.name for c in AuditLog.__table__.columns}
+        expected = {
+            "id", "timestamp", "api_key_hash", "endpoint", "method",
+            "request_summary", "response_status", "model_used",
+            "tokens_input", "tokens_output", "cost_usd", "latency_ms", "sandbox",
+        }
+        assert expected.issubset(columns)
+
+    def test_audit_log_table_name(self):
+        from app.models.audit_log import AuditLog
+        assert AuditLog.__tablename__ == "audit_logs"
+
+    def test_audit_log_sandbox_default(self):
+        """Sandbox column should default to False."""
+        from app.models.audit_log import AuditLog
+
+        col = AuditLog.__table__.columns["sandbox"]
+        assert col.default.arg is False
+
+
+# --------------------------------------------------------------------------- #
+# Sandbox header detection
+# --------------------------------------------------------------------------- #
+
+
+class TestSandboxDetection:
+    """Tests for X-Sandbox header detection in audit middleware."""
+
+    def test_hash_key_returns_sha256(self):
+        from app.middleware.audit import _hash_key
+
+        raw = "test-api-key"
+        expected = hashlib.sha256(raw.encode("utf-8")).hexdigest()
+        assert _hash_key(raw) == expected
+
+    def test_hash_key_none(self):
+        from app.middleware.audit import _hash_key
+
+        assert _hash_key(None) is None
+        assert _hash_key("") is None
+
+    def test_audit_disabled_by_default(self):
+        from app.middleware.audit import _is_audit_enabled
+
+        with patch.dict(os.environ, {"AUDIT_ENABLED": "0"}):
+            assert _is_audit_enabled() is False
+
+    def test_audit_enabled_when_flag_set(self):
+        from app.middleware.audit import _is_audit_enabled
+
+        with patch.dict(os.environ, {"AUDIT_ENABLED": "1"}):
+            assert _is_audit_enabled() is True
+
+
+# --------------------------------------------------------------------------- #
+# /admin/audit endpoint
+# --------------------------------------------------------------------------- #
+
+
+class TestAdminAuditEndpoint:
+    """Tests for the GET /admin/audit endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_requires_admin_key(self, client: AsyncClient):
+        """Endpoint should reject requests without admin key in production."""
+        with patch.dict(os.environ, {"ADMIN_API_KEY": "secret-admin-key"}):
+            resp = await client.get("/admin/audit")
+            assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_returns_entries_with_admin_key(self, client: AsyncClient):
+        """Endpoint should return audit entries with valid admin key."""
+        # In dev mode (no ADMIN_API_KEY set), admin key is not enforced
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ADMIN_API_KEY", None)
+            resp = await client.get("/admin/audit")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert "entries" in data
+            assert "count" in data
+            assert "limit" in data
+            assert "offset" in data
+
+    @pytest.mark.asyncio
+    async def test_pagination_params(self, client: AsyncClient):
+        """Endpoint should accept pagination params."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ADMIN_API_KEY", None)
+            resp = await client.get("/admin/audit?limit=10&offset=5")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["limit"] == 10
+            assert data["offset"] == 5
+
+    @pytest.mark.asyncio
+    async def test_filter_params_accepted(self, client: AsyncClient):
+        """Endpoint should accept all filter query params without error."""
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ADMIN_API_KEY", None)
+            resp = await client.get(
+                "/admin/audit",
+                params={
+                    "api_key_hash": "abc123",
+                    "endpoint": "/intelligence/ask",
+                    "date_from": "2026-01-01",
+                    "date_to": "2026-12-31",
+                    "sandbox_only": "true",
+                },
+            )
+            assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- **Per-key rate limiting** (`app/governance.py`): sliding-window counter backed by Redis INCR+TTL with in-memory fallback, configurable via `PER_KEY_RATE_LIMIT` env var (default 30/min)
- **Per-key budget enforcement** (`app/governance.py`): daily spend cap per API key tracked in Redis with `check_budget` and `record_spend` helpers, configurable via `PER_KEY_BUDGET_USD` (default $5)
- **Audit log infrastructure**: `AuditLog` ORM model, migration 025 with composite indexes, fire-and-forget `AuditMiddleware` that captures all `/intelligence/*` requests and `X-Sandbox: true` requests
- **`GET /admin/audit` endpoint**: paginated, filterable audit trail (admin-key required) with filters for api_key_hash, endpoint, date range, sandbox_only
- **Feature-flagged**: `AUDIT_ENABLED=0` by default, fully backward compatible

## Test plan
- [x] 20 tests in `tests/test_governance.py` all passing
- [ ] Verify rate limiting blocks at threshold with mock Redis
- [ ] Verify budget enforcement blocks after exhaustion
- [ ] Verify audit log model has all expected columns
- [ ] Verify sandbox header detection (`X-Sandbox: true`)
- [ ] Verify `/admin/audit` requires admin key and accepts all filter params
- [ ] Verify middleware is no-op when `AUDIT_ENABLED=0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)