### PR TITLE
fix: production config fixes for backfill endpoints

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -52,6 +52,15 @@ def _resolve_secrets():
                 os.environ["ANTHROPIC_API_KEY"] = _get_secret("anthropic-api-key", project).strip()
             except Exception:
                 logger.warning("ANTHROPIC_API_KEY not found in Secret Manager")
+        if not os.getenv("GITHUB_TOKEN") and not os.getenv("GH_TOKEN"):
+            try:
+                logger.info("Loading GITHUB_TOKEN from Secret Manager")
+                os.environ["GITHUB_TOKEN"] = _get_secret("github-token", project).strip()
+            except Exception:
+                logger.warning("GITHUB_TOKEN not found in Secret Manager")
+    # Normalise: if GH_TOKEN is set but GITHUB_TOKEN is not, copy it over
+    if os.getenv("GH_TOKEN") and not os.getenv("GITHUB_TOKEN"):
+        os.environ["GITHUB_TOKEN"] = os.getenv("GH_TOKEN")
     os.environ.setdefault("DATABASE_URL", "postgresql+asyncpg://postgres:postgres@localhost:5432/reporium")
 
 


### PR DESCRIPTION
## Summary
- Load GITHUB_TOKEN from GCP Secret Manager for dependency backfill endpoint
- Increase Cloud Run timeout from 60s to 300s for long-running backfills
- Fix Haiku model ID (20250414 → 20251001) across all routers
- Load ADMIN_API_KEY from Secret Manager in production
- Add GET /taxonomy/values and public GET /runs endpoints
- Update stale test assertions

## Test plan
- [ ] Deploy triggers successfully on merge
- [ ] `POST /admin/backfill-dependencies` no longer fails with "GITHUB_TOKEN env var not set"
- [ ] Admin endpoints authenticate correctly with Secret Manager key

🤖 Generated with [Claude Code](https://claude.com/claude-code)