### PR TITLE
fix: resolve CI timeout from sync get_event_loop() calls in TestTaskDoneCallback

### DIFF
--- a/tests/test_reliability_hardening.py
+++ b/tests/test_reliability_hardening.py
@@ -42,22 +42,20 @@ class TestPoolSizing:
 class TestTaskDoneCallback:
     """Verify _task_done_callback logs warnings for failed tasks and stays silent for successful ones."""
 
-    def test_logs_warning_for_failed_task(self, caplog):
+    @pytest.mark.asyncio
+    async def test_logs_warning_for_failed_task(self, caplog):
         from app.routers.intelligence import _task_done_callback
 
         async def _failing():
             raise RuntimeError("boom")
 
-        async def _run():
-            task = asyncio.create_task(_failing())
-            try:
-                await task
-            except RuntimeError:
-                pass
-            with caplog.at_level(logging.WARNING, logger="app.routers.intelligence"):
-                _task_done_callback(task)
-
-        asyncio.get_event_loop().run_until_complete(_run())
+        task = asyncio.create_task(_failing())
+        try:
+            await task
+        except RuntimeError:
+            pass
+        with caplog.at_level(logging.WARNING, logger="app.routers.intelligence"):
+            _task_done_callback(task)
 
         assert any("boom" in record.message for record in caplog.records), (
             "Expected a warning log containing 'boom'"
@@ -66,42 +64,38 @@ class TestTaskDoneCallback:
             "Expected log message to mention 'Background task'"
         )
 
-    def test_no_log_for_successful_task(self, caplog):
+    @pytest.mark.asyncio
+    async def test_no_log_for_successful_task(self, caplog):
         from app.routers.intelligence import _task_done_callback
 
         async def _ok():
             return 42
 
-        async def _run():
-            task = asyncio.create_task(_ok())
-            await task
-            with caplog.at_level(logging.WARNING, logger="app.routers.intelligence"):
-                _task_done_callback(task)
-
-        asyncio.get_event_loop().run_until_complete(_run())
+        task = asyncio.create_task(_ok())
+        await task
+        with caplog.at_level(logging.WARNING, logger="app.routers.intelligence"):
+            _task_done_callback(task)
 
         warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
         assert len(warning_records) == 0, (
             f"Expected no warning logs for a successful task, got: {warning_records}"
         )
 
-    def test_no_log_for_cancelled_task(self, caplog):
+    @pytest.mark.asyncio
+    async def test_no_log_for_cancelled_task(self, caplog):
         from app.routers.intelligence import _task_done_callback
 
         async def _slow():
             await asyncio.sleep(100)
 
-        async def _run():
-            task = asyncio.create_task(_slow())
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
-            with caplog.at_level(logging.WARNING, logger="app.routers.intelligence"):
-                _task_done_callback(task)
-
-        asyncio.get_event_loop().run_until_complete(_run())
+        task = asyncio.create_task(_slow())
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        with caplog.at_level(logging.WARNING, logger="app.routers.intelligence"):
+            _task_done_callback(task)
 
         warning_records = [r for r in caplog.records if r.levelno >= logging.WARNING]
         assert len(warning_records) == 0, (


### PR DESCRIPTION
## Summary

- Three sync test methods in `tests/test_reliability_hardening.py::TestTaskDoneCallback` were calling `asyncio.get_event_loop().run_until_complete()` from within a synchronous pytest test context
- Under Python 3.12 with pytest-asyncio in `AUTO` mode (session-scoped event loop), this raises `RuntimeError: This event loop is already running`, causing those tests to deadlock and hang indefinitely
- The test suite was consistently hitting the 10-minute CI timeout (~23.5 minutes of hang), blocked at the `test_reliability_hardening.py` tests (which run alphabetically after `test_rate_limiting.py`, at ~74% test completion)

## Fix

Converted all three `TestTaskDoneCallback` test methods from sync `def test_...` with `asyncio.get_event_loop().run_until_complete(_run())` wrappers to proper `async def test_...` with `@pytest.mark.asyncio`. The nested `_run()` coroutine body is inlined directly, eliminating the problematic `run_until_complete` call entirely.

## Test plan

- [ ] CI Tests workflow passes (was timing out after 10 minutes before this fix)
- [ ] All three `TestTaskDoneCallback` tests pass: `test_logs_warning_for_failed_task`, `test_no_log_for_successful_task`, `test_no_log_for_cancelled_task`
- [ ] `TestPoolSizing` tests (synchronous, no change) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)