### PR TITLE
ops: increase Cloud Run timeout to 300s for backfills

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,7 +44,7 @@ jobs:
             --min-instances=0
             --max-instances=10
             --concurrency=200
-            --timeout=60
+            --timeout=300
             --clear-vpc-connector
 
       - name: Prune old container images (keep latest 5)


### PR DESCRIPTION
Backfills timeout at 60s processing 1,600+ repos.