### PR TITLE
fix(sync): send X-Ingest-Key header in nightly populate script

### DIFF
--- a/scripts/populate_from_reporium_db.py
+++ b/scripts/populate_from_reporium_db.py
@@ -75,7 +75,10 @@ async def ingest_batch(
                 resp = await client.post(
                     f"{API_URL}/ingest/repos",
                     json=batch,
-                    headers={"Authorization": f"Bearer {API_KEY}"},
+                    headers={
+                        "Authorization": f"Bearer {API_KEY}",
+                        "X-Ingest-Key": API_KEY,
+                    },
                     timeout=60,
                 )
                 if resp.status_code == 200:
@@ -96,6 +99,10 @@ async def ingest_batch(
                         stats["failed"] += len(batch)
                         stats["error_details"].append(
                             {"batch_names": [r["name"] for r in batch], "status": resp.status_code, "body": resp.text[:200]}
+                        )
+                        print(
+                            f"[ingest-fail] {resp.status_code} {resp.text[:200]}",
+                            file=sys.stderr,
                         )
             except Exception as e:
                 if attempt < MAX_RETRIES - 1:


### PR DESCRIPTION
## Summary

- Nightly ``Sync from reporium-db`` workflow has been red **15 consecutive runs** (2026-04-04 through 2026-04-18), failing 1822/1822 repos silently each night.
- Root cause per RCA (``CONFLUENCE_NIGHTLY_SYNC_FAIL_RCA_2026-04-18.md``): PR #242 (``aba02df``) removed the dev-bypass from ``require_ingest_key``. In prod the ``/ingest/repos`` endpoint now always demands the ``X-Ingest-Key`` header, but ``scripts/populate_from_reporium_db.py`` only sends ``Authorization: Bearer``. Every POST 403s, retries exhaust, workflow exits 1.
- Minimal additive fix: add ``X-Ingest-Key`` header alongside the existing Bearer, and print the failing status/body to stderr so future failures are visible in Actions logs (currently only written to ``scripts/failed_repos.json``, which is not uploaded as an artifact).

## Diff (one file)

``scripts/populate_from_reporium_db.py`` — +8 / -1:
1. Headers dict at ~line 78 now sends both ``Authorization: Bearer {API_KEY}`` and ``X-Ingest-Key: API_KEY``.
2. Non-retryable error branch at ~line 98 now also prints ``[ingest-fail] {status} {body[:200]}`` to stderr.

``sys`` was already imported (line 13). No other logic changed: retry/backoff, fan-out (``CONCURRENCY=20``), batch size (50), schema mapping, endpoint URL, and rate limits are all untouched.

## Assumptions flagged for review

- **``INGESTION_API_KEY`` == server's ``_configured_ingest_header_key()`` expectation.** This PR reuses the same secret for both the Bearer check (``verify_api_key``) and the new ``X-Ingest-Key`` header. This relies on the server-side fallback in ``app/auth.py`` where ``_configured_ingest_header_key()`` falls back to ``INGESTION_API_KEY`` when ``INGEST_API_KEY`` is unset in prod. **If Cloud Run has ``INGEST_API_KEY`` set to a distinct value, this PR will still 403** — in that case a new workflow secret ``INGEST_API_KEY`` should be added and wired into ``sync_from_db.yml`` as a second env var, and the script should read whichever variable is present. Prior agent's reconnaissance indicated ``sync_from_db.yml`` already exports ``INGESTION_API_KEY``; no workflow change is made here.
- Not touched: ``sync_from_db.yml`` (assumed correct per prior recon), any other repo, any other file.
- Nightly workflow was **not** run manually as part of this PR.

## Test plan

- [ ] Verify Cloud Run env: confirm ``INGEST_API_KEY`` (if set) equals ``INGESTION_API_KEY``, or add a separate workflow secret and wire it through (follow-up if needed).
- [ ] After merge + sync into main, trigger ``Nightly Sync from reporium-db`` via ``workflow_dispatch``; expect ``Successfully ingested > 0`` and ``Failed: 0`` (or most landing in ``Already existed`` 409 path).
- [ ] Confirm stderr now shows ``[ingest-fail] ...`` when a batch fails (ideally never fires again, but observability is there for the next regression).

See ``CONFLUENCE_NIGHTLY_SYNC_FAIL_RCA_2026-04-18.md`` for full RCA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)