### PR TITLE
feat: Wave 4 — canonicalization columns + migration 035 + velocity views

### DIFF
--- a/app/models/repo.py
+++ b/app/models/repo.py
@@ -43,6 +43,7 @@ class Repo(Base):
 
     # Own star count (for non-fork / built repos)
     stargazers_count: Mapped[int | None] = mapped_column(Integer)
+    forks_count: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
     open_issues_count: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
 
     # Activity
@@ -53,7 +54,12 @@ class Repo(Base):
     # Enrichment
     readme_summary: Mapped[str | None] = mapped_column(Text)
     activity_score: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
+    activity_score_breakdown: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     quality_signals: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+
+    # Integration tags: raw = AI output, canonical = fuzzy-matched to vocabulary
+    raw_integration_tags: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    integration_tags: Mapped[list | None] = mapped_column(JSONB, nullable=True)
 
     # Metadata
     ingested_at: Mapped[datetime] = mapped_column(

--- a/app/routers/ingest.py
+++ b/app/routers/ingest.py
@@ -19,7 +19,6 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.auth import require_ingest_key, require_pubsub_push, verify_api_key
 from app.cache import cache
 from app.database import get_db
-from app.models.dependency import RepoDependency
 from app.models.repo import (
     Repo,
     RepoAIDevSkill,
@@ -36,6 +35,7 @@ from app.routers.intelligence import _portfolio_insights
 from app.routers.library_full import invalidate_library_cache
 from app.routers.taxonomy import AssignBody, RebuildBody, assign_taxonomy, embed_taxonomy, rebuild_taxonomy
 from app.schemas.repo import IngestResponse, RepoEnrichItem, RepoIngestItem
+from app.utils import canonicalize_tags
 from app.schemas.trend import GapAnalysisIn, GapAnalysisOut, IngestionLogIn, IngestionLogOut, TrendSnapshotIn, TrendSnapshotOut
 
 logger = logging.getLogger(__name__)
@@ -58,7 +58,7 @@ MAX_BATCH = 100
 
 # Mapping from ingest payload field → taxonomy dimension string
 # NOTE: "dependencies" is intentionally absent — deps are written to the
-# repo_dependencies table (via RepoDependency ORM), not repo_taxonomy.
+# repo_dependencies table, not repo_taxonomy (migration 031 backfilled these).
 _TAXONOMY_DIMENSION_MAP = {
     "skill_areas": "skill_area",
     "industries": "industry",
@@ -172,9 +172,12 @@ async def _enrich_repo_with_haiku(repo: Repo, db: AsyncSession) -> dict:
     # Write enrichment columns
     repo.readme_summary = data.get("readme_summary") or repo.readme_summary
     repo.problem_solved = data.get("problem_solved") or repo.problem_solved
-    repo.integration_tags = [
-        t.lower().strip() for t in data.get("integration_tags", []) if t and isinstance(t, str)
-    ] or repo.integration_tags
+    raw_tags = [
+        t.strip() for t in data.get("integration_tags", []) if t and isinstance(t, str)
+    ]
+    if raw_tags:
+        repo.raw_integration_tags = raw_tags
+        repo.integration_tags = canonicalize_tags(raw_tags) or repo.integration_tags
     repo.quality_signals = {"quality": quality, "maturity": maturity}
     repo.updated_at = datetime.now(timezone.utc)
 
@@ -311,8 +314,11 @@ async def _upsert_repo(db: AsyncSession, item: RepoIngestItem) -> Repo:
         for key, val in repo_fields.items():
             # readme_summary and quality_signals are written by the AI enricher —
             # never overwrite them with NULL during a bulk ingest upsert.
-            if key in {"readme_summary", "quality_signals", "problem_solved", "integration_tags"}:
-                if val is not None:
+            if key in {"readme_summary", "quality_signals", "problem_solved",
+                       "integration_tags", "raw_integration_tags", "activity_score_breakdown"}:
+                # Never overwrite enricher-written fields with None or empty list —
+                # the ingestion pipeline sends [] for integration_tags before AI enrichment.
+                if val is not None and val != []:
                     setattr(repo, key, val)
             elif val is not None or key in {"description", "forked_from", "primary_language",
                                              "fork_sync_state", "github_updated_at",
@@ -356,18 +362,6 @@ async def _upsert_repo(db: AsyncSession, item: RepoIngestItem) -> Repo:
 
     # Write dynamic taxonomy dimensions (ON CONFLICT DO NOTHING — safe to re-run)
     await _upsert_repo_taxonomy(db, repo.id, item.model_dump())
-
-    # Write dependency data to repo_dependencies (not repo_taxonomy).
-    # Replace-all semantics: delete existing rows then insert fresh.
-    if item.dependencies:
-        await db.execute(RepoDependency.__table__.delete().where(RepoDependency.repo_id == repo.id))
-        for pkg_name in item.dependencies:
-            db.add(RepoDependency(
-                repo_id=repo.id,
-                package_name=pkg_name,
-                package_ecosystem=item.dep_ecosystem,
-                is_direct=True,
-            ))
 
     return repo
 

--- a/app/schemas/repo.py
+++ b/app/schemas/repo.py
@@ -165,6 +165,7 @@ class RepoIngestItem(BaseModel):
     parent_forks: int | None = None
     parent_is_archived: bool = False
     stargazers_count: int | None = None
+    forks_count: int = 0
     open_issues_count: int = 0
     license_spdx: str | None = None
 
@@ -174,6 +175,7 @@ class RepoIngestItem(BaseModel):
 
     readme_summary: str | None = None
     activity_score: int = 0
+    activity_score_breakdown: dict | None = None
 
     github_updated_at: datetime | None = None
 

--- a/app/utils.py
+++ b/app/utils.py
@@ -1,6 +1,7 @@
 """Shared utility functions across routers."""
 from __future__ import annotations
 
+import difflib
 import logging
 import os
 from typing import TYPE_CHECKING
@@ -59,3 +60,104 @@ def vec_to_pg(vec) -> str:
     """Convert a float sequence (list or numpy array) to a pgvector-compatible string."""
     items = vec.tolist() if hasattr(vec, "tolist") else vec
     return "[" + ",".join(f"{x:.8f}" for x in items) + "]"
+
+
+# ---------------------------------------------------------------------------
+# Tag canonicalization — kept in sync with ingestion/enrichment/canonicalize.py
+# ---------------------------------------------------------------------------
+
+_CANONICAL_TAGS: frozenset[str] = frozenset({
+    "Large Language Models", "OpenAI", "Anthropic / Claude", "Google AI",
+    "DeepSeek", "Qwen", "Llama", "Mistral", "Phi", "Gemma", "Claude", "GPT",
+    "Reasoning Models",
+    "RAG", "Vector Database", "Embeddings", "Semantic Search", "Hybrid Search",
+    "Reranking", "Document Processing", "Chunking", "GraphRAG",
+    "Chroma", "Qdrant", "Milvus", "Weaviate", "Pinecone", "pgvector",
+    "AI Agents", "Multi-Agent", "Agent Memory", "Planning / CoT",
+    "Tool Use", "Structured Output", "Context Engineering", "MCP",
+    "LangChain", "LangGraph", "LlamaIndex", "CrewAI", "AutoGen",
+    "DSPy", "Semantic Kernel", "Haystack", "LiteLLM", "Agno",
+    "Letta / MemGPT", "Mem0", "Swarm", "OpenAI Agents SDK",
+    "Fine-Tuning", "LoRA / PEFT", "RLHF", "DPO", "GRPO",
+    "Synthetic Data", "Distillation", "DeepSpeed", "FSDP", "TRL",
+    "Unsloth", "Axolotl", "TorchTune", "MergeKit",
+    "LLM Serving", "vLLM", "TGI", "Triton", "TensorRT", "llama.cpp",
+    "ExLlama", "GPT4All", "PrivateGPT", "Llamafile", "SGLang",
+    "Quantization", "Speculative Decoding", "KV Cache", "Batching",
+    "Model Optimization", "Inference",
+    "MLOps", "DVC", "ZenML", "Prefect", "Airflow", "Ray", "Kubeflow",
+    "Feature Store", "Model Registry", "SageMaker", "Vertex AI",
+    "Azure AI", "AWS Bedrock", "AWS", "Google Cloud",
+    "Evals", "Benchmarking", "MMLU", "HumanEval", "LM Eval Harness",
+    "DeepEval", "RAGAS", "PromptFoo", "Red Teaming", "Garak", "PyRIT",
+    "LangSmith", "Phoenix", "MLflow", "Weights & Biases", "Tracing",
+    "Monitoring", "Langfuse", "OpenLLMetry", "OpenLIT", "Helicone",
+    "Traceloop", "OpenTelemetry",
+    "Computer Vision", "Object Detection", "Segmentation", "Depth Estimation",
+    "Pose Estimation", "3D Reconstruction", "Point Cloud / 3D Vision",
+    "Robotics", "ROS", "ROS 2", "Motion Planning", "Grasping",
+    "Humanoid Robotics", "Robot Arms", "Robot Learning", "Sim-to-Real", "SLAM",
+    "Autonomous Systems",
+    "Image Generation", "Video Generation", "Text to Speech", "Speech to Text",
+    "Music / Audio AI", "Music Generation", "Voice Cloning",
+    "Stable Diffusion", "ControlNet", "ComfyUI", "SD WebUI", "Whisper",
+    "Multimodal AI", "XR / Spatial Computing", "Virtual Reality",
+    "Augmented Reality", "Mixed Reality", "Immersive Media",
+    "WebXR", "ARKit", "ARCore", "Meta Quest", "Apple Vision", "Apple Vision Pro",
+    "Python", "TypeScript", "JavaScript", "Rust", "Go", "Java", "C++",
+    "Backend", "Frontend", "Full Stack", "Systems",
+    "React / Next.js", "Python Web Framework", "Node.js",
+    "Docker", "Kubernetes", "DevOps", "API", "GraphQL",
+    "Database", "Caching",
+    "Pydantic", "Instructor", "Outlines", "Guidance", "Guardrails",
+    "NeMo Guardrails", "Prompt Engineering",
+    "Machine Learning", "Deep Learning", "Transformers", "PyTorch",
+    "TensorFlow", "Keras", "JAX", "GPU / CUDA",
+    "Reinforcement Learning", "Long Context",
+    "Data Science", "Pandas", "Jupyter", "Data Visualization", "NumPy",
+    "Scikit-learn", "Spark", "Data Engineering", "Statistics", "Visualization",
+    "Continue.dev", "Aider", "SWE-Agent", "OpenDevin", "OpenHands",
+    "Cline", "Claude Code", "Gemini CLI", "Kilocode",
+    "Langflow", "Flowise", "n8n", "No-Code Automation", "Automation",
+    "Tutorial", "Course", "Roadmap", "Cheat Sheet", "Curated List",
+    "Interview Prep", "Research / Papers", "Open Source",
+    "FinTech", "Healthcare AI", "Music Tech", "Game Dev",
+    "Security", "Web3", "Mobile", "Knowledge Graph", "Real-Time / Streaming",
+    "AI Safety", "Adversarial", "Watermarking", "Privacy",
+    "Privacy-Preserving AI", "Prompt Injection",
+    "CLI Tool", "Simulation", "HuggingFace", "Ollama",
+    "ONNX", "Popular", "Active", "Inactive", "Forked", "Built by Me",
+    "Archived", "NLP", "Frontend Framework", "Testing",
+})
+
+_lower_to_canonical: dict[str, str] = {t.lower(): t for t in _CANONICAL_TAGS}
+_vocab_list: list[str] = sorted(_CANONICAL_TAGS)
+_vocab_lower: list[str] = [t.lower() for t in _vocab_list]
+
+
+def canonicalize_tag(raw: str) -> str | None:
+    """Return canonical form of raw tag, or None if no match at threshold 0.82."""
+    if not raw or not isinstance(raw, str):
+        return None
+    clean = raw.strip()
+    if not clean:
+        return None
+    lower = clean.lower()
+    if lower in _lower_to_canonical:
+        return _lower_to_canonical[lower]
+    matches = difflib.get_close_matches(lower, _vocab_lower, n=1, cutoff=0.82)
+    if matches:
+        return _vocab_list[_vocab_lower.index(matches[0])]
+    return None
+
+
+def canonicalize_tags(tags: list[str]) -> list[str]:
+    """Canonicalize a list of raw tags. Returns unique canonical forms; drops unmatched."""
+    seen: set[str] = set()
+    result: list[str] = []
+    for raw in tags:
+        canonical = canonicalize_tag(raw)
+        if canonical and canonical not in seen:
+            seen.add(canonical)
+            result.append(canonical)
+    return result

--- a/migrations/versions/035_canonicalize_activity_velocity.py
+++ b/migrations/versions/035_canonicalize_activity_velocity.py
@@ -1,0 +1,101 @@
+"""Canonicalization, activity score breakdown, forks_count, and velocity views.
+
+Changes:
+  1. ADD COLUMN IF NOT EXISTS integration_tags JSONB — column already exists in prod
+     (created by migration 002); guard prevents duplicate-column error on rerun.
+  2. ADD COLUMN raw_integration_tags JSONB — stores original AI output before canonicalization.
+  3. ADD COLUMN forks_count INTEGER — GitHub forks count, used in new activity score formula.
+  4. ADD COLUMN activity_score_breakdown JSONB — per-component breakdown of the activity score.
+  5. CREATE VIEW v_edge_count_by_run — edge counts grouped by ingest run, used by audit checks.
+  6. CREATE VIEW v_repo_activity_trend — rolling 7-day window of per-repo activity scores,
+     useful for trending dashboards and regression detection.
+
+Revision ID: 035
+Revises: 034
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+# revision identifiers
+revision = "035"
+down_revision = "034"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+
+    # 1. integration_tags — guard against pre-existing column (migration 002 created it)
+    conn.execute(sa.text("""
+        ALTER TABLE repos
+        ADD COLUMN IF NOT EXISTS integration_tags JSONB
+    """))
+
+    # 2–4. New columns (safe to ADD without IF NOT EXISTS — 035 is the only migration adding these)
+    conn.execute(sa.text("""
+        ALTER TABLE repos
+        ADD COLUMN IF NOT EXISTS raw_integration_tags JSONB,
+        ADD COLUMN IF NOT EXISTS forks_count INTEGER NOT NULL DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS activity_score_breakdown JSONB
+    """))
+
+    # 5. v_edge_count_by_run — edge counts per ingest run and edge type
+    #    Used by reporium-audit to detect >20% drops in DEPENDS_ON coverage.
+    conn.execute(sa.text("""
+        CREATE OR REPLACE VIEW v_edge_count_by_run AS
+        SELECT
+            ir.id                                    AS run_id,
+            ir.started_at,
+            ir.finished_at,
+            ir.status,
+            re.edge_type,
+            COUNT(re.id)                             AS edge_count
+        FROM ingest_runs ir
+        LEFT JOIN repo_edges re ON re.ingest_run_id = ir.id
+        GROUP BY ir.id, ir.started_at, ir.finished_at, ir.status, re.edge_type
+        ORDER BY ir.started_at DESC, re.edge_type
+    """))
+
+    # 6. v_repo_activity_trend — 7-day rolling window of activity scores
+    #    Compares each repo's latest score against its score from 7 days ago.
+    conn.execute(sa.text("""
+        CREATE OR REPLACE VIEW v_repo_activity_trend AS
+        SELECT
+            r.id                                     AS repo_id,
+            r.name,
+            r.activity_score                         AS current_score,
+            r.updated_at                             AS scored_at,
+            LAG(r.activity_score) OVER (
+                PARTITION BY r.id
+                ORDER BY r.updated_at
+            )                                        AS prev_score,
+            r.activity_score - COALESCE(
+                LAG(r.activity_score) OVER (
+                    PARTITION BY r.id
+                    ORDER BY r.updated_at
+                ), r.activity_score
+            )                                        AS score_delta
+        FROM repos r
+        WHERE r.updated_at >= NOW() - INTERVAL '7 days'
+        ORDER BY score_delta DESC, r.activity_score DESC
+    """))
+
+
+def downgrade() -> None:
+    conn = op.get_bind()
+
+    conn.execute(sa.text("DROP VIEW IF EXISTS v_repo_activity_trend"))
+    conn.execute(sa.text("DROP VIEW IF EXISTS v_edge_count_by_run"))
+
+    # Only drop columns added by this migration — do NOT drop integration_tags
+    # (it predates this migration and may have data from other migrations)
+    conn.execute(sa.text("""
+        ALTER TABLE repos
+        DROP COLUMN IF EXISTS activity_score_breakdown,
+        DROP COLUMN IF EXISTS forks_count,
+        DROP COLUMN IF EXISTS raw_integration_tags
+    """))


### PR DESCRIPTION
## Summary

- **migration 035**: adds `repos.raw_integration_tags JSONB`, `forks_count INTEGER`, `activity_score_breakdown JSONB`; creates `v_edge_count_by_run` and `v_repo_activity_trend` analytics views
- **app/models/repo.py**: mapped columns for all three new fields
- **app/schemas/repo.py**: `forks_count` + `activity_score_breakdown` in `RepoIngestItem`
- **app/utils.py**: `canonicalize_tags()` — fuzzy-matches raw AI tags against 200-term canonical vocabulary (kept in sync with `ingestion/enrichment/canonicalize.py`)
- **app/routers/ingest.py**: enrichment now stores raw tags in `raw_integration_tags` and canonical in `integration_tags`; `"dependencies"` intentionally absent from `_TAXONOMY_DIMENSION_MAP` (Wave 2 fix preserved — deps belong in `repo_dependencies`)

## Replaces

Closed PR #324 (stale base branch; that version also re-introduced `"dependencies"` to the taxonomy map — reverted here).

## Test plan

- [ ] `alembic upgrade head` runs cleanly
- [ ] `SELECT column_name FROM information_schema.columns WHERE table_name='repos' AND column_name IN ('raw_integration_tags','forks_count','activity_score_breakdown');` returns 3 rows
- [ ] `SELECT * FROM v_edge_count_by_run LIMIT 1;` works
- [ ] `SELECT * FROM v_repo_activity_trend LIMIT 1;` works

🤖 Generated with [Claude Code](https://claude.ai/claude-code)