### PR TITLE
feat: dependency graph infrastructure via GitHub SBOM API

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -17,7 +17,7 @@ from app.cache import cache
 from app.rate_limit import rate_limit_storage
 from app.slo_observer import slo_observer
 from app.database import async_session_factory, check_db_connection, engine
-from app.routers import admin, analytics, graph, ingest, intelligence, library, library_full, mentions, nl_filter, platform, recommendations, repos, search, taxonomy, trends, webhooks, wiki
+from app.routers import admin, analytics, dependencies, graph, ingest, intelligence, library, library_full, mentions, nl_filter, platform, recommendations, repos, search, taxonomy, trends, webhooks, wiki
 from app.telemetry import init_telemetry
 
 
@@ -278,6 +278,7 @@ app.include_router(recommendations.router)
 app.include_router(library_full.router)
 app.include_router(taxonomy.router, prefix="/taxonomy")
 app.include_router(mentions.router)
+app.include_router(dependencies.router)
 app.include_router(admin.router)
 app.include_router(webhooks.router)
 

--- a/app/models/dependency.py
+++ b/app/models/dependency.py
@@ -1,0 +1,29 @@
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import Boolean, ForeignKey, String, Text, TIMESTAMP, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.sql import func
+
+from app.database import Base
+
+
+class RepoDependency(Base):
+    __tablename__ = "repo_dependencies"
+
+    id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True, default=uuid4)
+    repo_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), ForeignKey("repos.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    package_name: Mapped[str] = mapped_column(Text, nullable=False)
+    package_ecosystem: Mapped[str | None] = mapped_column(String, nullable=True)
+    version_constraint: Mapped[str | None] = mapped_column(String, nullable=True)
+    is_direct: Mapped[bool] = mapped_column(Boolean, default=True, server_default="true")
+    fetched_at: Mapped[datetime] = mapped_column(
+        TIMESTAMP(timezone=True), nullable=False, server_default=func.now()
+    )
+
+    __table_args__ = (
+        UniqueConstraint("repo_id", "package_name", "package_ecosystem", name="uq_repo_dep_repo_pkg_eco"),
+    )

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -1633,3 +1633,197 @@ async def backfill_community_signals(
         await db.commit()
 
     return {"total": total, "updated": updated, "failed": failed, "skipped": skipped, "dry_run": False}
+
+
+# ── SBOM dependency backfill ─────────────────────────────────────────────────
+
+def parse_purl(purl: str) -> tuple[str | None, str | None, str | None]:
+    """Parse a Package URL into (ecosystem, name, version).
+
+    purl format: ``pkg:<ecosystem>/<namespace>/<name>@<version>``
+    or ``pkg:<ecosystem>/<name>@<version>``
+
+    Returns (ecosystem, name, version_constraint) -- any part may be None
+    if the purl cannot be parsed.
+    """
+    if not purl or not purl.startswith("pkg:"):
+        return None, None, None
+
+    body = purl[4:]  # strip "pkg:"
+    version: str | None = None
+    if "@" in body:
+        body, version = body.rsplit("@", 1)
+
+    parts = body.split("/", 2)
+    if len(parts) < 2:
+        return None, None, None
+
+    ecosystem = parts[0]
+    # If there's a namespace (e.g. @scope/name in npm), keep only the final name
+    name = parts[-1]
+    return ecosystem, name, version
+
+
+def _extract_deps_from_sbom(sbom: dict) -> list[dict]:
+    """Extract dependency info from an SPDX SBOM response.
+
+    Returns a list of dicts with keys: package_name, package_ecosystem,
+    version_constraint, is_direct.
+    """
+    deps: list[dict] = []
+    packages = sbom.get("sbom", {}).get("packages", [])
+
+    for pkg in packages:
+        # Skip the root package (SPDX document itself)
+        spdx_id = pkg.get("SPDXID", "")
+        if spdx_id == "SPDXRef-DOCUMENT":
+            continue
+
+        # Try to extract from purl in externalRefs
+        purl_ref = None
+        for ref in pkg.get("externalRefs", []):
+            if ref.get("referenceType") == "purl":
+                purl_ref = ref.get("referenceLocator")
+                break
+
+        if purl_ref:
+            ecosystem, name, version = parse_purl(purl_ref)
+            if name:
+                deps.append({
+                    "package_name": name,
+                    "package_ecosystem": ecosystem,
+                    "version_constraint": version,
+                    "is_direct": True,
+                })
+        else:
+            # Fallback: use package name field
+            pkg_name = pkg.get("name")
+            if pkg_name:
+                version_info = pkg.get("versionInfo")
+                deps.append({
+                    "package_name": pkg_name,
+                    "package_ecosystem": None,
+                    "version_constraint": version_info,
+                    "is_direct": True,
+                })
+
+    return deps
+
+
+@router.post("/admin/backfill-dependencies", response_model=dict)
+@_limiter.limit("5/minute")
+async def backfill_dependencies(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+    _api_key: str = Depends(verify_api_key),
+    _admin_key: None = Depends(require_admin_key),
+):
+    """Fetch SBOM dependency data from GitHub for repos with no dependencies stored.
+
+    Uses the free GitHub SBOM API (dependency-graph/sbom) to extract packages
+    from SPDX format. Parses purl references to extract ecosystem and version.
+    """
+    github_token = os.environ.get("GITHUB_TOKEN", "")
+    if not github_token:
+        raise HTTPException(status_code=500, detail="GITHUB_TOKEN env var not set")
+
+    # Find repos with no entries in repo_dependencies
+    result = await db.execute(text("""
+        SELECT r.id, r.owner, r.name
+        FROM repos r
+        LEFT JOIN repo_dependencies d ON d.repo_id = r.id
+        WHERE d.id IS NULL
+        ORDER BY r.updated_at DESC
+    """))
+    rows = result.fetchall()
+
+    if not rows:
+        return {
+            "total_repos": 0,
+            "repos_with_deps": 0,
+            "dependencies_inserted": 0,
+            "failed": 0,
+            "skipped": 0,
+        }
+
+    total_repos = len(rows)
+    repos_with_deps = 0
+    dependencies_inserted = 0
+    failed = 0
+    skipped = 0
+
+    sem = asyncio.Semaphore(10)
+    headers = {
+        "Authorization": f"Bearer {github_token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    async def fetch_sbom(client: httpx.AsyncClient, owner: str, name: str) -> dict | None:
+        async with sem:
+            url = f"https://api.github.com/repos/{owner}/{name}/dependency-graph/sbom"
+            try:
+                resp = await client.get(url, headers=headers, timeout=30.0)
+                if resp.status_code == 404:
+                    return None
+                if resp.status_code == 403:
+                    logger.warning("GitHub SBOM 403 for %s/%s -- rate limited or no access", owner, name)
+                    return None
+                resp.raise_for_status()
+                return resp.json()
+            except httpx.HTTPStatusError as exc:
+                logger.warning("SBOM fetch error for %s/%s: %s", owner, name, exc)
+                return None
+            except Exception as exc:
+                logger.warning("SBOM fetch exception for %s/%s: %s", owner, name, exc)
+                return None
+
+    async with httpx.AsyncClient() as client:
+        for row in rows:
+            sbom = await fetch_sbom(client, row.owner, row.name)
+            if sbom is None:
+                skipped += 1
+                continue
+
+            deps = _extract_deps_from_sbom(sbom)
+            if not deps:
+                skipped += 1
+                continue
+
+            repo_inserted = 0
+            for dep in deps:
+                try:
+                    await db.execute(text("""
+                        INSERT INTO repo_dependencies (id, repo_id, package_name, package_ecosystem, version_constraint, is_direct)
+                        VALUES (gen_random_uuid(), :repo_id, :package_name, :package_ecosystem, :version_constraint, :is_direct)
+                        ON CONFLICT ON CONSTRAINT uq_repo_dep_repo_pkg_eco DO NOTHING
+                    """), {
+                        "repo_id": str(row.id),
+                        "package_name": dep["package_name"],
+                        "package_ecosystem": dep["package_ecosystem"],
+                        "version_constraint": dep["version_constraint"],
+                        "is_direct": dep["is_direct"],
+                    })
+                    repo_inserted += 1
+                except Exception as exc:
+                    logger.warning("Dep insert failed for %s/%s pkg=%s: %s", row.owner, row.name, dep["package_name"], exc)
+                    failed += 1
+
+            if repo_inserted > 0:
+                repos_with_deps += 1
+                dependencies_inserted += repo_inserted
+
+            # Commit per repo to avoid holding large transactions
+            try:
+                await db.commit()
+            except Exception as exc:
+                logger.warning("Commit failed after %s/%s: %s", row.owner, row.name, exc)
+                failed += 1
+
+    return {
+        "total_repos": total_repos,
+        "repos_with_deps": repos_with_deps,
+        "dependencies_inserted": dependencies_inserted,
+        "failed": failed,
+        "skipped": skipped,
+    }

--- a/app/routers/dependencies.py
+++ b/app/routers/dependencies.py
@@ -1,0 +1,103 @@
+"""Dependency graph endpoints -- reads from repo_dependencies (populated by SBOM backfill)."""
+
+import logging
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.database import get_db
+from app.models.dependency import RepoDependency
+from app.models.repo import Repo
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Dependencies"])
+
+
+@router.get("/repos/{repo_id}/dependencies", response_model=list[dict])
+async def get_repo_dependencies(
+    repo_id: UUID,
+    ecosystem: str | None = Query(default=None, description="Filter by ecosystem (pypi, npm, etc.)"),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return all dependencies for a repo, ordered by package_name."""
+
+    # Verify repo exists
+    repo = await db.get(Repo, repo_id)
+    if repo is None:
+        raise HTTPException(status_code=404, detail="Repo not found")
+
+    stmt = (
+        select(RepoDependency)
+        .where(RepoDependency.repo_id == repo_id)
+        .order_by(RepoDependency.package_name)
+    )
+    if ecosystem:
+        stmt = stmt.where(RepoDependency.package_ecosystem == ecosystem)
+
+    result = await db.execute(stmt)
+    deps = result.scalars().all()
+
+    return [
+        {
+            "id": str(d.id),
+            "package_name": d.package_name,
+            "package_ecosystem": d.package_ecosystem,
+            "version_constraint": d.version_constraint,
+            "is_direct": d.is_direct,
+            "fetched_at": d.fetched_at.isoformat() if d.fetched_at else None,
+        }
+        for d in deps
+    ]
+
+
+@router.get("/dependencies/dependents", response_model=list[dict])
+async def get_dependents(
+    package: str = Query(..., description="Package name to search for (e.g. 'pytorch', 'langchain')"),
+    ecosystem: str | None = Query(default=None, description="Filter by ecosystem"),
+    db: AsyncSession = Depends(get_db),
+):
+    """Return all repos that depend on a given package.
+
+    Enables queries like 'show me all repos using PyTorch'.
+    """
+
+    stmt = (
+        select(
+            Repo.id,
+            Repo.name,
+            Repo.owner,
+            Repo.description,
+            Repo.github_url,
+            Repo.primary_language,
+            RepoDependency.package_ecosystem,
+            RepoDependency.version_constraint,
+            RepoDependency.is_direct,
+        )
+        .join(RepoDependency, RepoDependency.repo_id == Repo.id)
+        .where(func.lower(RepoDependency.package_name) == package.lower())
+    )
+    if ecosystem:
+        stmt = stmt.where(RepoDependency.package_ecosystem == ecosystem)
+
+    stmt = stmt.order_by(Repo.name)
+
+    result = await db.execute(stmt)
+    rows = result.fetchall()
+
+    return [
+        {
+            "repo_id": str(r.id),
+            "name": r.name,
+            "owner": r.owner,
+            "description": r.description,
+            "github_url": r.github_url,
+            "primary_language": r.primary_language,
+            "package_ecosystem": r.package_ecosystem,
+            "version_constraint": r.version_constraint,
+            "is_direct": r.is_direct,
+        }
+        for r in rows
+    ]

--- a/migrations/versions/028_create_repo_dependencies.py
+++ b/migrations/versions/028_create_repo_dependencies.py
@@ -1,0 +1,51 @@
+"""Create repo_dependencies table for SBOM-based dependency tracking.
+
+Revision ID: 028
+Revises: 027
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "028"
+down_revision = "027"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "repo_dependencies",
+        sa.Column("id", sa.dialects.postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "repo_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("repos.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("package_name", sa.Text, nullable=False),
+        sa.Column("package_ecosystem", sa.String, nullable=True),
+        sa.Column("version_constraint", sa.String, nullable=True),
+        sa.Column("is_direct", sa.Boolean, nullable=False, server_default="true"),
+        sa.Column(
+            "fetched_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+
+    op.create_index("idx_repo_dependencies_repo_id", "repo_dependencies", ["repo_id"])
+    op.create_index("idx_repo_dependencies_package_name", "repo_dependencies", ["package_name"])
+    op.create_unique_constraint(
+        "uq_repo_dep_repo_pkg_eco",
+        "repo_dependencies",
+        ["repo_id", "package_name", "package_ecosystem"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("uq_repo_dep_repo_pkg_eco", "repo_dependencies", type_="unique")
+    op.drop_index("idx_repo_dependencies_package_name", table_name="repo_dependencies")
+    op.drop_index("idx_repo_dependencies_repo_id", table_name="repo_dependencies")
+    op.drop_table("repo_dependencies")

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -1,0 +1,253 @@
+"""Tests for dependency graph infrastructure: purl parsing, SBOM extraction,
+backfill auth, and dependents lookup."""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+from app.routers.admin import parse_purl, _extract_deps_from_sbom
+from tests.conftest import TEST_API_KEY
+
+
+# ── purl parsing ─────────────────────────────────────────────────────────────
+
+class TestParsePurl:
+    def test_simple_pypi(self):
+        eco, name, ver = parse_purl("pkg:pypi/langchain@0.1.0")
+        assert eco == "pypi"
+        assert name == "langchain"
+        assert ver == "0.1.0"
+
+    def test_npm_scoped(self):
+        eco, name, ver = parse_purl("pkg:npm/%40openai/api@4.0.0")
+        assert eco == "npm"
+        assert name == "api"
+        assert ver == "4.0.0"
+
+    def test_no_version(self):
+        eco, name, ver = parse_purl("pkg:pypi/requests")
+        assert eco == "pypi"
+        assert name == "requests"
+        assert ver is None
+
+    def test_with_namespace(self):
+        eco, name, ver = parse_purl("pkg:maven/org.apache.commons/commons-lang3@3.12.0")
+        assert eco == "maven"
+        assert name == "commons-lang3"
+        assert ver == "3.12.0"
+
+    def test_empty_string(self):
+        eco, name, ver = parse_purl("")
+        assert eco is None
+        assert name is None
+        assert ver is None
+
+    def test_none(self):
+        eco, name, ver = parse_purl(None)
+        assert eco is None
+        assert name is None
+        assert ver is None
+
+    def test_invalid_prefix(self):
+        eco, name, ver = parse_purl("notpkg:pypi/foo@1.0")
+        assert eco is None
+        assert name is None
+
+    def test_no_slash(self):
+        eco, name, ver = parse_purl("pkg:pypi")
+        assert eco is None
+        assert name is None
+
+    def test_cargo(self):
+        eco, name, ver = parse_purl("pkg:cargo/serde@1.0.193")
+        assert eco == "cargo"
+        assert name == "serde"
+        assert ver == "1.0.193"
+
+    def test_golang(self):
+        # golang purls have deeper namespace paths; split(/, 2) keeps the tail
+        eco, name, ver = parse_purl("pkg:golang/github.com/gin-gonic/gin@1.9.1")
+        assert eco == "golang"
+        assert name == "gin-gonic/gin"
+        assert ver == "1.9.1"
+
+    def test_version_with_build_metadata(self):
+        eco, name, ver = parse_purl("pkg:pypi/torch@2.1.0+cu121")
+        assert eco == "pypi"
+        assert name == "torch"
+        assert ver == "2.1.0+cu121"
+
+
+# ── SBOM extraction ──────────────────────────────────────────────────────────
+
+class TestExtractDepsFromSbom:
+    def test_basic_sbom(self):
+        sbom = {
+            "sbom": {
+                "packages": [
+                    {
+                        "SPDXID": "SPDXRef-DOCUMENT",
+                        "name": "root-project",
+                    },
+                    {
+                        "SPDXID": "SPDXRef-pip-langchain",
+                        "name": "langchain",
+                        "externalRefs": [
+                            {
+                                "referenceType": "purl",
+                                "referenceLocator": "pkg:pypi/langchain@0.1.0",
+                            }
+                        ],
+                    },
+                    {
+                        "SPDXID": "SPDXRef-pip-requests",
+                        "name": "requests",
+                        "externalRefs": [
+                            {
+                                "referenceType": "purl",
+                                "referenceLocator": "pkg:pypi/requests@2.31.0",
+                            }
+                        ],
+                    },
+                ]
+            }
+        }
+        deps = _extract_deps_from_sbom(sbom)
+        assert len(deps) == 2
+        assert deps[0]["package_name"] == "langchain"
+        assert deps[0]["package_ecosystem"] == "pypi"
+        assert deps[0]["version_constraint"] == "0.1.0"
+        assert deps[1]["package_name"] == "requests"
+
+    def test_skips_document_root(self):
+        sbom = {
+            "sbom": {
+                "packages": [
+                    {"SPDXID": "SPDXRef-DOCUMENT", "name": "my-project"},
+                ]
+            }
+        }
+        deps = _extract_deps_from_sbom(sbom)
+        assert len(deps) == 0
+
+    def test_fallback_to_name_field(self):
+        sbom = {
+            "sbom": {
+                "packages": [
+                    {
+                        "SPDXID": "SPDXRef-unknown",
+                        "name": "some-lib",
+                        "versionInfo": "1.2.3",
+                    },
+                ]
+            }
+        }
+        deps = _extract_deps_from_sbom(sbom)
+        assert len(deps) == 1
+        assert deps[0]["package_name"] == "some-lib"
+        assert deps[0]["package_ecosystem"] is None
+        assert deps[0]["version_constraint"] == "1.2.3"
+
+    def test_empty_sbom(self):
+        deps = _extract_deps_from_sbom({})
+        assert len(deps) == 0
+
+    def test_no_packages_key(self):
+        deps = _extract_deps_from_sbom({"sbom": {}})
+        assert len(deps) == 0
+
+    def test_mixed_purl_and_fallback(self):
+        sbom = {
+            "sbom": {
+                "packages": [
+                    {
+                        "SPDXID": "SPDXRef-1",
+                        "name": "with-purl",
+                        "externalRefs": [
+                            {"referenceType": "purl", "referenceLocator": "pkg:npm/react@18.0.0"}
+                        ],
+                    },
+                    {
+                        "SPDXID": "SPDXRef-2",
+                        "name": "no-purl-lib",
+                        "versionInfo": "0.5",
+                    },
+                ]
+            }
+        }
+        deps = _extract_deps_from_sbom(sbom)
+        assert len(deps) == 2
+        assert deps[0]["package_ecosystem"] == "npm"
+        assert deps[1]["package_ecosystem"] is None
+
+    def test_non_purl_external_refs_ignored(self):
+        sbom = {
+            "sbom": {
+                "packages": [
+                    {
+                        "SPDXID": "SPDXRef-1",
+                        "name": "mylib",
+                        "externalRefs": [
+                            {"referenceType": "cpe23Type", "referenceLocator": "cpe:2.3:*:*:*"}
+                        ],
+                    },
+                ]
+            }
+        }
+        deps = _extract_deps_from_sbom(sbom)
+        assert len(deps) == 1
+        assert deps[0]["package_name"] == "mylib"
+        assert deps[0]["package_ecosystem"] is None
+
+
+# ── Backfill endpoint auth ───────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_backfill_dependencies_requires_api_key(client: AsyncClient):
+    response = await client.post("/admin/backfill-dependencies")
+    assert response.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_backfill_dependencies_requires_admin_key(client: AsyncClient):
+    response = await client.post(
+        "/admin/backfill-dependencies",
+        headers={"Authorization": f"Bearer {TEST_API_KEY}"},
+    )
+    # Without admin key, should be rejected (admin key check uses a separate header)
+    assert response.status_code in (401, 403, 500)
+
+
+# ── GET /repos/{repo_id}/dependencies ────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_get_dependencies_404_for_unknown_repo(client: AsyncClient):
+    fake_id = str(uuid.uuid4())
+    response = await client.get(f"/repos/{fake_id}/dependencies")
+    assert response.status_code == 404
+
+
+# ── GET /dependencies/dependents ─────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_dependents_requires_package_param(client: AsyncClient):
+    response = await client.get("/dependencies/dependents")
+    assert response.status_code == 422  # missing required query param
+
+
+@pytest.mark.asyncio
+async def test_dependents_returns_empty_for_unknown_package(client: AsyncClient):
+    response = await client.get("/dependencies/dependents", params={"package": "nonexistent-pkg-xyz"})
+    assert response.status_code == 200
+    assert response.json() == []
+
+
+@pytest.mark.asyncio
+async def test_dependents_with_ecosystem_filter(client: AsyncClient):
+    response = await client.get(
+        "/dependencies/dependents",
+        params={"package": "nonexistent-pkg-xyz", "ecosystem": "pypi"},
+    )
+    assert response.status_code == 200
+    assert response.json() == []


### PR DESCRIPTION
## Summary
- Add `RepoDependency` model (`app/models/dependency.py`) with UUID PK, repo FK, package_name, package_ecosystem, version_constraint, is_direct, fetched_at, and unique constraint on (repo_id, package_name, package_ecosystem)
- Add Alembic migration `028_create_repo_dependencies.py` with indexes on repo_id and package_name
- Add `POST /admin/backfill-dependencies` endpoint that fetches SBOM data from GitHub's free dependency-graph API, parses SPDX/purl format, and inserts with ON CONFLICT DO NOTHING dedup (httpx.AsyncClient + Semaphore(10) + GITHUB_TOKEN)
- Add `GET /repos/{repo_id}/dependencies` endpoint returning deps ordered by package_name with optional ecosystem filter
- Add `GET /dependencies/dependents?package=pytorch` endpoint for cross-repo lookup ("show me all repos using X")
- Add 24 tests covering purl parsing (pypi, npm scoped, maven, cargo, golang), SBOM extraction (root skip, fallback, mixed refs), auth gates, 404 handling, and dependents query validation

## Test plan
- [x] All 24 tests in `tests/test_dependencies.py` pass locally
- [ ] Run migration on staging DB
- [ ] Call `POST /admin/backfill-dependencies` with GITHUB_TOKEN set
- [ ] Verify `/repos/{id}/dependencies` returns parsed packages
- [ ] Verify `/dependencies/dependents?package=langchain` returns matching repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)