### PR TITLE
fix(ci): add pytest-timeout to stop 21-min test hang

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,4 @@
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
+timeout = 30

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ pgvector==0.3.5
 httpx==0.27.2
 pytest==8.3.3
 pytest-asyncio==0.24.0
+pytest-timeout==2.3.1
 anyio==4.6.2
 google-cloud-secret-manager==2.22.0
 slowapi==0.1.9


### PR DESCRIPTION
## Summary
- Adds `pytest-timeout==2.3.1` to `requirements.txt`
- Adds `timeout = 30` to `[tool.pytest.ini_options]` in `pyproject.toml`

## Root cause
`test_compute_quality_signals_returns_computed_count` was hanging indefinitely in CI (observed: 21+ minutes before the job-level timeout killed the run). The `seed_repo` autouse fixture calls `POST /ingest/repos`, which — following a prior test failure leaving a DB lock — could block the next request indefinitely with no per-test guard.

A 30-second pytest-timeout cap makes any stuck test fail fast and produce a clear `TimeoutExpired` error instead of silently eating the CI budget.

## Test plan
- [ ] CI passes (no job-level timeout)
- [ ] If a test hangs in future, it fails with a clear timeout error within 30s

🤖 Generated with [Claude Code](https://claude.com/claude-code)