### PR TITLE
KAN-119 Permanent graph snapshot-first serving

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ INGEST_API_KEY=change-me-ingest-key
 
 # Cache and environment
 REDIS_URL=redis://localhost:6379
+GRAPH_SNAPSHOT_BUCKET=
+GRAPH_SNAPSHOT_OBJECT=reporium/graph/knowledge-graph.json
+GRAPH_SNAPSHOT_LOCAL_PATH=
 ENVIRONMENT=development
 
 # GCP / Pub/Sub integration

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,6 +45,7 @@ jobs:
             --max-instances=10
             --concurrency=200
             --timeout=300
+            --set-env-vars=GRAPH_SNAPSHOT_BUCKET=perditio-platform-bucket,GRAPH_SNAPSHOT_OBJECT=reporium/graph/knowledge-graph.json
             --clear-vpc-connector
 
       - name: Prune old container images (keep latest 5)

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,9 @@
 name: Tests
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ uvicorn app.main:app --reload
 | `ADMIN_API_KEY` | No | X-Admin-Key header for admin endpoints. Unset = open in dev. |
 | `INGEST_API_KEY` | No | X-Ingest-Key header for ingest endpoints. Unset = open in dev. |
 | `REDIS_URL` | No | Redis connection string — API works without it |
+| `GRAPH_SNAPSHOT_BUCKET` | No | GCS bucket for the published graph snapshot artifact |
+| `GRAPH_SNAPSHOT_OBJECT` | No | Object path for the graph snapshot artifact |
+| `GRAPH_SNAPSHOT_LOCAL_PATH` | No | Local graph snapshot file for development/tests |
 | `GH_USERNAME` | No | GitHub username |
 | `GH_TOKEN` | No | GitHub token |
 | `ENVIRONMENT` | No | `development` \| `production` |
@@ -56,6 +59,8 @@ uvicorn app.main:app --reload
 | `GCP_PROJECT_ID` | No | GCP project ID (default: `perditio-platform`) |
 
 > Secrets are resolved from GCP Secret Manager in production (no `.env` needed on Cloud Run).
+>
+> `GET /graph/edges` serves from the published graph snapshot artifact before attempting live database queries so the graph UI remains available during primary DB incidents.
 
 ---
 

--- a/app/config.py
+++ b/app/config.py
@@ -76,6 +76,12 @@ class Settings(BaseSettings):
     redis_url: str | None = None
     cache_ttl_seconds: int = 300  # 5 minutes default
 
+    # Graph snapshot serving
+    graph_snapshot_bucket: str | None = None
+    graph_snapshot_object: str = "reporium/graph/knowledge-graph.json"
+    graph_snapshot_local_path: str | None = None
+    graph_snapshot_cache_ttl_seconds: int = 300
+
     # Auth
     ingestion_api_key: str
 

--- a/app/graph_snapshot.py
+++ b/app/graph_snapshot.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+GRAPH_SNAPSHOT_VERSION = 1
+_snapshot_cache: dict[str, Any] | None = None
+_snapshot_cache_loaded_at = 0.0
+_snapshot_lock = asyncio.Lock()
+
+
+def _parse_snapshot_datetime(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        logger.warning("Could not parse graph snapshot datetime: %s", value)
+        return None
+
+
+def _read_snapshot_from_disk(path: str) -> dict[str, Any]:
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def _read_snapshot_from_gcs(bucket_name: str, object_name: str) -> dict[str, Any]:
+    from google.cloud import storage
+
+    client = storage.Client(project=settings.gcp_project)
+    blob = client.bucket(bucket_name).blob(object_name)
+    return json.loads(blob.download_as_text())
+
+
+def _read_snapshot_payload() -> dict[str, Any] | None:
+    if settings.graph_snapshot_local_path:
+        path = Path(settings.graph_snapshot_local_path)
+        if path.exists():
+            return _read_snapshot_from_disk(str(path))
+        logger.warning("Graph snapshot local path does not exist: %s", path)
+
+    if settings.graph_snapshot_bucket:
+        return _read_snapshot_from_gcs(
+            settings.graph_snapshot_bucket,
+            settings.graph_snapshot_object,
+        )
+
+    return None
+
+
+async def load_graph_snapshot(force_refresh: bool = False) -> dict[str, Any] | None:
+    global _snapshot_cache, _snapshot_cache_loaded_at
+
+    ttl_seconds = max(1, settings.graph_snapshot_cache_ttl_seconds)
+    now = time.monotonic()
+    if (
+        not force_refresh
+        and _snapshot_cache is not None
+        and (now - _snapshot_cache_loaded_at) < ttl_seconds
+    ):
+        return _snapshot_cache
+
+    async with _snapshot_lock:
+        now = time.monotonic()
+        if (
+            not force_refresh
+            and _snapshot_cache is not None
+            and (now - _snapshot_cache_loaded_at) < ttl_seconds
+        ):
+            return _snapshot_cache
+
+        try:
+            snapshot = await asyncio.to_thread(_read_snapshot_payload)
+        except Exception as exc:
+            if _snapshot_cache is not None:
+                logger.warning(
+                    "Graph snapshot refresh failed; serving stale in-memory snapshot: %s",
+                    exc,
+                )
+                return _snapshot_cache
+            logger.warning("Graph snapshot refresh failed with no stale cache: %s", exc)
+            return None
+
+        if snapshot is None:
+            return _snapshot_cache
+
+        if snapshot.get("snapshot_version") != GRAPH_SNAPSHOT_VERSION:
+            logger.warning(
+                "Ignoring graph snapshot with unsupported version %s",
+                snapshot.get("snapshot_version"),
+            )
+            return _snapshot_cache
+
+        _snapshot_cache = snapshot
+        _snapshot_cache_loaded_at = time.monotonic()
+        return snapshot
+
+
+def _node_to_response(node: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": node.get("name"),
+        "owner": node.get("owner"),
+        "description": node.get("description"),
+        "category": node.get("primary_category"),
+    }
+
+
+def _node_to_viz(node: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": node.get("name"),
+        "owner": node.get("owner"),
+        "description": node.get("description"),
+        "primary_category": node.get("primary_category"),
+        "stars": int(node.get("stars") or 0),
+        "stars_log": float(node.get("stars_log") or 0.0),
+        "quality": node.get("quality"),
+    }
+
+
+def build_graph_payload_from_snapshot(
+    snapshot: dict[str, Any],
+    *,
+    limit: int,
+    min_similarity: float,
+    neighbours: int,
+    since_interval: str | None = None,
+) -> dict[str, Any]:
+    node_index = {
+        str(node["repo_id"]): node
+        for node in snapshot.get("nodes", [])
+        if node.get("repo_id")
+    }
+    if not node_index:
+        raise ValueError("Graph snapshot is missing nodes")
+
+    cutoff: datetime | None = None
+    if since_interval:
+        value_str, unit = since_interval.split(" ", 1)
+        value = int(value_str)
+        seconds_map = {
+            "day": 86400,
+            "hour": 3600,
+            "minute": 60,
+        }
+        cutoff = datetime.now(timezone.utc) - timedelta(seconds=value * seconds_map[unit])
+
+    def include_pair(source_id: str, target_id: str) -> bool:
+        if cutoff is None:
+            return True
+        source_dt = _parse_snapshot_datetime(node_index[source_id].get("updated_at"))
+        target_dt = _parse_snapshot_datetime(node_index[target_id].get("updated_at"))
+        return (source_dt and source_dt >= cutoff) or (target_dt and target_dt >= cutoff)
+
+    edges_by_pair: dict[tuple[str, str], dict[str, Any]] = {}
+
+    for edge in snapshot.get("similarity_edges", []):
+        source_id = str(edge.get("source_repo_id") or "")
+        target_id = str(edge.get("target_repo_id") or "")
+        if not source_id or not target_id:
+            continue
+        if source_id not in node_index or target_id not in node_index:
+            continue
+        if int(edge.get("rank") or 999999) > neighbours:
+            continue
+        weight = float(edge.get("weight") or 0.0)
+        if weight < min_similarity:
+            continue
+        if not include_pair(source_id, target_id):
+            continue
+
+        pair_key = tuple(sorted((source_id, target_id)))
+        existing = edges_by_pair.get(pair_key)
+        if existing and float(existing["weight"]) >= weight:
+            continue
+
+        edges_by_pair[pair_key] = {
+            "edgeType": "SIMILAR_TO",
+            "weight": round(weight, 4),
+            "evidence": None,
+            "source": _node_to_response(node_index[source_id]),
+            "target": _node_to_response(node_index[target_id]),
+            "_node_ids": (source_id, target_id),
+        }
+
+    for edge in snapshot.get("typed_edges", []):
+        source_id = str(edge.get("source_repo_id") or "")
+        target_id = str(edge.get("target_repo_id") or "")
+        if not source_id or not target_id:
+            continue
+        if source_id not in node_index or target_id not in node_index:
+            continue
+        if not include_pair(source_id, target_id):
+            continue
+
+        pair_key = tuple(sorted((source_id, target_id)))
+        edges_by_pair[pair_key] = {
+            "edgeType": edge.get("edge_type", "RELATED_TO"),
+            "weight": round(float(edge.get("weight") or 0.5), 4),
+            "evidence": None,
+            "source": _node_to_response(node_index[source_id]),
+            "target": _node_to_response(node_index[target_id]),
+            "_node_ids": (source_id, target_id),
+        }
+
+    edges = sorted(
+        edges_by_pair.values(),
+        key=lambda edge: (float(edge["weight"]), edge["edgeType"] != "SIMILAR_TO"),
+        reverse=True,
+    )[:limit]
+
+    included_node_ids: set[str] = set()
+    for edge in edges:
+        source_id, target_id = edge.pop("_node_ids")
+        included_node_ids.add(source_id)
+        included_node_ids.add(target_id)
+
+    included_nodes = [_node_to_viz(node_index[node_id]) for node_id in included_node_ids]
+
+    stats = snapshot.get("stats", {})
+    return {
+        "total": len(edges),
+        "total_repos": len(included_nodes),
+        "total_public_repos": int(stats.get("total_public_repos") or 0),
+        "repos_with_embeddings": int(stats.get("repos_with_embeddings") or 0),
+        "edgeTypes": sorted({edge["edgeType"] for edge in edges}),
+        "nodes": included_nodes,
+        "edges": edges,
+        "graph_source": "snapshot",
+        "snapshot_generated_at": snapshot.get("generated_at"),
+    }

--- a/app/routers/graph.py
+++ b/app/routers/graph.py
@@ -25,6 +25,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.cache import cache
 from app.database import get_db
 from app.embeddings import get_embedding_model
+from app.graph_snapshot import build_graph_payload_from_snapshot, load_graph_snapshot
 from app.rate_limit import rate_limit_storage
 from app.utils import vec_to_pg
 
@@ -63,9 +64,13 @@ def _parse_since(since: str | None) -> str | None:
 
 def _log_scale_stars(stars: int | None) -> float:
     """Return a log-scaled star value for node sizing (0.0 when no stars)."""
-    if not stars or stars <= 0:
+    try:
+        stars_value = int(stars or 0)
+    except (TypeError, ValueError):
         return 0.0
-    return round(math.log10(stars + 1), 4)
+    if stars_value <= 0:
+        return 0.0
+    return round(math.log10(stars_value + 1), 4)
 
 
 def _extract_quality(quality_signals: dict | None) -> float | None:
@@ -73,12 +78,19 @@ def _extract_quality(quality_signals: dict | None) -> float | None:
 
     Returns the ``overall`` key if present, else None.
     """
-    if not quality_signals:
+    if not isinstance(quality_signals, dict):
         return None
     overall = quality_signals.get("overall")
     if overall is not None:
         return round(float(overall), 4)
     return None
+
+
+def _safe_int(value, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
 
 
 def _rows_to_edges(rows) -> list[dict]:
@@ -127,11 +139,256 @@ def _rows_to_nodes(rows) -> list[dict]:
                     "owner": getattr(row, f"{prefix}_owner"),
                     "description": getattr(row, f"{prefix}_description"),
                     "primary_category": getattr(row, f"{prefix}_category"),
-                    "stars": stars or 0,
+                    "stars": _safe_int(stars),
                     "stars_log": _log_scale_stars(stars),
                     "quality": _extract_quality(qs),
                 }
     return list(node_map.values())
+
+
+def _json_graph_response(payload: dict) -> JSONResponse:
+    response = JSONResponse(content=payload)
+    response.headers["Cache-Control"] = "public, max-age=3600"
+    return response
+
+
+async def _build_graph_payload_from_db(
+    db: AsyncSession,
+    *,
+    limit: int,
+    min_similarity: float,
+    neighbours: int,
+    interval: str | None,
+) -> dict:
+    # Build optional temporal WHERE clause
+    since_clause = ""
+    if interval:
+        since_clause = (
+            "AND (r1.updated_at >= NOW() - :since_interval::interval "
+            "OR r2.updated_at >= NOW() - :since_interval::interval)"
+        )
+
+    # Use a CTE to find top-K neighbours per repo via HNSW index.
+    # The <=> operator returns cosine distance; 1 - distance = similarity.
+    # We lateral-join to get the K nearest neighbours per repo efficiently.
+    sql = text(f"""
+        WITH ranked AS (
+            SELECT
+                e1.repo_id   AS source_id,
+                e2.repo_id   AS target_id,
+                1 - (e1.embedding_vec <=> e2.embedding_vec) AS similarity
+            FROM repo_embeddings e1
+            CROSS JOIN LATERAL (
+                SELECT e2_inner.repo_id,
+                       e2_inner.embedding_vec
+                FROM repo_embeddings e2_inner
+                WHERE e2_inner.repo_id != e1.repo_id
+                ORDER BY e1.embedding_vec <=> e2_inner.embedding_vec
+                LIMIT :neighbours
+            ) e2
+            WHERE 1 - (e1.embedding_vec <=> e2.embedding_vec) >= :min_sim
+        ),
+        deduped AS (
+            SELECT DISTINCT ON (LEAST(source_id, target_id), GREATEST(source_id, target_id))
+                source_id, target_id, similarity
+            FROM ranked
+            ORDER BY LEAST(source_id, target_id), GREATEST(source_id, target_id),
+                     similarity DESC
+        ),
+        -- Orphan rescue: repos with embeddings but no edges above threshold
+        orphan_edges AS (
+            SELECT DISTINCT ON (LEAST(e1.repo_id, e2.repo_id), GREATEST(e1.repo_id, e2.repo_id))
+                e1.repo_id AS source_id,
+                e2.repo_id AS target_id,
+                1 - (e1.embedding_vec <=> e2.embedding_vec) AS similarity
+            FROM repo_embeddings e1
+            CROSS JOIN LATERAL (
+                SELECT e2_inner.repo_id,
+                       e2_inner.embedding_vec
+                FROM repo_embeddings e2_inner
+                WHERE e2_inner.repo_id != e1.repo_id
+                ORDER BY e1.embedding_vec <=> e2_inner.embedding_vec
+                LIMIT 1
+            ) e2
+            WHERE NOT EXISTS (
+                SELECT 1 FROM deduped d
+                WHERE d.source_id = e1.repo_id OR d.target_id = e1.repo_id
+            )
+            ORDER BY LEAST(e1.repo_id, e2.repo_id), GREATEST(e1.repo_id, e2.repo_id),
+                     similarity DESC
+        ),
+        all_edges AS (
+            SELECT source_id, target_id, similarity FROM deduped
+            UNION
+            SELECT source_id, target_id, similarity FROM orphan_edges
+        )
+        SELECT
+            ae.similarity,
+            r1.name               AS source_name,
+            r1.description        AS source_description,
+            r1.primary_category   AS source_category,
+            r1.owner              AS source_owner,
+            r1.stargazers_count   AS source_stars,
+            r1.quality_signals    AS source_quality_signals,
+            r1.updated_at         AS source_updated_at,
+            r2.name               AS target_name,
+            r2.description        AS target_description,
+            r2.primary_category   AS target_category,
+            r2.owner              AS target_owner,
+            r2.stargazers_count   AS target_stars,
+            r2.quality_signals    AS target_quality_signals,
+            r2.updated_at         AS target_updated_at
+        FROM all_edges ae
+        JOIN repos r1 ON r1.id = ae.source_id AND r1.is_private = false
+        JOIN repos r2 ON r2.id = ae.target_id AND r2.is_private = false
+        WHERE 1=1 {since_clause}
+        ORDER BY ae.similarity DESC
+        LIMIT :limit
+    """)
+
+    params: dict = {
+        "neighbours": neighbours,
+        "min_sim": min_similarity,
+        "limit": limit,
+    }
+    if interval:
+        params["since_interval"] = interval
+
+    result = await db.execute(sql, params)
+    rows = result.fetchall()
+
+    # Build similarity edges, keyed by (source, target) for dedup
+    edges_by_pair: dict[tuple[str, str], dict] = {}
+    node_map: dict[str, dict] = {}
+
+    for row in rows:
+        key = (row.source_name, row.target_name)
+        if key not in edges_by_pair:
+            edges_by_pair[key] = {
+                "edgeType": "SIMILAR_TO",
+                "weight": round(float(row.similarity), 4),
+                "evidence": None,
+                "source": {
+                    "name": row.source_name, "owner": row.source_owner,
+                    "description": row.source_description, "category": row.source_category,
+                },
+                "target": {
+                    "name": row.target_name, "owner": row.target_owner,
+                    "description": row.target_description, "category": row.target_category,
+                },
+            }
+        if row.source_name not in node_map:
+            node_map[row.source_name] = {
+                "name": row.source_name, "owner": row.source_owner,
+                "description": row.source_description,
+                "primary_category": row.source_category,
+                "stars": _safe_int(row.source_stars),
+                "stars_log": _log_scale_stars(row.source_stars),
+                "quality": _extract_quality(row.source_quality_signals),
+            }
+        if row.target_name not in node_map:
+            node_map[row.target_name] = {
+                "name": row.target_name, "owner": row.target_owner,
+                "description": row.target_description,
+                "primary_category": row.target_category,
+                "stars": _safe_int(row.target_stars),
+                "stars_log": _log_scale_stars(row.target_stars),
+                "quality": _extract_quality(row.target_quality_signals),
+            }
+
+    # Merge typed relationship edges from repo_edges â€” override SIMILAR_TO when same pair
+    try:
+        typed_sql = text("""
+            SELECT
+                re.edge_type,
+                re.weight,
+                r1.name        AS source_name,
+                r1.owner       AS source_owner,
+                r1.description AS source_description,
+                r1.primary_category AS source_category,
+                r1.stargazers_count AS source_stars,
+                r1.quality_signals  AS source_quality_signals,
+                r2.name        AS target_name,
+                r2.owner       AS target_owner,
+                r2.description AS target_description,
+                r2.primary_category AS target_category,
+                r2.stargazers_count AS target_stars,
+                r2.quality_signals  AS target_quality_signals
+            FROM repo_edges re
+            JOIN repos r1 ON r1.id = re.source_repo_id AND r1.is_private = false
+            JOIN repos r2 ON r2.id = re.target_repo_id AND r2.is_private = false
+            WHERE re.edge_type IN ('ALTERNATIVE_TO', 'COMPATIBLE_WITH', 'DEPENDS_ON', 'EXTENDS')
+            ORDER BY re.weight DESC NULLS LAST
+            LIMIT 5000
+        """)
+        typed_result = await db.execute(typed_sql)
+        typed_rows = typed_result.fetchall()
+
+        for trow in typed_rows:
+            if not isinstance(getattr(trow, "edge_type", None), str):
+                continue
+            key = (trow.source_name, trow.target_name)
+            # Typed edge overrides similarity edge for same pair
+            edges_by_pair[key] = {
+                "edgeType": trow.edge_type,
+                "weight": round(float(trow.weight or 0.5), 4),
+                "evidence": None,
+                "source": {
+                    "name": trow.source_name, "owner": trow.source_owner,
+                    "description": trow.source_description, "category": trow.source_category,
+                },
+                "target": {
+                    "name": trow.target_name, "owner": trow.target_owner,
+                    "description": trow.target_description, "category": trow.target_category,
+                },
+            }
+            if trow.source_name not in node_map:
+                node_map[trow.source_name] = {
+                    "name": trow.source_name, "owner": trow.source_owner,
+                    "description": trow.source_description,
+                    "primary_category": trow.source_category,
+                    "stars": _safe_int(trow.source_stars),
+                    "stars_log": _log_scale_stars(trow.source_stars),
+                    "quality": _extract_quality(trow.source_quality_signals),
+                }
+            if trow.target_name not in node_map:
+                node_map[trow.target_name] = {
+                    "name": trow.target_name, "owner": trow.target_owner,
+                    "description": trow.target_description,
+                    "primary_category": trow.target_category,
+                    "stars": _safe_int(trow.target_stars),
+                    "stars_log": _log_scale_stars(trow.target_stars),
+                    "quality": _extract_quality(trow.target_quality_signals),
+                }
+    except Exception as exc:
+        # repo_edges table may not exist yet â€” degrade gracefully
+        logger.warning("Could not fetch typed graph edges: %s", exc)
+
+    edges = list(edges_by_pair.values())
+    nodes = list(node_map.values())
+
+    # Count repos with and without embeddings for diagnostics
+    counts = await db.execute(text("""
+        SELECT
+            (SELECT COUNT(*) FROM repos WHERE is_private = false) AS total_public,
+            (SELECT COUNT(DISTINCT re.repo_id)
+             FROM repo_embeddings re
+             JOIN repos r ON r.id = re.repo_id
+             WHERE r.is_private = false
+               AND re.embedding_vec IS NOT NULL) AS with_embeddings
+    """))
+    count_row = counts.fetchone()
+
+    return {
+        "total": len(edges),
+        "total_repos": len(nodes),
+        "total_public_repos": count_row.total_public if count_row else 0,
+        "repos_with_embeddings": count_row.with_embeddings if count_row else 0,
+        "edgeTypes": sorted({e["edgeType"] for e in edges}),
+        "nodes": nodes,
+        "edges": edges,
+        "graph_source": "database",
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -168,9 +425,23 @@ async def get_graph_edges(
     cache_key = f"graph_edges:{limit}:{min_similarity}:{neighbours}:{since or 'all'}"
     cached = await cache.get(cache_key)
     if cached is not None:
-        response = JSONResponse(content=cached)
-        response.headers["Cache-Control"] = "public, max-age=3600"
-        return response
+        return _json_graph_response(cached)
+
+    snapshot = await load_graph_snapshot()
+    if snapshot is not None:
+        try:
+            snapshot_payload = build_graph_payload_from_snapshot(
+                snapshot,
+                limit=limit,
+                min_similarity=min_similarity,
+                neighbours=neighbours,
+                since_interval=interval,
+            )
+        except Exception as exc:
+            logger.warning("Graph snapshot build failed; falling back to live DB: %s", exc)
+        else:
+            await cache.set(cache_key, snapshot_payload, ttl=CACHE_TTL_GRAPH_EDGES)
+            return _json_graph_response(snapshot_payload)
 
     # Build optional temporal WHERE clause
     since_clause = ""
@@ -294,7 +565,7 @@ async def get_graph_edges(
                 "name": row.source_name, "owner": row.source_owner,
                 "description": row.source_description,
                 "primary_category": row.source_category,
-                "stars": row.source_stars or 0,
+                "stars": _safe_int(row.source_stars),
                 "stars_log": _log_scale_stars(row.source_stars),
                 "quality": _extract_quality(row.source_quality_signals),
             }
@@ -303,7 +574,7 @@ async def get_graph_edges(
                 "name": row.target_name, "owner": row.target_owner,
                 "description": row.target_description,
                 "primary_category": row.target_category,
-                "stars": row.target_stars or 0,
+                "stars": _safe_int(row.target_stars),
                 "stars_log": _log_scale_stars(row.target_stars),
                 "quality": _extract_quality(row.target_quality_signals),
             }
@@ -337,6 +608,8 @@ async def get_graph_edges(
         typed_rows = typed_result.fetchall()
 
         for trow in typed_rows:
+            if not isinstance(getattr(trow, "edge_type", None), str):
+                continue
             key = (trow.source_name, trow.target_name)
             # Typed edge overrides similarity edge for same pair
             edges_by_pair[key] = {
@@ -357,7 +630,7 @@ async def get_graph_edges(
                     "name": trow.source_name, "owner": trow.source_owner,
                     "description": trow.source_description,
                     "primary_category": trow.source_category,
-                    "stars": trow.source_stars or 0,
+                    "stars": _safe_int(trow.source_stars),
                     "stars_log": _log_scale_stars(trow.source_stars),
                     "quality": _extract_quality(trow.source_quality_signals),
                 }
@@ -366,7 +639,7 @@ async def get_graph_edges(
                     "name": trow.target_name, "owner": trow.target_owner,
                     "description": trow.target_description,
                     "primary_category": trow.target_category,
-                    "stars": trow.target_stars or 0,
+                    "stars": _safe_int(trow.target_stars),
                     "stars_log": _log_scale_stars(trow.target_stars),
                     "quality": _extract_quality(trow.target_quality_signals),
                 }
@@ -402,9 +675,7 @@ async def get_graph_edges(
     # Store in Redis cache
     await cache.set(cache_key, result_payload, ttl=CACHE_TTL_GRAPH_EDGES)
 
-    response = JSONResponse(content=result_payload)
-    response.headers["Cache-Control"] = "public, max-age=3600"
-    return response
+    return _json_graph_response(result_payload)
 
 
 # ---------------------------------------------------------------------------

--- a/docs/adr/007-graph-snapshot-serving.md
+++ b/docs/adr/007-graph-snapshot-serving.md
@@ -1,0 +1,52 @@
+# ADR 007: Serve The Knowledge Graph From A Published Snapshot
+
+## Status
+
+Accepted on 2026-04-13.
+
+## Context
+
+`reporium.com` depends on `GET /graph/edges` for both the home-page knowledge graph widget and the full graph page. The previous implementation built the graph on demand from live PostgreSQL reads against `repo_embeddings`, then merged typed edges from `repo_edges`.
+
+That design created a production coupling between page availability and the primary database's read health. On 2026-04-13, a database quota/provider incident caused `/graph/edges` to fail and the production graph UI disappeared.
+
+The graph itself is not user-generated request-specific data. It is a derived platform artifact that changes on ingestion/rebuild cadence, not on every browser request.
+
+## Decision
+
+The canonical serving path for `GET /graph/edges` is now:
+
+1. Redis response cache
+2. Published graph snapshot artifact
+3. Live database query fallback
+
+The snapshot artifact is produced by `reporium-ingestion` and contains:
+
+- public graph nodes with visualization metadata
+- directed similarity edges with rank and weight
+- typed graph edges (`DEPENDS_ON`, `COMPATIBLE_WITH`, `ALTERNATIVE_TO`, `EXTENDS`)
+- snapshot generation metadata and repo-count diagnostics
+
+The API filters the snapshot in memory for `limit`, `min_similarity`, `neighbours`, and `since`, then returns the existing response shape. Live database reads remain available as a fallback path, not the primary contract.
+
+## Consequences
+
+Positive:
+
+- production graph availability no longer depends on request-time database health
+- graph serving cost and latency become predictable
+- the frontend and API continue using the same endpoint contract
+- the snapshot can be refreshed independently from API deployment
+
+Tradeoffs:
+
+- graph freshness is tied to snapshot publication cadence
+- artifact publication becomes a required operational dependency
+- unusual query shapes still rely on the snapshot's retained neighbour depth
+
+## Rollout Notes
+
+- `reporium-ingestion` publishes the artifact to `GRAPH_SNAPSHOT_BUCKET` / `GRAPH_SNAPSHOT_OBJECT`
+- `scripts/publish_graph_snapshot.py` provides a read-only publication path for emergency refreshes
+- `reporium-api` reads the snapshot from GCS or a local test path and caches it in-process
+- regression tests cover snapshot-first serving and publisher output

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ pytest==8.3.3
 pytest-asyncio==0.24.0
 anyio==4.6.2
 google-cloud-secret-manager==2.22.0
+google-cloud-storage==2.19.0
 slowapi==0.1.9
 anthropic==0.87.0
 sentence-transformers==3.4.1

--- a/tests/test_graph_snapshot_serving.py
+++ b/tests/test_graph_snapshot_serving.py
@@ -1,0 +1,138 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from app.database import get_db
+from app.graph_snapshot import GRAPH_SNAPSHOT_VERSION, build_graph_payload_from_snapshot
+from app.main import app
+
+
+def _sample_snapshot() -> dict:
+    return {
+        "snapshot_version": GRAPH_SNAPSHOT_VERSION,
+        "generated_at": "2026-04-13T01:00:00+00:00",
+        "stats": {
+            "total_public_repos": 3,
+            "repos_with_embeddings": 3,
+        },
+        "nodes": [
+            {
+                "repo_id": "repo-1",
+                "name": "repo-a",
+                "owner": "perditioinc",
+                "description": "Repo A",
+                "primary_category": "ai-agents",
+                "stars": 100,
+                "stars_log": 2.0,
+                "quality": 0.9,
+                "updated_at": "2026-04-13T01:00:00+00:00",
+            },
+            {
+                "repo_id": "repo-2",
+                "name": "repo-b",
+                "owner": "perditioinc",
+                "description": "Repo B",
+                "primary_category": "rag-retrieval",
+                "stars": 50,
+                "stars_log": 1.7,
+                "quality": 0.8,
+                "updated_at": "2026-04-13T01:00:00+00:00",
+            },
+            {
+                "repo_id": "repo-3",
+                "name": "repo-c",
+                "owner": "perditioinc",
+                "description": "Repo C",
+                "primary_category": "vector-db",
+                "stars": 25,
+                "stars_log": 1.4,
+                "quality": 0.7,
+                "updated_at": "2026-04-13T01:00:00+00:00",
+            },
+        ],
+        "similarity_edges": [
+            {
+                "source_repo_id": "repo-1",
+                "target_repo_id": "repo-2",
+                "rank": 1,
+                "weight": 0.82,
+            },
+            {
+                "source_repo_id": "repo-1",
+                "target_repo_id": "repo-3",
+                "rank": 2,
+                "weight": 0.45,
+            },
+            {
+                "source_repo_id": "repo-2",
+                "target_repo_id": "repo-1",
+                "rank": 1,
+                "weight": 0.82,
+            },
+        ],
+        "typed_edges": [
+            {
+                "source_repo_id": "repo-2",
+                "target_repo_id": "repo-3",
+                "edge_type": "DEPENDS_ON",
+                "weight": 1.0,
+            }
+        ],
+    }
+
+
+class TestGraphSnapshotPayload:
+
+    def test_build_graph_payload_from_snapshot_filters_similarity_and_keeps_typed_edges(self):
+        payload = build_graph_payload_from_snapshot(
+            _sample_snapshot(),
+            limit=10,
+            min_similarity=0.5,
+            neighbours=1,
+        )
+
+        assert payload["graph_source"] == "snapshot"
+        assert payload["total"] == 2
+        assert payload["total_repos"] == 3
+        assert payload["edgeTypes"] == ["DEPENDS_ON", "SIMILAR_TO"]
+
+        edge_types = {edge["edgeType"] for edge in payload["edges"]}
+        assert "SIMILAR_TO" in edge_types
+        assert "DEPENDS_ON" in edge_types
+
+
+class TestGraphSnapshotServing:
+
+    @pytest.mark.asyncio
+    async def test_graph_edges_prefers_snapshot_before_db(self):
+        mock_db = AsyncMock()
+        mock_db.execute = AsyncMock()
+
+        async def _db_override():
+            yield mock_db
+
+        app.dependency_overrides[get_db] = _db_override
+
+        try:
+            with (
+                patch("app.routers.graph.cache") as mock_cache,
+                patch("app.routers.graph.load_graph_snapshot", new=AsyncMock(return_value=_sample_snapshot())),
+            ):
+                mock_cache.get = AsyncMock(return_value=None)
+                mock_cache.set = AsyncMock()
+
+                async with AsyncClient(
+                    transport=ASGITransport(app=app), base_url="http://test"
+                ) as client:
+                    resp = await client.get(
+                        "/graph/edges",
+                        params={"limit": 10, "min_similarity": 0.5, "neighbours": 1},
+                    )
+
+                assert resp.status_code == 200
+                assert resp.json()["graph_source"] == "snapshot"
+                mock_db.execute.assert_not_called()
+                mock_cache.set.assert_called_once()
+        finally:
+            app.dependency_overrides.pop(get_db, None)


### PR DESCRIPTION
## Summary\n- serve /graph/edges from published snapshot artifacts before live DB reads\n- add graph snapshot config and Cloud Run deploy env wiring\n- add regression tests plus ADR 007 for the permanent fix\n\n## Verification\n- python -m pytest tests/test_graph_snapshot_serving.py tests/test_graph_optimization.py tests/test_graph_viz.py -q\n\n## Jira\n- KAN-119\n