### PR TITLE
fix: load ADMIN_API_KEY from Secret Manager

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -40,6 +40,12 @@ def _resolve_secrets():
         if not os.getenv("INGESTION_API_KEY"):
             logger.info("Loading INGESTION_API_KEY from Secret Manager")
             os.environ["INGESTION_API_KEY"] = _get_secret("reporium-ingestion-api-key", project)
+        if not os.getenv("ADMIN_API_KEY"):
+            try:
+                logger.info("Loading ADMIN_API_KEY from Secret Manager")
+                os.environ["ADMIN_API_KEY"] = _get_secret("reporium-admin-api-key", project).strip()
+            except Exception:
+                logger.warning("ADMIN_API_KEY not found in Secret Manager")
         if not os.getenv("ANTHROPIC_API_KEY"):
             try:
                 logger.info("Loading ANTHROPIC_API_KEY from Secret Manager")


### PR DESCRIPTION
## Summary
- Admin endpoints (backfill, enrichment) returned 500 in production because ADMIN_API_KEY was never loaded from GCP Secret Manager
- Added secret loading in config.py alongside INGESTION_API_KEY and ANTHROPIC_API_KEY
- Secret `reporium-admin-api-key` created in GCP Secret Manager
- GitHub Secret `ADMIN_API_KEY` set for deploy.yml post-deploy steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)