### PR TITLE
feat: graph viz API - nodes, subgraph, clusters, temporal filter

### DIFF
--- a/app/routers/graph.py
+++ b/app/routers/graph.py
@@ -12,8 +12,10 @@ all-MiniLM-L6-v2 embeddings and the HNSW index for fast ANN queries.
 
 import hashlib
 import logging
+import math
+import re
 
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 from slowapi import Limiter
 from slowapi.util import get_remote_address
@@ -30,15 +32,103 @@ logger = logging.getLogger(__name__)
 
 CACHE_TTL_GRAPH_EDGES = 3600  # 1 hr
 CACHE_TTL_GRAPH_SEARCH = 1800  # 30 min
+CACHE_TTL_GRAPH_SUBGRAPH = 1800  # 30 min
+CACHE_TTL_GRAPH_CLUSTERS = 3600  # 1 hr
 
 _EMBEDDING_MODEL_NAME = "all-MiniLM-L6-v2"
 _EMBEDDING_DIMENSION = 384
 
-CACHE_TTL_GRAPH_EDGES = 3600  # 1 hr
-
 router = APIRouter(tags=["Graph"])
 _limiter = Limiter(key_func=get_remote_address, storage_uri=rate_limit_storage)
 
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _parse_since(since: str | None) -> str | None:
+    """Parse a duration string like '7d', '24h', '30m' into a Postgres interval.
+
+    Returns None if *since* is falsy or not a recognised pattern.
+    """
+    if not since:
+        return None
+    m = re.match(r"^(\d+)([dhm])$", since.strip().lower())
+    if not m:
+        return None
+    value, unit = m.group(1), m.group(2)
+    unit_map = {"d": "day", "h": "hour", "m": "minute"}
+    return f"{value} {unit_map[unit]}"
+
+
+def _log_scale_stars(stars: int | None) -> float:
+    """Return a log-scaled star value for node sizing (0.0 when no stars)."""
+    if not stars or stars <= 0:
+        return 0.0
+    return round(math.log10(stars + 1), 4)
+
+
+def _extract_quality(quality_signals: dict | None) -> float | None:
+    """Extract a 0-1 quality score from the quality_signals JSONB.
+
+    Returns the ``overall`` key if present, else None.
+    """
+    if not quality_signals:
+        return None
+    overall = quality_signals.get("overall")
+    if overall is not None:
+        return round(float(overall), 4)
+    return None
+
+
+def _rows_to_edges(rows) -> list[dict]:
+    """Convert DB rows (with source_*/target_* columns) to edge dicts."""
+    return [
+        {
+            "edgeType": "SIMILAR_TO",
+            "weight": round(float(row.similarity), 4),
+            "evidence": None,
+            "source": {
+                "name": row.source_name,
+                "owner": row.source_owner,
+                "description": row.source_description,
+                "category": row.source_category,
+            },
+            "target": {
+                "name": row.target_name,
+                "owner": row.target_owner,
+                "description": row.target_description,
+                "category": row.target_category,
+            },
+        }
+        for row in rows
+    ]
+
+
+def _rows_to_nodes(rows) -> list[dict]:
+    """Build unique nodes list from edge rows that contain viz columns."""
+    node_map: dict[str, dict] = {}
+    for row in rows:
+        for prefix in ("source", "target"):
+            name = getattr(row, f"{prefix}_name")
+            if name not in node_map:
+                stars = getattr(row, f"{prefix}_stars", None)
+                qs = getattr(row, f"{prefix}_quality_signals", None)
+                node_map[name] = {
+                    "name": name,
+                    "owner": getattr(row, f"{prefix}_owner"),
+                    "description": getattr(row, f"{prefix}_description"),
+                    "primary_category": getattr(row, f"{prefix}_category"),
+                    "stars": stars or 0,
+                    "stars_log": _log_scale_stars(stars),
+                    "quality": _extract_quality(qs),
+                }
+    return list(node_map.values())
+
+
+# ---------------------------------------------------------------------------
+# GET /graph/edges — enhanced with nodes array + temporal filter
+# ---------------------------------------------------------------------------
 
 @router.get("/graph/edges")
 @_limiter.limit("20/minute")
@@ -49,25 +139,43 @@ async def get_graph_edges(
                                   description="Minimum cosine similarity threshold"),
     neighbours: int = Query(default=8, ge=1, le=30,
                             description="Max neighbours per repo"),
+    since: str | None = Query(default=None,
+                              description="Temporal filter, e.g. '7d', '24h', '30m'"),
     db: AsyncSession = Depends(get_db),
 ):
     """
     Returns knowledge graph edges based on pgvector embedding similarity.
     Each repo is connected to its top-K nearest neighbours above the
     similarity threshold.  Edges are SIMILAR_TO with weight = similarity.
+
+    Includes a ``nodes`` array with cluster metadata for visualization
+    (primary_category, log-scaled stars, quality score).
+
+    Optional ``since`` param filters to edges where at least one node was
+    added/updated within the given time window (e.g. ``?since=7d``).
     """
+    interval = _parse_since(since)
+
     # --- Redis cache check ---
-    cache_key = f"graph_edges:{limit}:{min_similarity}:{neighbours}"
+    cache_key = f"graph_edges:{limit}:{min_similarity}:{neighbours}:{since or 'all'}"
     cached = await cache.get(cache_key)
     if cached is not None:
         response = JSONResponse(content=cached)
         response.headers["Cache-Control"] = "public, max-age=3600"
         return response
 
+    # Build optional temporal WHERE clause
+    since_clause = ""
+    if interval:
+        since_clause = (
+            "AND (r1.updated_at >= NOW() - :since_interval::interval "
+            "OR r2.updated_at >= NOW() - :since_interval::interval)"
+        )
+
     # Use a CTE to find top-K neighbours per repo via HNSW index.
     # The <=> operator returns cosine distance; 1 - distance = similarity.
     # We lateral-join to get the K nearest neighbours per repo efficiently.
-    sql = text("""
+    sql = text(f"""
         WITH ranked AS (
             SELECT
                 e1.repo_id   AS source_id,
@@ -120,54 +228,66 @@ async def get_graph_edges(
         )
         SELECT
             ae.similarity,
-            r1.name        AS source_name,
-            r1.description AS source_description,
-            r1.primary_category AS source_category,
-            r1.owner       AS source_owner,
-            r2.name        AS target_name,
-            r2.description AS target_description,
-            r2.primary_category AS target_category,
-            r2.owner       AS target_owner
+            r1.name               AS source_name,
+            r1.description        AS source_description,
+            r1.primary_category   AS source_category,
+            r1.owner              AS source_owner,
+            r1.stargazers_count   AS source_stars,
+            r1.quality_signals    AS source_quality_signals,
+            r1.updated_at         AS source_updated_at,
+            r2.name               AS target_name,
+            r2.description        AS target_description,
+            r2.primary_category   AS target_category,
+            r2.owner              AS target_owner,
+            r2.stargazers_count   AS target_stars,
+            r2.quality_signals    AS target_quality_signals,
+            r2.updated_at         AS target_updated_at
         FROM all_edges ae
         JOIN repos r1 ON r1.id = ae.source_id AND r1.is_private = false
         JOIN repos r2 ON r2.id = ae.target_id AND r2.is_private = false
+        WHERE 1=1 {since_clause}
         ORDER BY ae.similarity DESC
         LIMIT :limit
     """)
 
-    result = await db.execute(sql, {
+    params: dict = {
         "neighbours": neighbours,
         "min_sim": min_similarity,
         "limit": limit,
-    })
+    }
+    if interval:
+        params["since_interval"] = interval
+
+    result = await db.execute(sql, params)
     rows = result.fetchall()
 
-    edges = [
-        {
-            "edgeType": "SIMILAR_TO",
-            "weight": round(float(row.similarity), 4),
-            "evidence": None,
-            "source": {
+    edges = _rows_to_edges(rows)
+
+    # Build unique nodes map with visualization metadata
+    node_map: dict[str, dict] = {}
+    for row in rows:
+        if row.source_name not in node_map:
+            node_map[row.source_name] = {
                 "name": row.source_name,
                 "owner": row.source_owner,
                 "description": row.source_description,
-                "category": row.source_category,
-            },
-            "target": {
+                "primary_category": row.source_category,
+                "stars": row.source_stars or 0,
+                "stars_log": _log_scale_stars(row.source_stars),
+                "quality": _extract_quality(row.source_quality_signals),
+            }
+        if row.target_name not in node_map:
+            node_map[row.target_name] = {
                 "name": row.target_name,
                 "owner": row.target_owner,
                 "description": row.target_description,
-                "category": row.target_category,
-            },
-        }
-        for row in rows
-    ]
+                "primary_category": row.target_category,
+                "stars": row.target_stars or 0,
+                "stars_log": _log_scale_stars(row.target_stars),
+                "quality": _extract_quality(row.target_quality_signals),
+            }
 
-    # Count distinct repos in result set
-    repo_ids = set()
-    for row in rows:
-        repo_ids.add(row.source_name)
-        repo_ids.add(row.target_name)
+    nodes = list(node_map.values())
 
     # Count repos with and without embeddings for diagnostics
     counts = await db.execute(text("""
@@ -183,10 +303,11 @@ async def get_graph_edges(
 
     result_payload = {
         "total": len(edges),
-        "total_repos": len(repo_ids),
+        "total_repos": len(nodes),
         "total_public_repos": count_row.total_public if count_row else 0,
         "repos_with_embeddings": count_row.with_embeddings if count_row else 0,
         "edgeTypes": ["SIMILAR_TO"],
+        "nodes": nodes,
         "edges": edges,
     }
 
@@ -196,34 +317,6 @@ async def get_graph_edges(
     response = JSONResponse(content=result_payload)
     response.headers["Cache-Control"] = "public, max-age=3600"
     return response
-
-
-# ---------------------------------------------------------------------------
-# Helper: build edge dicts from rows (shared by /graph/edges and search)
-# ---------------------------------------------------------------------------
-
-def _rows_to_edges(rows) -> list[dict]:
-    """Convert DB rows (with source_*/target_* columns) to edge dicts."""
-    return [
-        {
-            "edgeType": "SIMILAR_TO",
-            "weight": round(float(row.similarity), 4),
-            "evidence": None,
-            "source": {
-                "name": row.source_name,
-                "owner": row.source_owner,
-                "description": row.source_description,
-                "category": row.source_category,
-            },
-            "target": {
-                "name": row.target_name,
-                "owner": row.target_owner,
-                "description": row.target_description,
-                "category": row.target_category,
-            },
-        }
-        for row in rows
-    ]
 
 
 # ---------------------------------------------------------------------------
@@ -339,6 +432,289 @@ async def search_graph_edges(
     }
 
     await cache.set(cache_key, payload, ttl=CACHE_TTL_GRAPH_SEARCH)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# GET /graph/subgraph/{repo_name} — 2-hop neighbourhood of a specific repo
+# ---------------------------------------------------------------------------
+
+@router.get("/graph/subgraph/{repo_name}")
+@_limiter.limit("15/minute")
+async def get_repo_subgraph(
+    request: Request,
+    repo_name: str,
+    neighbours: int = Query(default=8, ge=1, le=30,
+                            description="Max neighbours per hop"),
+    min_similarity: float = Query(default=0.5, ge=0.0, le=1.0,
+                                  description="Minimum cosine similarity threshold"),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Returns the 2-hop neighbourhood of a specific repo for focused
+    exploration (e.g. "show me repos related to LangChain").
+
+    Hop 1: direct embedding neighbours of the target repo.
+    Hop 2: neighbours of each hop-1 repo.
+
+    Redis cached with 30-min TTL.
+    """
+    cache_key = f"graph_subgraph:{repo_name}:{neighbours}:{min_similarity}"
+    cached = await cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    # Verify the repo exists and has an embedding
+    check = await db.execute(text("""
+        SELECT r.id, r.name, r.owner, r.description, r.primary_category,
+               r.stargazers_count, r.quality_signals
+        FROM repos r
+        JOIN repo_embeddings re ON re.repo_id = r.id
+        WHERE r.name = :name AND r.is_private = false
+          AND re.embedding_vec IS NOT NULL
+        LIMIT 1
+    """), {"name": repo_name})
+    seed_row = check.fetchone()
+
+    if seed_row is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Repo '{repo_name}' not found or has no embedding",
+        )
+
+    # 2-hop neighbourhood via CTEs
+    sql = text("""
+        WITH seed AS (
+            SELECT re.repo_id, re.embedding_vec
+            FROM repo_embeddings re
+            JOIN repos r ON r.id = re.repo_id
+            WHERE r.name = :name AND r.is_private = false
+            LIMIT 1
+        ),
+        -- Hop 1: direct neighbours of seed
+        hop1 AS (
+            SELECT
+                s.repo_id      AS source_id,
+                e2.repo_id     AS target_id,
+                1 - (s.embedding_vec <=> e2.embedding_vec) AS similarity
+            FROM seed s
+            CROSS JOIN LATERAL (
+                SELECT e2_inner.repo_id, e2_inner.embedding_vec
+                FROM repo_embeddings e2_inner
+                WHERE e2_inner.repo_id != s.repo_id
+                ORDER BY s.embedding_vec <=> e2_inner.embedding_vec
+                LIMIT :neighbours
+            ) e2
+            WHERE 1 - (s.embedding_vec <=> e2.embedding_vec) >= :min_sim
+        ),
+        -- Hop 2: neighbours of hop-1 repos
+        hop2 AS (
+            SELECT
+                h1.target_id   AS source_id,
+                e3.repo_id     AS target_id,
+                1 - (e1.embedding_vec <=> e3.embedding_vec) AS similarity
+            FROM hop1 h1
+            JOIN repo_embeddings e1 ON e1.repo_id = h1.target_id
+            CROSS JOIN LATERAL (
+                SELECT e3_inner.repo_id, e3_inner.embedding_vec
+                FROM repo_embeddings e3_inner
+                WHERE e3_inner.repo_id != h1.target_id
+                  AND e3_inner.repo_id != (SELECT repo_id FROM seed)
+                ORDER BY e1.embedding_vec <=> e3_inner.embedding_vec
+                LIMIT :neighbours
+            ) e3
+            WHERE 1 - (e1.embedding_vec <=> e3.embedding_vec) >= :min_sim
+        ),
+        all_edges AS (
+            SELECT source_id, target_id, similarity FROM hop1
+            UNION
+            SELECT source_id, target_id, similarity FROM hop2
+        ),
+        deduped AS (
+            SELECT DISTINCT ON (LEAST(source_id, target_id), GREATEST(source_id, target_id))
+                source_id, target_id, similarity
+            FROM all_edges
+            ORDER BY LEAST(source_id, target_id), GREATEST(source_id, target_id),
+                     similarity DESC
+        )
+        SELECT
+            d.similarity,
+            r1.name               AS source_name,
+            r1.description        AS source_description,
+            r1.primary_category   AS source_category,
+            r1.owner              AS source_owner,
+            r1.stargazers_count   AS source_stars,
+            r1.quality_signals    AS source_quality_signals,
+            r2.name               AS target_name,
+            r2.description        AS target_description,
+            r2.primary_category   AS target_category,
+            r2.owner              AS target_owner,
+            r2.stargazers_count   AS target_stars,
+            r2.quality_signals    AS target_quality_signals
+        FROM deduped d
+        JOIN repos r1 ON r1.id = d.source_id AND r1.is_private = false
+        JOIN repos r2 ON r2.id = d.target_id AND r2.is_private = false
+        ORDER BY d.similarity DESC
+    """)
+
+    result = await db.execute(sql, {
+        "name": repo_name,
+        "neighbours": neighbours,
+        "min_sim": min_similarity,
+    })
+    rows = result.fetchall()
+    edges = _rows_to_edges(rows)
+    nodes = _rows_to_nodes(rows)
+
+    # Ensure the seed node is in the nodes list
+    seed_in_nodes = any(n["name"] == repo_name for n in nodes)
+    if not seed_in_nodes:
+        nodes.insert(0, {
+            "name": seed_row.name,
+            "owner": seed_row.owner,
+            "description": seed_row.description,
+            "primary_category": seed_row.primary_category,
+            "stars": seed_row.stargazers_count or 0,
+            "stars_log": _log_scale_stars(seed_row.stargazers_count),
+            "quality": _extract_quality(seed_row.quality_signals),
+        })
+
+    payload = {
+        "repo_name": repo_name,
+        "total_edges": len(edges),
+        "total_nodes": len(nodes),
+        "edgeTypes": ["SIMILAR_TO"],
+        "nodes": nodes,
+        "edges": edges,
+    }
+
+    await cache.set(cache_key, payload, ttl=CACHE_TTL_GRAPH_SUBGRAPH)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# GET /graph/clusters — repos grouped by primary_category
+# ---------------------------------------------------------------------------
+
+@router.get("/graph/clusters")
+@_limiter.limit("10/minute")
+async def get_graph_clusters(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Returns repos grouped by primary_category with cluster-level stats:
+    category name, repo count, average stars, top 5 repos by stars, and
+    inter-cluster edge counts.
+
+    Redis cached with 1-hr TTL.
+    """
+    cache_key = "graph_clusters"
+    cached = await cache.get(cache_key)
+    if cached is not None:
+        return cached
+
+    # 1. Cluster stats + top repos per category
+    stats_sql = text("""
+        WITH cat_stats AS (
+            SELECT
+                primary_category,
+                COUNT(*)                        AS repo_count,
+                ROUND(AVG(COALESCE(stargazers_count, 0))::numeric, 1) AS avg_stars
+            FROM repos
+            WHERE is_private = false AND primary_category IS NOT NULL
+            GROUP BY primary_category
+        ),
+        top_repos AS (
+            SELECT
+                r.primary_category,
+                r.name,
+                r.owner,
+                COALESCE(r.stargazers_count, 0) AS stars,
+                ROW_NUMBER() OVER (
+                    PARTITION BY r.primary_category
+                    ORDER BY COALESCE(r.stargazers_count, 0) DESC
+                ) AS rn
+            FROM repos r
+            WHERE r.is_private = false AND r.primary_category IS NOT NULL
+        )
+        SELECT
+            cs.primary_category,
+            cs.repo_count,
+            cs.avg_stars,
+            tr.name     AS repo_name,
+            tr.owner    AS repo_owner,
+            tr.stars    AS repo_stars
+        FROM cat_stats cs
+        LEFT JOIN top_repos tr
+            ON tr.primary_category = cs.primary_category AND tr.rn <= 5
+        ORDER BY cs.repo_count DESC, cs.primary_category, tr.rn
+    """)
+    stats_result = await db.execute(stats_sql)
+    stats_rows = stats_result.fetchall()
+
+    # Build cluster map
+    clusters: dict[str, dict] = {}
+    for row in stats_rows:
+        cat = row.primary_category
+        if cat not in clusters:
+            clusters[cat] = {
+                "category": cat,
+                "repo_count": row.repo_count,
+                "avg_stars": float(row.avg_stars) if row.avg_stars else 0.0,
+                "top_repos": [],
+                "inter_cluster_edges": {},
+            }
+        if row.repo_name:
+            clusters[cat]["top_repos"].append({
+                "name": row.repo_name,
+                "owner": row.repo_owner,
+                "stars": row.repo_stars,
+            })
+
+    # 2. Inter-cluster edge counts (how connected categories are)
+    # Uses a sampled approach: top-3 neighbours per repo, count cross-category edges
+    inter_sql = text("""
+        WITH edges AS (
+            SELECT
+                r1.primary_category AS cat1,
+                r2.primary_category AS cat2
+            FROM repo_embeddings e1
+            CROSS JOIN LATERAL (
+                SELECT e2_inner.repo_id
+                FROM repo_embeddings e2_inner
+                WHERE e2_inner.repo_id != e1.repo_id
+                ORDER BY e1.embedding_vec <=> e2_inner.embedding_vec
+                LIMIT 3
+            ) e2
+            JOIN repos r1 ON r1.id = e1.repo_id AND r1.is_private = false
+            JOIN repos r2 ON r2.id = e2.repo_id AND r2.is_private = false
+            WHERE r1.primary_category IS NOT NULL
+              AND r2.primary_category IS NOT NULL
+              AND r1.primary_category != r2.primary_category
+        )
+        SELECT cat1, cat2, COUNT(*) AS edge_count
+        FROM edges
+        GROUP BY cat1, cat2
+        ORDER BY edge_count DESC
+    """)
+    inter_result = await db.execute(inter_sql)
+    inter_rows = inter_result.fetchall()
+
+    for row in inter_rows:
+        if row.cat1 in clusters:
+            clusters[row.cat1]["inter_cluster_edges"][row.cat2] = row.edge_count
+        if row.cat2 in clusters:
+            clusters[row.cat2]["inter_cluster_edges"][row.cat1] = row.edge_count
+
+    cluster_list = list(clusters.values())
+
+    payload = {
+        "total_clusters": len(cluster_list),
+        "clusters": cluster_list,
+    }
+
+    await cache.set(cache_key, payload, ttl=CACHE_TTL_GRAPH_CLUSTERS)
     return payload
 
 

--- a/tests/test_graph_viz.py
+++ b/tests/test_graph_viz.py
@@ -1,0 +1,561 @@
+"""
+Tests for graph visualization API enhancements:
+- Enhanced /graph/edges with nodes array, temporal filter
+- GET /graph/subgraph/{repo_name} — 2-hop neighbourhood
+- GET /graph/clusters — category-grouped cluster stats
+
+Uses dependency_overrides[get_db] for DB injection and mocks for Redis
+cache — same pattern as test_graph_optimization.py.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.database import get_db
+from app.main import app
+from app.routers.graph import _extract_quality, _log_scale_stars, _parse_since
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_edge_row(
+    source_name="repo-a",
+    target_name="repo-b",
+    similarity=0.82,
+    source_stars=100,
+    target_stars=50,
+    source_quality=None,
+    target_quality=None,
+    source_updated_at=None,
+    target_updated_at=None,
+):
+    """Simulate a DB row from the enhanced graph edges SQL."""
+    row = MagicMock()
+    row.similarity = similarity
+    row.source_name = source_name
+    row.source_owner = "perditioinc"
+    row.source_description = f"{source_name} desc"
+    row.source_category = "ai-agents"
+    row.source_stars = source_stars
+    row.source_quality_signals = source_quality
+    row.source_updated_at = source_updated_at
+    row.target_name = target_name
+    row.target_owner = "perditioinc"
+    row.target_description = f"{target_name} desc"
+    row.target_category = "rag-retrieval"
+    row.target_stars = target_stars
+    row.target_quality_signals = target_quality
+    row.target_updated_at = target_updated_at
+    return row
+
+
+def _make_counts_row(total_public=100, with_embeddings=80):
+    row = MagicMock()
+    row.total_public = total_public
+    row.with_embeddings = with_embeddings
+    return row
+
+
+def _make_seed_row(name="langchain"):
+    row = MagicMock()
+    row.id = "00000000-0000-0000-0000-000000000001"
+    row.name = name
+    row.owner = "langchain-ai"
+    row.description = f"{name} framework"
+    row.primary_category = "ai-agents"
+    row.stargazers_count = 5000
+    row.quality_signals = {"overall": 0.85}
+    return row
+
+
+def _make_cluster_stats_row(category, repo_count, avg_stars, repo_name=None,
+                            repo_owner=None, repo_stars=None):
+    row = MagicMock()
+    row.primary_category = category
+    row.repo_count = repo_count
+    row.avg_stars = avg_stars
+    row.repo_name = repo_name
+    row.repo_owner = repo_owner
+    row.repo_stars = repo_stars
+    return row
+
+
+def _make_inter_cluster_row(cat1, cat2, edge_count):
+    row = MagicMock()
+    row.cat1 = cat1
+    row.cat2 = cat2
+    row.edge_count = edge_count
+    return row
+
+
+def _override_db_multi(call_results: list):
+    """Successive execute() calls return successive row lists."""
+    call_idx = 0
+
+    async def _execute(*args, **kwargs):
+        nonlocal call_idx
+        result = MagicMock()
+        if call_idx < len(call_results):
+            data = call_results[call_idx]
+            call_idx += 1
+        else:
+            data = []
+        if isinstance(data, list):
+            result.fetchall.return_value = data
+            result.fetchone.return_value = data[0] if data else None
+        else:
+            result.fetchall.return_value = [data]
+            result.fetchone.return_value = data
+        return result
+
+    mock_db = AsyncMock()
+    mock_db.execute = AsyncMock(side_effect=_execute)
+
+    async def _override():
+        yield mock_db
+
+    return mock_db, _override
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for helper functions
+# ---------------------------------------------------------------------------
+
+class TestHelpers:
+
+    def test_parse_since_days(self):
+        assert _parse_since("7d") == "7 day"
+
+    def test_parse_since_hours(self):
+        assert _parse_since("24h") == "24 hour"
+
+    def test_parse_since_minutes(self):
+        assert _parse_since("30m") == "30 minute"
+
+    def test_parse_since_none(self):
+        assert _parse_since(None) is None
+
+    def test_parse_since_invalid(self):
+        assert _parse_since("abc") is None
+        assert _parse_since("7x") is None
+        assert _parse_since("") is None
+
+    def test_log_scale_stars_positive(self):
+        result = _log_scale_stars(100)
+        assert result > 0
+        assert isinstance(result, float)
+
+    def test_log_scale_stars_zero(self):
+        assert _log_scale_stars(0) == 0.0
+
+    def test_log_scale_stars_none(self):
+        assert _log_scale_stars(None) == 0.0
+
+    def test_log_scale_stars_large(self):
+        # 10000 stars -> log10(10001) ~ 4.0
+        result = _log_scale_stars(10000)
+        assert 3.9 < result < 4.1
+
+    def test_extract_quality_with_overall(self):
+        assert _extract_quality({"overall": 0.85}) == 0.85
+
+    def test_extract_quality_none(self):
+        assert _extract_quality(None) is None
+
+    def test_extract_quality_no_overall(self):
+        assert _extract_quality({"has_tests": True}) is None
+
+
+# ---------------------------------------------------------------------------
+# A. Enhanced GET /graph/edges — nodes array + temporal filter
+# ---------------------------------------------------------------------------
+
+class TestGraphEdgesNodes:
+
+    @pytest.mark.asyncio
+    async def test_edges_response_includes_nodes(self):
+        """Response should include a 'nodes' array with viz metadata."""
+        edge_rows = [
+            _make_edge_row("repo-a", "repo-b", 0.9, source_stars=500,
+                           target_stars=200,
+                           source_quality={"overall": 0.8},
+                           target_quality={"overall": 0.6}),
+        ]
+        counts_row = _make_counts_row()
+        _, db_override = _override_db_multi([edge_rows, counts_row])
+        app.dependency_overrides[get_db] = db_override
+
+        try:
+            with patch("app.routers.graph.cache") as mock_cache:
+                mock_cache.get = AsyncMock(return_value=None)
+                mock_cache.set = AsyncMock()
+
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.get("/graph/edges")
+
+                assert resp.status_code == 200
+                body = resp.json()
+
+                # Should have nodes array
+                assert "nodes" in body
+                assert len(body["nodes"]) == 2
+
+                # Check node properties
+                node_a = next(n for n in body["nodes"] if n["name"] == "repo-a")
+                assert node_a["primary_category"] == "ai-agents"
+                assert node_a["stars"] == 500
+                assert node_a["stars_log"] > 0
+                assert node_a["quality"] == 0.8
+
+                node_b = next(n for n in body["nodes"] if n["name"] == "repo-b")
+                assert node_b["stars"] == 200
+                assert node_b["quality"] == 0.6
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    @pytest.mark.asyncio
+    async def test_edges_with_since_param(self):
+        """Passing ?since=7d should include the param in cache key."""
+        edge_rows = [_make_edge_row()]
+        counts_row = _make_counts_row()
+        _, db_override = _override_db_multi([edge_rows, counts_row])
+        app.dependency_overrides[get_db] = db_override
+
+        try:
+            with patch("app.routers.graph.cache") as mock_cache:
+                mock_cache.get = AsyncMock(return_value=None)
+                mock_cache.set = AsyncMock()
+
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.get("/graph/edges", params={"since": "7d"})
+
+                assert resp.status_code == 200
+
+                # Verify cache key includes the since value
+                cache_get_key = mock_cache.get.call_args[0][0]
+                assert "7d" in cache_get_key
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    @pytest.mark.asyncio
+    async def test_edges_without_since_uses_all(self):
+        """Without ?since, cache key should include 'all'."""
+        counts_row = _make_counts_row()
+        _, db_override = _override_db_multi([[], counts_row])
+        app.dependency_overrides[get_db] = db_override
+
+        try:
+            with patch("app.routers.graph.cache") as mock_cache:
+                mock_cache.get = AsyncMock(return_value=None)
+                mock_cache.set = AsyncMock()
+
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.get("/graph/edges")
+
+                assert resp.status_code == 200
+                cache_get_key = mock_cache.get.call_args[0][0]
+                assert "all" in cache_get_key
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    @pytest.mark.asyncio
+    async def test_nodes_deduplicated(self):
+        """Nodes appearing in multiple edges should only appear once."""
+        edge_rows = [
+            _make_edge_row("repo-a", "repo-b", 0.9),
+            _make_edge_row("repo-a", "repo-c", 0.8),
+        ]
+        counts_row = _make_counts_row()
+        _, db_override = _override_db_multi([edge_rows, counts_row])
+        app.dependency_overrides[get_db] = db_override
+
+        try:
+            with patch("app.routers.graph.cache") as mock_cache:
+                mock_cache.get = AsyncMock(return_value=None)
+                mock_cache.set = AsyncMock()
+
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.get("/graph/edges")
+
+                body = resp.json()
+                # repo-a appears in both edges but should be only one node
+                names = [n["name"] for n in body["nodes"]]
+                assert names.count("repo-a") == 1
+                assert len(body["nodes"]) == 3  # a, b, c
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+
+# ---------------------------------------------------------------------------
+# B. GET /graph/subgraph/{repo_name} — 2-hop neighbourhood
+# ---------------------------------------------------------------------------
+
+class TestGraphSubgraph:
+
+    @pytest.mark.asyncio
+    async def test_subgraph_returns_nodes_and_edges(self):
+        """Subgraph should return nodes + edges for 2-hop neighbourhood."""
+        seed = _make_seed_row("langchain")
+        edge_rows = [
+            _make_edge_row("langchain", "llamaindex", 0.88, 5000, 3000),
+            _make_edge_row("llamaindex", "chromadb", 0.72, 3000, 1000),
+        ]
+        _, db_override = _override_db_multi([seed, edge_rows])
+        app.dependency_overrides[get_db] = db_override
+
+        try:
+            with patch("app.routers.graph.cache") as mock_cache:
+                mock_cache.get = AsyncMock(return_value=None)
+                mock_cache.set = AsyncMock()
+
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.get("/graph/subgraph/langchain")
+
+                assert resp.status_code == 200
+                body = resp.json()
+                assert body["repo_name"] == "langchain"
+                assert body["total_edges"] == 2
+                assert body["total_nodes"] >= 3
+                assert "nodes" in body
+                assert "edges" in body
+
+                # Cache should be set with 30-min TTL
+                mock_cache.set.assert_called_once()
+                call_args = mock_cache.set.call_args
+                assert call_args[1].get("ttl") == 1800 or call_args[0][2] == 1800
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    @pytest.mark.asyncio
+    async def test_subgraph_404_for_missing_repo(self):
+        """Should return 404 when repo not found."""
+        # First execute returns no rows (repo not found)
+        mock_db = AsyncMock()
+        result = MagicMock()
+        result.fetchone.return_value = None
+        mock_db.execute = AsyncMock(return_value=result)
+
+        async def _override():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = _override
+
+        try:
+            with patch("app.routers.graph.cache") as mock_cache:
+                mock_cache.get = AsyncMock(return_value=None)
+
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.get("/graph/subgraph/nonexistent-repo")
+
+                assert resp.status_code == 404
+                assert "nonexistent-repo" in resp.json()["detail"]
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    @pytest.mark.asyncio
+    async def test_subgraph_cache_hit(self):
+        """Cached subgraph should be returned without DB query."""
+        cached = {
+            "repo_name": "langchain",
+            "total_edges": 5,
+            "total_nodes": 4,
+            "edgeTypes": ["SIMILAR_TO"],
+            "nodes": [],
+            "edges": [],
+        }
+        mock_db = AsyncMock()
+
+        async def _override():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = _override
+
+        try:
+            with patch("app.routers.graph.cache") as mock_cache:
+                mock_cache.get = AsyncMock(return_value=cached)
+
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.get("/graph/subgraph/langchain")
+
+                assert resp.status_code == 200
+                assert resp.json()["repo_name"] == "langchain"
+                mock_db.execute.assert_not_called()
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    @pytest.mark.asyncio
+    async def test_subgraph_includes_seed_node(self):
+        """Even if seed is not in edge rows, it should appear in nodes."""
+        seed = _make_seed_row("lonely-repo")
+        # No edges found
+        _, db_override = _override_db_multi([seed, []])
+        app.dependency_overrides[get_db] = db_override
+
+        try:
+            with patch("app.routers.graph.cache") as mock_cache:
+                mock_cache.get = AsyncMock(return_value=None)
+                mock_cache.set = AsyncMock()
+
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.get("/graph/subgraph/lonely-repo")
+
+                assert resp.status_code == 200
+                body = resp.json()
+                assert body["total_nodes"] == 1
+                assert body["nodes"][0]["name"] == "lonely-repo"
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+
+# ---------------------------------------------------------------------------
+# C. GET /graph/clusters — category-grouped cluster stats
+# ---------------------------------------------------------------------------
+
+class TestGraphClusters:
+
+    @pytest.mark.asyncio
+    async def test_clusters_returns_categories(self):
+        """Should return clusters grouped by primary_category."""
+        stats_rows = [
+            _make_cluster_stats_row("ai-agents", 10, 500.0, "autogen", "microsoft", 8000),
+            _make_cluster_stats_row("ai-agents", 10, 500.0, "crewai", "crewai", 5000),
+            _make_cluster_stats_row("rag-retrieval", 5, 200.0, "llamaindex", "run-llama", 3000),
+        ]
+        inter_rows = [
+            _make_inter_cluster_row("ai-agents", "rag-retrieval", 12),
+        ]
+        _, db_override = _override_db_multi([stats_rows, inter_rows])
+        app.dependency_overrides[get_db] = db_override
+
+        try:
+            with patch("app.routers.graph.cache") as mock_cache:
+                mock_cache.get = AsyncMock(return_value=None)
+                mock_cache.set = AsyncMock()
+
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.get("/graph/clusters")
+
+                assert resp.status_code == 200
+                body = resp.json()
+                assert body["total_clusters"] == 2
+
+                # Find the ai-agents cluster
+                ai = next(c for c in body["clusters"] if c["category"] == "ai-agents")
+                assert ai["repo_count"] == 10
+                assert ai["avg_stars"] == 500.0
+                assert len(ai["top_repos"]) == 2
+                assert ai["top_repos"][0]["name"] == "autogen"
+
+                # Inter-cluster edges
+                assert ai["inter_cluster_edges"]["rag-retrieval"] == 12
+
+                # Cache set with 1hr TTL
+                mock_cache.set.assert_called_once()
+                call_args = mock_cache.set.call_args
+                assert call_args[1].get("ttl") == 3600 or call_args[0][2] == 3600
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    @pytest.mark.asyncio
+    async def test_clusters_cache_hit(self):
+        """Cached clusters should be returned without DB query."""
+        cached = {"total_clusters": 3, "clusters": []}
+        mock_db = AsyncMock()
+
+        async def _override():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = _override
+
+        try:
+            with patch("app.routers.graph.cache") as mock_cache:
+                mock_cache.get = AsyncMock(return_value=cached)
+
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.get("/graph/clusters")
+
+                assert resp.status_code == 200
+                assert resp.json()["total_clusters"] == 3
+                mock_db.execute.assert_not_called()
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    @pytest.mark.asyncio
+    async def test_clusters_empty(self):
+        """No categories should return empty cluster list."""
+        _, db_override = _override_db_multi([[], []])
+        app.dependency_overrides[get_db] = db_override
+
+        try:
+            with patch("app.routers.graph.cache") as mock_cache:
+                mock_cache.get = AsyncMock(return_value=None)
+                mock_cache.set = AsyncMock()
+
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.get("/graph/clusters")
+
+                assert resp.status_code == 200
+                body = resp.json()
+                assert body["total_clusters"] == 0
+                assert body["clusters"] == []
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    @pytest.mark.asyncio
+    async def test_clusters_bidirectional_inter_edges(self):
+        """Inter-cluster edges should be tracked bidirectionally."""
+        stats_rows = [
+            _make_cluster_stats_row("cat-a", 5, 100.0),
+            _make_cluster_stats_row("cat-b", 3, 50.0),
+        ]
+        inter_rows = [
+            _make_inter_cluster_row("cat-a", "cat-b", 7),
+        ]
+        _, db_override = _override_db_multi([stats_rows, inter_rows])
+        app.dependency_overrides[get_db] = db_override
+
+        try:
+            with patch("app.routers.graph.cache") as mock_cache:
+                mock_cache.get = AsyncMock(return_value=None)
+                mock_cache.set = AsyncMock()
+
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.get("/graph/clusters")
+
+                body = resp.json()
+                cat_a = next(c for c in body["clusters"] if c["category"] == "cat-a")
+                cat_b = next(c for c in body["clusters"] if c["category"] == "cat-b")
+
+                # Both sides should see the inter-cluster connection
+                assert cat_a["inter_cluster_edges"]["cat-b"] == 7
+                assert cat_b["inter_cluster_edges"]["cat-a"] == 7
+        finally:
+            app.dependency_overrides.pop(get_db, None)


### PR DESCRIPTION
## Summary
- **Enhanced GET /graph/edges**: Added `nodes` array with `primary_category` (color-coding), `stars_log` (log-scaled for node sizing), and `quality` (from quality_signals for opacity). Added optional `?since=7d|24h|30m` temporal filter for "what's new" views.
- **New GET /graph/subgraph/{repo_name}**: 2-hop neighborhood exploration of a specific repo via embedding similarity. Returns nodes + edges for the local subgraph. Redis cached (30min TTL). 404 if repo not found.
- **New GET /graph/clusters**: Repos grouped by primary_category with repo count, avg stars, top 5 repos by stars, and inter-cluster edge counts showing category connectivity. Redis cached (1hr TTL).

## Test plan
- [x] 24 new tests in `tests/test_graph_viz.py` -- all passing
- [x] Unit tests for helper functions (`_parse_since`, `_log_scale_stars`, `_extract_quality`)
- [x] Integration tests for nodes array in /graph/edges response
- [x] Temporal filter cache key differentiation
- [x] Subgraph: happy path, 404 for missing repo, cache hit, seed node inclusion
- [x] Clusters: category grouping, bidirectional inter-cluster edges, cache hit, empty state
- [x] Existing test_graph_optimization.py tests unaffected (pre-existing `redis_cache` mock failures are not regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)