### PR TITLE
feat: community health signals backfill endpoint

### DIFF
--- a/app/models/repo.py
+++ b/app/models/repo.py
@@ -70,6 +70,15 @@ class Repo(Base):
     has_tests: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
     has_ci: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
 
+    # Community health signals (backfilled from free GitHub API)
+    contributors_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    release_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    latest_release_date: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
+    issue_close_rate: Mapped[float | None] = mapped_column(Float, nullable=True)
+    pr_merge_rate: Mapped[float | None] = mapped_column(Float, nullable=True)
+    has_discussions: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    community_health_pct: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
     # Security risk — curated manually or via admin API
     # Structure: {risk_level, incident_reported, incident_date, incident_url, incident_summary}
     security_signals: Mapped[dict | None] = mapped_column(JSONB, nullable=True)

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -1394,3 +1394,242 @@ async def backfill_licenses(
         await db.commit()
 
     return {"total": total, "updated": updated, "failed": failed, "skipped": skipped, "dry_run": False}
+
+
+# ---------------------------------------------------------------------------
+# Community health signals backfill
+# ---------------------------------------------------------------------------
+
+def _parse_last_page(link_header: str | None) -> int | None:
+    """Extract the last page number from a GitHub ``Link`` header.
+
+    Returns ``None`` when the header is absent or has no ``rel="last"`` entry
+    (which means the first page already contains all results).
+    """
+    if not link_header:
+        return None
+    import re
+    match = re.search(r'<[^>]*[?&]page=(\d+)[^>]*>;\s*rel="last"', link_header)
+    if match:
+        return int(match.group(1))
+    return None
+
+
+async def _fetch_community_signals(
+    client: httpx.AsyncClient,
+    semaphore: asyncio.Semaphore,
+    owner: str,
+    name: str,
+) -> dict | None:
+    """Fetch community health signals for a single repo from the free GitHub API.
+
+    Returns a dict with the signal values, or ``None`` on unrecoverable error
+    (404, etc.).
+    """
+    base = f"https://api.github.com/repos/{owner}/{name}"
+    signals: dict = {}
+
+    async with semaphore:
+        try:
+            # 1. Main repo endpoint → has_discussions, open_issues_count
+            resp = await client.get(base, timeout=15.0)
+            if resp.status_code == 404:
+                return None
+            resp.raise_for_status()
+            repo_data = resp.json()
+            signals["has_discussions"] = repo_data.get("has_discussions", False)
+
+            # 2. Contributors (per_page=1, parse Link header for total)
+            resp_c = await client.get(
+                f"{base}/contributors",
+                params={"per_page": "1", "anon": "true"},
+                timeout=15.0,
+            )
+            if resp_c.status_code == 200:
+                last_page = _parse_last_page(resp_c.headers.get("link"))
+                signals["contributors_count"] = last_page if last_page else len(resp_c.json())
+            elif resp_c.status_code == 204:
+                # Empty repo — no contributors
+                signals["contributors_count"] = 0
+
+            # 3. Releases (per_page=1, parse Link header for count + latest date)
+            resp_r = await client.get(
+                f"{base}/releases",
+                params={"per_page": "1"},
+                timeout=15.0,
+            )
+            if resp_r.status_code == 200:
+                releases = resp_r.json()
+                last_page = _parse_last_page(resp_r.headers.get("link"))
+                signals["release_count"] = last_page if last_page else len(releases)
+                if releases:
+                    signals["latest_release_date"] = releases[0].get("published_at")
+            else:
+                signals["release_count"] = 0
+
+            # 4. Community profile → health_percentage
+            resp_cp = await client.get(
+                f"{base}/community/profile",
+                timeout=15.0,
+            )
+            if resp_cp.status_code == 200:
+                signals["community_health_pct"] = resp_cp.json().get("health_percentage")
+
+            # 5. Issue close rate
+            #    closed issues = total from search, open from repo data
+            open_issues = repo_data.get("open_issues_count", 0)
+            resp_closed = await client.get(
+                "https://api.github.com/search/issues",
+                params={
+                    "q": f"repo:{owner}/{name} type:issue is:closed",
+                    "per_page": "1",
+                },
+                timeout=15.0,
+            )
+            if resp_closed.status_code == 200:
+                closed_count = resp_closed.json().get("total_count", 0)
+                total_issues = open_issues + closed_count
+                signals["issue_close_rate"] = round(
+                    closed_count / total_issues, 4
+                ) if total_issues > 0 else None
+
+            # 6. PR merge rate
+            resp_closed_pr = await client.get(
+                "https://api.github.com/search/issues",
+                params={
+                    "q": f"repo:{owner}/{name} type:pr is:merged",
+                    "per_page": "1",
+                },
+                timeout=15.0,
+            )
+            resp_total_pr = await client.get(
+                "https://api.github.com/search/issues",
+                params={
+                    "q": f"repo:{owner}/{name} type:pr",
+                    "per_page": "1",
+                },
+                timeout=15.0,
+            )
+            if resp_closed_pr.status_code == 200 and resp_total_pr.status_code == 200:
+                merged_count = resp_closed_pr.json().get("total_count", 0)
+                total_prs = resp_total_pr.json().get("total_count", 0)
+                signals["pr_merge_rate"] = round(
+                    merged_count / total_prs, 4
+                ) if total_prs > 0 else None
+
+            return signals
+
+        except Exception as exc:
+            logger.warning("Community signals fetch failed for %s/%s: %s", owner, name, exc)
+            return None
+
+
+@router.post("/admin/backfill-community-signals", response_model=dict)
+@_limiter.limit("5/minute")
+async def backfill_community_signals(
+    request: Request,
+    dry_run: bool = Query(default=False, description="Preview without writing"),
+    batch_size: int = Query(default=0, ge=0, le=500, description="Max repos to process (0 = all)"),
+    db: AsyncSession = Depends(get_db),
+    _api_key: str = Depends(verify_api_key),
+    _admin_key: None = Depends(require_admin_key),
+):
+    """Backfill community health signals for repos missing ``community_health_pct``.
+
+    Calls the free GitHub REST API to populate:
+    ``contributors_count``, ``release_count``, ``latest_release_date``,
+    ``issue_close_rate``, ``pr_merge_rate``, ``has_discussions``, and
+    ``community_health_pct``.
+
+    Uses ``GITHUB_TOKEN`` env var for authenticated requests (5 000 req/hr).
+
+    Returns ``{total, updated, failed, skipped, dry_run}``.
+    """
+    query = (
+        "SELECT id, owner, name FROM repos "
+        "WHERE community_health_pct IS NULL "
+        "ORDER BY updated_at DESC"
+    )
+    if batch_size > 0:
+        query += f" LIMIT {batch_size}"
+
+    result = await db.execute(text(query))
+    rows = result.fetchall()
+    total = len(rows)
+
+    if total == 0:
+        return {"total": 0, "updated": 0, "failed": 0, "skipped": 0, "dry_run": dry_run}
+
+    if dry_run:
+        return {"total": total, "updated": 0, "failed": 0, "skipped": 0, "dry_run": True}
+
+    headers: dict[str, str] = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    gh_token = os.getenv("GITHUB_TOKEN")
+    if gh_token:
+        headers["Authorization"] = f"Bearer {gh_token}"
+
+    semaphore = asyncio.Semaphore(10)
+    updated = 0
+    failed = 0
+    skipped = 0
+
+    async with httpx.AsyncClient(headers=headers) as client:
+        tasks = [
+            _fetch_community_signals(client, semaphore, row.owner, row.name)
+            for row in rows
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
+    for row, signals in zip(rows, results):
+        if isinstance(signals, Exception):
+            failed += 1
+            logger.warning(
+                "Community signals exception for %s/%s: %s", row.owner, row.name, signals
+            )
+            continue
+        if signals is None:
+            skipped += 1
+            continue
+        if not signals:
+            skipped += 1
+            continue
+
+        try:
+            set_clauses = []
+            params: dict = {"id": str(row.id)}
+
+            for col in (
+                "contributors_count",
+                "release_count",
+                "latest_release_date",
+                "issue_close_rate",
+                "pr_merge_rate",
+                "has_discussions",
+                "community_health_pct",
+            ):
+                if col in signals and signals[col] is not None:
+                    set_clauses.append(f"{col} = :{col}")
+                    params[col] = signals[col]
+
+            if not set_clauses:
+                skipped += 1
+                continue
+
+            await db.execute(
+                text(f"UPDATE repos SET {', '.join(set_clauses)} WHERE id = :id"),
+                params,
+            )
+            updated += 1
+        except Exception as exc:
+            failed += 1
+            logger.warning(
+                "Community signals update failed for %s/%s: %s", row.owner, row.name, exc
+            )
+
+    if updated > 0:
+        await db.commit()
+
+    return {"total": total, "updated": updated, "failed": failed, "skipped": skipped, "dry_run": False}

--- a/migrations/versions/026_add_community_health_signals.py
+++ b/migrations/versions/026_add_community_health_signals.py
@@ -1,0 +1,41 @@
+"""Add community health signal columns to repos table.
+
+Stores contributor count, release info, issue close rate, PR merge rate,
+GitHub Discussions flag, and community health percentage from the free
+GitHub REST API.
+
+Revision ID: 026
+Revises: 025
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "026"
+down_revision = "025"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("repos", sa.Column("contributors_count", sa.Integer, nullable=True))
+    op.add_column("repos", sa.Column("release_count", sa.Integer, nullable=True))
+    op.add_column(
+        "repos",
+        sa.Column("latest_release_date", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.add_column("repos", sa.Column("issue_close_rate", sa.Float, nullable=True))
+    op.add_column("repos", sa.Column("pr_merge_rate", sa.Float, nullable=True))
+    op.add_column("repos", sa.Column("has_discussions", sa.Boolean, nullable=True))
+    op.add_column("repos", sa.Column("community_health_pct", sa.Integer, nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("repos", "community_health_pct")
+    op.drop_column("repos", "has_discussions")
+    op.drop_column("repos", "pr_merge_rate")
+    op.drop_column("repos", "issue_close_rate")
+    op.drop_column("repos", "latest_release_date")
+    op.drop_column("repos", "release_count")
+    op.drop_column("repos", "contributors_count")

--- a/tests/test_community_signals.py
+++ b/tests/test_community_signals.py
@@ -1,0 +1,218 @@
+"""Tests for POST /admin/backfill-community-signals and helpers."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+from httpx import AsyncClient
+
+from app.routers.admin import _fetch_community_signals, _parse_last_page
+from tests.conftest import AUTH_HEADERS
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _parse_last_page
+# ---------------------------------------------------------------------------
+
+
+class TestParseLinkHeader:
+    def test_last_page_present(self):
+        header = (
+            '<https://api.github.com/repos/o/n/contributors?per_page=1&page=2>; rel="next", '
+            '<https://api.github.com/repos/o/n/contributors?per_page=1&page=47>; rel="last"'
+        )
+        assert _parse_last_page(header) == 47
+
+    def test_no_last_rel(self):
+        header = '<https://api.github.com/repos/o/n/contributors?per_page=1&page=2>; rel="next"'
+        assert _parse_last_page(header) is None
+
+    def test_none_header(self):
+        assert _parse_last_page(None) is None
+
+    def test_empty_string(self):
+        assert _parse_last_page("") is None
+
+    def test_single_page(self):
+        # When all results fit in one page, GitHub omits the Link header entirely
+        assert _parse_last_page(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _fetch_community_signals
+# ---------------------------------------------------------------------------
+
+
+def _mock_response(status_code=200, json_data=None, headers=None):
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    resp.headers = headers or {}
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "error", request=MagicMock(), response=resp,
+        )
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_fetch_signals_404_returns_none():
+    """If the main repo endpoint returns 404, the helper should return None."""
+    import asyncio
+
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.get = AsyncMock(return_value=_mock_response(404))
+
+    result = await _fetch_community_signals(client, asyncio.Semaphore(1), "owner", "repo")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_signals_success():
+    """Happy path: all sub-requests succeed."""
+    import asyncio
+
+    repo_resp = _mock_response(200, {
+        "has_discussions": True,
+        "open_issues_count": 10,
+    })
+
+    contrib_resp = _mock_response(200, [{"id": 1}], {
+        "link": '<https://api.github.com/repos/o/n/contributors?per_page=1&page=25>; rel="last"',
+    })
+
+    release_resp = _mock_response(200, [{"published_at": "2026-01-15T00:00:00Z"}], {
+        "link": '<https://api.github.com/repos/o/n/releases?per_page=1&page=8>; rel="last"',
+    })
+
+    community_resp = _mock_response(200, {"health_percentage": 85})
+
+    closed_issues_resp = _mock_response(200, {"total_count": 40})
+    merged_pr_resp = _mock_response(200, {"total_count": 30})
+    total_pr_resp = _mock_response(200, {"total_count": 50})
+
+    call_index = 0
+    responses = [
+        repo_resp,       # GET /repos/{owner}/{name}
+        contrib_resp,    # GET /repos/.../contributors
+        release_resp,    # GET /repos/.../releases
+        community_resp,  # GET /repos/.../community/profile
+        closed_issues_resp,  # search/issues (closed issues)
+        merged_pr_resp,      # search/issues (merged PRs)
+        total_pr_resp,       # search/issues (total PRs)
+    ]
+
+    async def mock_get(*args, **kwargs):
+        nonlocal call_index
+        idx = call_index
+        call_index += 1
+        return responses[idx]
+
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.get = mock_get
+
+    result = await _fetch_community_signals(client, asyncio.Semaphore(1), "owner", "repo")
+
+    assert result is not None
+    assert result["has_discussions"] is True
+    assert result["contributors_count"] == 25
+    assert result["release_count"] == 8
+    assert result["latest_release_date"] == "2026-01-15T00:00:00Z"
+    assert result["community_health_pct"] == 85
+    assert result["issue_close_rate"] == round(40 / 50, 4)
+    assert result["pr_merge_rate"] == round(30 / 50, 4)
+
+
+@pytest.mark.asyncio
+async def test_fetch_signals_no_link_header_falls_back():
+    """When no Link header exists, use length of the returned JSON array."""
+    import asyncio
+
+    repo_resp = _mock_response(200, {"has_discussions": False, "open_issues_count": 0})
+    contrib_resp = _mock_response(200, [{"id": 1}, {"id": 2}, {"id": 3}])
+    release_resp = _mock_response(200, [])
+    community_resp = _mock_response(200, {"health_percentage": 40})
+    closed_issues_resp = _mock_response(200, {"total_count": 0})
+    merged_pr_resp = _mock_response(200, {"total_count": 0})
+    total_pr_resp = _mock_response(200, {"total_count": 0})
+
+    call_index = 0
+    responses = [repo_resp, contrib_resp, release_resp, community_resp,
+                 closed_issues_resp, merged_pr_resp, total_pr_resp]
+
+    async def mock_get(*args, **kwargs):
+        nonlocal call_index
+        idx = call_index
+        call_index += 1
+        return responses[idx]
+
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.get = mock_get
+
+    result = await _fetch_community_signals(client, asyncio.Semaphore(1), "o", "n")
+    assert result["contributors_count"] == 3
+    assert result["release_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_fetch_signals_exception_returns_none():
+    """Network errors should be caught and return None."""
+    import asyncio
+
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.get = AsyncMock(side_effect=httpx.ConnectError("connection refused"))
+
+    result = await _fetch_community_signals(client, asyncio.Semaphore(1), "o", "n")
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Integration-style tests (via test client)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backfill_community_signals_requires_auth(client: AsyncClient):
+    """Endpoint should reject unauthenticated requests."""
+    resp = await client.post("/admin/backfill-community-signals")
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_backfill_community_signals_dry_run(client: AsyncClient):
+    """dry_run should return counts without modifying the database."""
+    resp = await client.post(
+        "/admin/backfill-community-signals?dry_run=true",
+        headers=AUTH_HEADERS,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "total" in data
+    assert "updated" in data
+    assert "failed" in data
+    assert "skipped" in data
+    assert data["dry_run"] is True
+    assert data["updated"] == 0
+
+
+@pytest.mark.asyncio
+async def test_backfill_community_signals_batch_size(client: AsyncClient):
+    """batch_size param should be accepted and validated."""
+    resp = await client.post(
+        "/admin/backfill-community-signals?dry_run=true&batch_size=5",
+        headers=AUTH_HEADERS,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["dry_run"] is True
+
+
+@pytest.mark.asyncio
+async def test_backfill_community_signals_invalid_batch_size(client: AsyncClient):
+    """batch_size > 500 should be rejected."""
+    resp = await client.post(
+        "/admin/backfill-community-signals?batch_size=999",
+        headers=AUTH_HEADERS,
+    )
+    assert resp.status_code == 422


### PR DESCRIPTION
## Summary
- Adds 7 new nullable columns to `repos` table via migration 026: `contributors_count`, `release_count`, `latest_release_date`, `issue_close_rate`, `pr_merge_rate`, `has_discussions`, `community_health_pct`
- New `POST /admin/backfill-community-signals` endpoint that fetches data from free GitHub REST API endpoints (repo info, contributors, releases, community profile, search/issues)
- Uses `httpx.AsyncClient` with `asyncio.Semaphore(10)` for concurrency; parses `Link` headers for pagination-based counts
- Supports `dry_run` and `batch_size` query params; requires admin auth

## Test plan
- [x] 5 unit tests for `_parse_last_page` Link header parser
- [x] 4 unit tests for `_fetch_community_signals` (404, success, no-link-header fallback, network error)
- [x] 4 integration tests (auth required, dry_run, batch_size, invalid batch_size validation)
- [ ] Manual test against staging with `dry_run=true` to verify repo count
- [ ] Run migration 026 on staging DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)