### PR TITLE
feat: HackerNews mentions infrastructure (free HN Algolia API)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -17,7 +17,7 @@ from app.cache import cache
 from app.rate_limit import rate_limit_storage
 from app.slo_observer import slo_observer
 from app.database import async_session_factory, check_db_connection, engine
-from app.routers import admin, analytics, graph, ingest, intelligence, library, library_full, nl_filter, platform, recommendations, repos, search, taxonomy, trends, webhooks, wiki
+from app.routers import admin, analytics, graph, ingest, intelligence, library, library_full, mentions, nl_filter, platform, recommendations, repos, search, taxonomy, trends, webhooks, wiki
 from app.telemetry import init_telemetry
 
 
@@ -277,6 +277,7 @@ app.include_router(nl_filter.router)
 app.include_router(recommendations.router)
 app.include_router(library_full.router)
 app.include_router(taxonomy.router, prefix="/taxonomy")
+app.include_router(mentions.router)
 app.include_router(admin.router)
 app.include_router(webhooks.router)
 

--- a/app/models/mention.py
+++ b/app/models/mention.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import Integer, String, Text, TIMESTAMP, UniqueConstraint, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class RepoMention(Base):
+    __tablename__ = "repo_mentions"
+
+    id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, default=uuid4)
+    repo_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("repos.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    source: Mapped[str] = mapped_column(String, nullable=False)  # "hackernews", "reddit", "youtube"
+    external_id: Mapped[str] = mapped_column(String, nullable=False)  # HN story ID
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    url: Mapped[str | None] = mapped_column(Text, nullable=True)  # link to the discussion
+    score: Mapped[int | None] = mapped_column(Integer, nullable=True)  # HN points
+    comment_count: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    author: Mapped[str | None] = mapped_column(String, nullable=True)
+    published_at: Mapped[datetime | None] = mapped_column(TIMESTAMP(timezone=True), nullable=True)
+    fetched_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint("repo_id", "source", "external_id", name="uq_repo_mentions_repo_source_ext"),
+    )

--- a/app/routers/mentions.py
+++ b/app/routers/mentions.py
@@ -1,0 +1,55 @@
+import logging
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.models.mention import RepoMention
+from app.models.repo import Repo
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Mentions"])
+
+
+@router.get("/repos/{repo_id}/mentions", response_model=list[dict])
+async def get_repo_mentions(
+    repo_id: UUID,
+    source: str | None = Query(default=None, description="Filter by source (hackernews, reddit, youtube)"),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return all social mentions for a repo, ordered by score descending."""
+
+    # Verify repo exists
+    repo = await db.get(Repo, repo_id)
+    if repo is None:
+        raise HTTPException(status_code=404, detail="Repo not found")
+
+    stmt = (
+        select(RepoMention)
+        .where(RepoMention.repo_id == repo_id)
+        .order_by(RepoMention.score.desc().nullslast())
+    )
+    if source:
+        stmt = stmt.where(RepoMention.source == source)
+
+    result = await db.execute(stmt)
+    mentions = result.scalars().all()
+
+    return [
+        {
+            "id": str(m.id),
+            "source": m.source,
+            "external_id": m.external_id,
+            "title": m.title,
+            "url": m.url,
+            "score": m.score,
+            "comment_count": m.comment_count,
+            "author": m.author,
+            "published_at": m.published_at.isoformat() if m.published_at else None,
+            "fetched_at": m.fetched_at.isoformat() if m.fetched_at else None,
+        }
+        for m in mentions
+    ]

--- a/migrations/versions/027_create_repo_mentions.py
+++ b/migrations/versions/027_create_repo_mentions.py
@@ -1,0 +1,53 @@
+"""Create repo_mentions table for tracking HN / social mentions.
+
+Revision ID: 027
+Revises: 026
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "027"
+down_revision = "026"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "repo_mentions",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "repo_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("repos.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("source", sa.String, nullable=False),
+        sa.Column("external_id", sa.String, nullable=False),
+        sa.Column("title", sa.Text, nullable=False),
+        sa.Column("url", sa.Text, nullable=True),
+        sa.Column("score", sa.Integer, nullable=True),
+        sa.Column("comment_count", sa.Integer, nullable=True),
+        sa.Column("author", sa.String, nullable=True),
+        sa.Column("published_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.Column(
+            "fetched_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    op.create_index("idx_repo_mentions_repo_id", "repo_mentions", ["repo_id"])
+    op.create_unique_constraint(
+        "uq_repo_mentions_repo_source_ext",
+        "repo_mentions",
+        ["repo_id", "source", "external_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_repo_mentions_repo_source_ext", "repo_mentions", type_="unique")
+    op.drop_index("idx_repo_mentions_repo_id", table_name="repo_mentions")
+    op.drop_table("repo_mentions")

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -1,0 +1,279 @@
+"""Tests for HackerNews mentions backfill and retrieval endpoints."""
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+from tests.conftest import AUTH_HEADERS, TEST_API_KEY
+
+# ---------------------------------------------------------------------------
+# Helper fixtures
+# ---------------------------------------------------------------------------
+
+FAKE_HN_HITS = {
+    "hits": [
+        {
+            "objectID": "12345",
+            "title": "Show HN: Cool AI Repo",
+            "points": 150,
+            "num_comments": 42,
+            "author": "pg",
+            "created_at_i": 1700000000,
+        },
+        {
+            "objectID": "67890",
+            "title": "Another mention of test-repo",
+            "points": 30,
+            "num_comments": 5,
+            "author": "dang",
+            "created_at_i": 1700100000,
+        },
+    ]
+}
+
+EMPTY_HN_HITS = {"hits": []}
+
+
+def _mock_hn_response(json_data):
+    """Create a mock httpx response."""
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.raise_for_status = MagicMock()
+    resp.json.return_value = json_data
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# POST /admin/backfill-hn-mentions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backfill_hn_mentions_requires_api_key(client: AsyncClient):
+    response = await client.post("/admin/backfill-hn-mentions")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_backfill_hn_mentions_dry_run(client: AsyncClient):
+    """Dry run should report mentions_found but insert nothing."""
+
+    # Seed a repo first
+    repo_payload = {
+        "name": "hn-test-repo",
+        "owner": "testuser",
+        "description": "A repo for HN tests",
+        "is_fork": False,
+        "primary_language": "Python",
+        "github_url": "https://github.com/testuser/hn-test-repo",
+        "tags": [],
+        "categories": [],
+        "builders": [],
+        "ai_dev_skills": [],
+        "pm_skills": [],
+        "languages": [],
+        "commits": [],
+    }
+    ingest_resp = await client.post(
+        "/ingest/repos",
+        json=[repo_payload],
+        headers=AUTH_HEADERS,
+    )
+    assert ingest_resp.status_code in (200, 201)
+
+    # Mock httpx to return fake HN data
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=_mock_hn_response(FAKE_HN_HITS))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.routers.admin.httpx.AsyncClient", return_value=mock_client):
+        response = await client.post(
+            "/admin/backfill-hn-mentions?dry_run=true",
+            headers={"Authorization": f"Bearer {TEST_API_KEY}"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["dry_run"] is True
+    assert data["mentions_found"] > 0
+    assert data["mentions_inserted"] == 0
+
+
+@pytest.mark.asyncio
+async def test_backfill_hn_mentions_inserts(client: AsyncClient):
+    """Actual run should insert mentions and report counts."""
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=_mock_hn_response(FAKE_HN_HITS))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.routers.admin.httpx.AsyncClient", return_value=mock_client):
+        response = await client.post(
+            "/admin/backfill-hn-mentions?dry_run=false",
+            headers={"Authorization": f"Bearer {TEST_API_KEY}"},
+        )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["dry_run"] is False
+    assert data["mentions_inserted"] >= 0  # may be 0 if re-run (idempotent)
+    assert "total_repos" in data
+    assert "failed" in data
+
+
+@pytest.mark.asyncio
+async def test_backfill_hn_idempotent(client: AsyncClient):
+    """Running backfill twice should not create duplicates."""
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=_mock_hn_response(FAKE_HN_HITS))
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("app.routers.admin.httpx.AsyncClient", return_value=mock_client):
+        r1 = await client.post(
+            "/admin/backfill-hn-mentions",
+            headers={"Authorization": f"Bearer {TEST_API_KEY}"},
+        )
+        r2 = await client.post(
+            "/admin/backfill-hn-mentions",
+            headers={"Authorization": f"Bearer {TEST_API_KEY}"},
+        )
+
+    assert r1.status_code == 200
+    assert r2.status_code == 200
+    # Second run should insert 0 new mentions (all duplicates)
+    assert r2.json()["mentions_inserted"] == 0
+
+
+# ---------------------------------------------------------------------------
+# GET /repos/{repo_id}/mentions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_mentions_nonexistent_repo(client: AsyncClient):
+    fake_id = str(uuid.uuid4())
+    response = await client.get(f"/repos/{fake_id}/mentions")
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_mentions_empty(client: AsyncClient):
+    """A repo with no mentions should return an empty list."""
+    repo_payload = {
+        "name": "no-mentions-repo",
+        "owner": "testuser",
+        "description": "No mentions here",
+        "is_fork": False,
+        "primary_language": "Go",
+        "github_url": "https://github.com/testuser/no-mentions-repo",
+        "tags": [],
+        "categories": [],
+        "builders": [],
+        "ai_dev_skills": [],
+        "pm_skills": [],
+        "languages": [],
+        "commits": [],
+    }
+    ingest_resp = await client.post(
+        "/ingest/repos", json=[repo_payload], headers=AUTH_HEADERS
+    )
+    assert ingest_resp.status_code in (200, 201)
+
+    repos_resp = await client.get("/repos?q=no-mentions-repo", headers=AUTH_HEADERS)
+    assert repos_resp.status_code == 200
+    repos_data = repos_resp.json()
+    repo_id = repos_data["repos"][0]["id"]
+
+    response = await client.get(f"/repos/{repo_id}/mentions")
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_get_mentions_returns_data(client: AsyncClient):
+    """After backfill, mentions endpoint should return results."""
+    repos_resp = await client.get("/repos?q=hn-test-repo", headers=AUTH_HEADERS)
+    if repos_resp.status_code != 200 or not repos_resp.json().get("repos"):
+        pytest.skip("hn-test-repo not found -- depends on prior backfill test")
+
+    repo_id = repos_resp.json()["repos"][0]["id"]
+    response = await client.get(f"/repos/{repo_id}/mentions")
+    assert response.status_code == 200
+    mentions = response.json()
+
+    if len(mentions) > 0:
+        m = mentions[0]
+        assert "id" in m
+        assert "source" in m
+        assert "title" in m
+        assert "score" in m
+        assert "url" in m
+
+
+@pytest.mark.asyncio
+async def test_get_mentions_source_filter(client: AsyncClient):
+    """Filter by source should only return matching mentions."""
+    repos_resp = await client.get("/repos?q=hn-test-repo", headers=AUTH_HEADERS)
+    if repos_resp.status_code != 200 or not repos_resp.json().get("repos"):
+        pytest.skip("hn-test-repo not found")
+
+    repo_id = repos_resp.json()["repos"][0]["id"]
+
+    # Filter for a source that does not exist
+    response = await client.get(f"/repos/{repo_id}/mentions?source=reddit")
+    assert response.status_code == 200
+    assert response.json() == []
+
+    # Filter for hackernews (should return results if backfill ran)
+    response = await client.get(f"/repos/{repo_id}/mentions?source=hackernews")
+    assert response.status_code == 200
+    for m in response.json():
+        assert m["source"] == "hackernews"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for helper functions
+# ---------------------------------------------------------------------------
+
+
+def test_hn_hit_to_mention():
+    from app.routers.admin import _hn_hit_to_mention
+
+    hit = {
+        "objectID": "99999",
+        "title": "Test Title",
+        "points": 100,
+        "num_comments": 20,
+        "author": "testauthor",
+        "created_at_i": 1700000000,
+    }
+    repo_id = uuid.uuid4()
+    result = _hn_hit_to_mention(hit, repo_id)
+
+    assert result["repo_id"] == repo_id
+    assert result["source"] == "hackernews"
+    assert result["external_id"] == "99999"
+    assert result["title"] == "Test Title"
+    assert result["score"] == 100
+    assert result["comment_count"] == 20
+    assert result["author"] == "testauthor"
+    assert result["url"] == "https://news.ycombinator.com/item?id=99999"
+    assert result["published_at"] is not None
+
+
+def test_hn_hit_to_mention_missing_fields():
+    from app.routers.admin import _hn_hit_to_mention
+
+    hit = {"objectID": "111", "title": None}
+    repo_id = uuid.uuid4()
+    result = _hn_hit_to_mention(hit, repo_id)
+
+    assert result["title"] == "(no title)"
+    assert result["score"] is None
+    assert result["published_at"] is None


### PR DESCRIPTION
## Summary
- New `repo_mentions` table (migration 027) for tracking community mentions across sources
- `POST /admin/backfill-hn-mentions` — fetches HN stories for all repos via free Algolia API
- `GET /repos/{repo_id}/mentions` — returns mentions ordered by score, filterable by source
- Semaphore(5) rate limiting, `ON CONFLICT DO NOTHING` deduplication

Replaces PR #274 (had merge conflicts).

## Test plan
- [x] 9 tests covering auth, dry_run, insertion, idempotency, source filtering
- [ ] Manual backfill run on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)