### PR TITLE
chore(promote): dev→main — Nightly Sync header fix + KAN-165 + KAN-122

### DIFF
--- a/app/models/query_log.py
+++ b/app/models/query_log.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import BigInteger, Boolean, Integer, Numeric, Text, TIMESTAMP
+from sqlalchemy import BigInteger, Boolean, Integer, Numeric, String, Text, TIMESTAMP
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
@@ -15,6 +15,7 @@ class QueryLog(Base):
       - Cost tracking  (tokens_prompt + tokens_completion → cost_usd)
       - Semantic caching (question similarity search)
       - Abuse detection (hashed_ip anomaly detection)
+      - JIRA workflow integration (Workato Recipe 2)
     """
 
     __tablename__ = "query_log"
@@ -46,3 +47,15 @@ class QueryLog(Base):
     # Model metadata
     model: Mapped[str | None] = mapped_column(Text)
     cache_hit: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False, server_default="false")
+
+    # ── JIRA integration fields (KAN-165 / Workato Recipe 2) ─────────────────
+    # Set by Workato after creating a JIRA ticket from the ask
+    jira_ticket_key: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    # "open" | "in_progress" | "done" | "rejected"
+    jira_status: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    # Freeform note of what was done in response
+    action_taken: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Computed spend in cents (input_tokens + output_tokens × model rate)
+    cost_cents: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    # "positive" | "negative" | "neutral" — optional, written by Workato
+    sentiment: Mapped[str | None] = mapped_column(String(16), nullable=True)

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -3,17 +3,19 @@ import json
 import logging
 import os
 from dataclasses import dataclass, field as dc_field
-from datetime import date
+from datetime import date, datetime
+from typing import Optional
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 from slowapi import Limiter
 from slowapi.util import get_remote_address
-from sqlalchemy import delete, func, select, text
+from sqlalchemy import delete, func, select, text, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import require_admin_key, verify_api_key
+from app.models.query_log import QueryLog
 from app.cache import cache
 from app.database import get_db
 from app.models.repo import IngestRun, Repo, RepoCategory, RepoEmbedding, RepoTag
@@ -2169,3 +2171,123 @@ async def backfill_hn_mentions(
         "failed": failed,
         "skipped": skipped,
     }
+
+
+# ── KAN-165: JIRA × Reporium AI ask admin endpoints (Workato Recipe 2) ───────
+
+class AskRow(BaseModel):
+    """Serialised view of a query_log row returned by the asks admin endpoints."""
+
+    id: int
+    created_at: datetime
+    query: str
+    model: Optional[str]
+    input_tokens: Optional[int]
+    output_tokens: Optional[int]
+    cost_cents: Optional[int]
+    jira_ticket_key: Optional[str]
+    jira_status: Optional[str]
+    action_taken: Optional[str]
+    sentiment: Optional[str]
+    latency_ms: Optional[int]
+    user_ip_hash: Optional[str]
+
+    class Config:
+        from_attributes = True
+
+
+class AskPatchRequest(BaseModel):
+    """Partial-update body for PATCH /admin/asks/{ask_id}."""
+
+    jira_ticket_key: Optional[str] = None
+    jira_status: Optional[str] = None
+    action_taken: Optional[str] = None
+    sentiment: Optional[str] = None
+
+
+def _row_to_ask(row: QueryLog) -> dict:
+    return {
+        "id": row.id,
+        "created_at": row.timestamp.isoformat() if row.timestamp else None,
+        "query": row.question,
+        "model": row.model,
+        "input_tokens": row.tokens_prompt,
+        "output_tokens": row.tokens_completion,
+        "cost_cents": row.cost_cents,
+        "jira_ticket_key": row.jira_ticket_key,
+        "jira_status": row.jira_status,
+        "action_taken": row.action_taken,
+        "sentiment": row.sentiment,
+        "latency_ms": row.latency_ms,
+        "user_ip_hash": row.hashed_ip,
+    }
+
+
+@router.get("/admin/asks", response_model=dict)
+async def list_asks(
+    limit: int = Query(default=50, ge=1, le=500),
+    offset: int = Query(default=0, ge=0),
+    since: Optional[datetime] = Query(default=None, description="ISO8601 timestamp — filter created_at >= since"),
+    jira_status: Optional[str] = Query(default=None, description="Filter by jira_status value"),
+    has_ticket: Optional[bool] = Query(default=None, description="When true, only rows with non-null jira_ticket_key"),
+    db: AsyncSession = Depends(get_db),
+    _api_key: str = Depends(verify_api_key),
+    _admin_key: None = Depends(require_admin_key),
+):
+    """List /ask log entries with optional filters. Used by Workato Recipe 2."""
+
+    base_q = select(QueryLog)
+    count_q = select(func.count()).select_from(QueryLog)
+
+    if since is not None:
+        base_q = base_q.where(QueryLog.timestamp >= since)
+        count_q = count_q.where(QueryLog.timestamp >= since)
+
+    if jira_status is not None:
+        base_q = base_q.where(QueryLog.jira_status == jira_status)
+        count_q = count_q.where(QueryLog.jira_status == jira_status)
+
+    if has_ticket is True:
+        base_q = base_q.where(QueryLog.jira_ticket_key.isnot(None))
+        count_q = count_q.where(QueryLog.jira_ticket_key.isnot(None))
+    elif has_ticket is False:
+        base_q = base_q.where(QueryLog.jira_ticket_key.is_(None))
+        count_q = count_q.where(QueryLog.jira_ticket_key.is_(None))
+
+    total_result = await db.execute(count_q)
+    total = total_result.scalar() or 0
+
+    rows_result = await db.execute(
+        base_q.order_by(QueryLog.timestamp.desc()).offset(offset).limit(limit)
+    )
+    rows = rows_result.scalars().all()
+
+    return {
+        "total": total,
+        "asks": [_row_to_ask(r) for r in rows],
+    }
+
+
+@router.patch("/admin/asks/{ask_id}", response_model=dict)
+async def patch_ask(
+    ask_id: int,
+    body: AskPatchRequest,
+    db: AsyncSession = Depends(get_db),
+    _api_key: str = Depends(verify_api_key),
+    _admin_key: None = Depends(require_admin_key),
+):
+    """Partially update a query_log row (JIRA fields). Called by Workato Recipe 2."""
+
+    result = await db.execute(select(QueryLog).where(QueryLog.id == ask_id))
+    row = result.scalar_one_or_none()
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"Ask {ask_id} not found")
+
+    patch_data = body.model_dump(exclude_unset=True)
+    if patch_data:
+        for field, value in patch_data.items():
+            setattr(row, field, value)
+        await db.commit()
+        await db.refresh(row)
+
+    return _row_to_ask(row)

--- a/app/routers/platform.py
+++ b/app/routers/platform.py
@@ -63,6 +63,33 @@ async def metrics_latest(
         await db.execute(select(func.max(Repo.updated_at)))
     ).scalar_one()
 
+    # KAN-122: additive aliases expected by the frontend dashboard.
+    # total_public_repos / repos_with_embeddings exclude private repos.
+    counts_row = (
+        await db.execute(
+            text(
+                """
+                SELECT
+                    (SELECT COUNT(*) FROM repos WHERE is_private = false) AS total_public,
+                    (SELECT COUNT(DISTINCT re.repo_id)
+                     FROM repo_embeddings re
+                     JOIN repos r ON r.id = re.repo_id
+                     WHERE r.is_private = false
+                       AND re.embedding_vec IS NOT NULL) AS with_embeddings
+                """
+            )
+        )
+    ).fetchone()
+    total_public = int(counts_row.total_public or 0) if counts_row else 0
+    with_embeddings = int(counts_row.with_embeddings or 0) if counts_row else 0
+
+    # snapshot_generated_at: read from the in-memory snapshot cache so this
+    # endpoint needs no extra GCS round-trip.
+    from app.graph_snapshot import _snapshot_cache  # local import; module already loaded
+    snapshot_generated_at = (
+        _snapshot_cache.get("generated_at") if _snapshot_cache else None
+    )
+
     return {
         "repos_tracked": total,
         "repos_with_ai_skills": repos_with_skills,
@@ -71,6 +98,10 @@ async def metrics_latest(
         "last_sync": last_updated.isoformat() if last_updated else None,
         "api_version": os.getenv("APP_VERSION", os.getenv("GITHUB_SHA", "unknown")[:7]),
         "build_number": os.getenv("BUILD_NUMBER", "0"),
+        # Frontend-expected aliases (additive — do NOT remove the keys above)
+        "total_public_repos": total_public,
+        "repos_with_embeddings": with_embeddings,
+        "snapshot_generated_at": snapshot_generated_at,
     }
 
 

--- a/migrations/versions/037_query_log_jira_fields.py
+++ b/migrations/versions/037_query_log_jira_fields.py
@@ -1,0 +1,56 @@
+"""Add JIRA integration fields to query_log for Workato Recipe 2.
+
+Changes:
+  1. jira_ticket_key VARCHAR(32) NULL  — JIRA ticket created from the ask
+  2. jira_status     VARCHAR(32) NULL  — "open" | "in_progress" | "done" | "rejected"
+  3. action_taken    TEXT NULL         — freeform note of resolution
+  4. cost_cents      INTEGER NULL      — aggregated spend (input+output tokens × model rate)
+  5. sentiment       VARCHAR(16) NULL  — "positive" | "negative" | "neutral"
+
+  Indexes:
+  - idx_query_log_created_at_desc  (created_at DESC) — dashboard time-range queries
+  - idx_query_log_jira_ticket_key  partial on non-null jira_ticket_key — Workato lookups
+
+Revision ID: 037
+Revises: 036
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "037"
+down_revision = "036"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("query_log", sa.Column("jira_ticket_key", sa.String(32), nullable=True))
+    op.add_column("query_log", sa.Column("jira_status", sa.String(32), nullable=True))
+    op.add_column("query_log", sa.Column("action_taken", sa.Text(), nullable=True))
+    op.add_column("query_log", sa.Column("cost_cents", sa.Integer(), nullable=True))
+    op.add_column("query_log", sa.Column("sentiment", sa.String(16), nullable=True))
+
+    # Index for time-range dashboard queries (DESC matches typical ORDER BY)
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_query_log_created_at_desc
+        ON query_log (timestamp DESC)
+    """)
+
+    # Sparse index — only rows where a JIRA ticket has been assigned
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS idx_query_log_jira_ticket_key
+        ON query_log (jira_ticket_key)
+        WHERE jira_ticket_key IS NOT NULL
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS idx_query_log_jira_ticket_key")
+    op.execute("DROP INDEX IF EXISTS idx_query_log_created_at_desc")
+    op.drop_column("query_log", "sentiment")
+    op.drop_column("query_log", "cost_cents")
+    op.drop_column("query_log", "action_taken")
+    op.drop_column("query_log", "jira_status")
+    op.drop_column("query_log", "jira_ticket_key")

--- a/scripts/populate_from_reporium_db.py
+++ b/scripts/populate_from_reporium_db.py
@@ -75,7 +75,10 @@ async def ingest_batch(
                 resp = await client.post(
                     f"{API_URL}/ingest/repos",
                     json=batch,
-                    headers={"Authorization": f"Bearer {API_KEY}"},
+                    headers={
+                        "Authorization": f"Bearer {API_KEY}",
+                        "X-Ingest-Key": API_KEY,
+                    },
                     timeout=60,
                 )
                 if resp.status_code == 200:
@@ -96,6 +99,10 @@ async def ingest_batch(
                         stats["failed"] += len(batch)
                         stats["error_details"].append(
                             {"batch_names": [r["name"] for r in batch], "status": resp.status_code, "body": resp.text[:200]}
+                        )
+                        print(
+                            f"[ingest-fail] {resp.status_code} {resp.text[:200]}",
+                            file=sys.stderr,
                         )
             except Exception as e:
                 if attempt < MAX_RETRIES - 1:

--- a/tests/test_admin_asks.py
+++ b/tests/test_admin_asks.py
@@ -1,0 +1,224 @@
+"""Tests for KAN-165: GET /admin/asks and PATCH /admin/asks/{ask_id}.
+
+These are integration tests that run against the in-memory test DB (SQLite
+via conftest.py's _setup_db fixture which creates tables from ORM metadata).
+"""
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+
+from app.database import async_session_factory
+from app.models.query_log import QueryLog
+from tests.conftest import AUTH_HEADERS, TEST_API_KEY
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _insert_query_log(question: str = "test question", **kwargs) -> int:
+    """Insert a QueryLog row directly and return its id."""
+    async with async_session_factory() as session:
+        row = QueryLog(question=question, **kwargs)
+        session.add(row)
+        await session.commit()
+        await session.refresh(row)
+        return row.id
+
+
+# ---------------------------------------------------------------------------
+# Auth guards
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_list_asks_requires_api_key(client: AsyncClient):
+    response = await client.get("/admin/asks")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_patch_ask_requires_api_key(client: AsyncClient):
+    response = await client.patch("/admin/asks/1", json={"jira_status": "open"})
+    assert response.status_code == 403
+
+
+# ---------------------------------------------------------------------------
+# GET /admin/asks — basic shape
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_list_asks_returns_correct_shape(client: AsyncClient):
+    response = await client.get("/admin/asks", headers=AUTH_HEADERS)
+    assert response.status_code == 200
+    data = response.json()
+    assert "total" in data
+    assert "asks" in data
+    assert isinstance(data["total"], int)
+    assert isinstance(data["asks"], list)
+
+
+@pytest.mark.asyncio
+async def test_list_asks_row_contains_expected_fields(client: AsyncClient):
+    ask_id = await _insert_query_log(
+        question="what is rag?",
+        model="haiku",
+        tokens_prompt=100,
+        tokens_completion=200,
+        cost_cents=1,
+        latency_ms=350,
+    )
+    response = await client.get("/admin/asks", headers=AUTH_HEADERS)
+    assert response.status_code == 200
+    data = response.json()
+    # Find our row
+    matching = [a for a in data["asks"] if a["id"] == ask_id]
+    assert len(matching) == 1
+    row = matching[0]
+    expected_keys = {
+        "id", "created_at", "query", "model",
+        "input_tokens", "output_tokens", "cost_cents",
+        "jira_ticket_key", "jira_status", "action_taken",
+        "sentiment", "latency_ms", "user_ip_hash",
+    }
+    assert expected_keys == set(row.keys())
+    assert row["query"] == "what is rag?"
+    assert row["model"] == "haiku"
+    assert row["input_tokens"] == 100
+    assert row["output_tokens"] == 200
+    assert row["cost_cents"] == 1
+    assert row["latency_ms"] == 350
+    assert row["jira_ticket_key"] is None
+    assert row["jira_status"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_asks_limit_enforced(client: AsyncClient):
+    # Insert 3 rows
+    for i in range(3):
+        await _insert_query_log(question=f"limit test question {i}")
+
+    response = await client.get("/admin/asks?limit=2", headers=AUTH_HEADERS)
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data["asks"]) <= 2
+
+
+@pytest.mark.asyncio
+async def test_list_asks_limit_max_500(client: AsyncClient):
+    response = await client.get("/admin/asks?limit=501", headers=AUTH_HEADERS)
+    assert response.status_code == 422  # FastAPI validation error
+
+
+@pytest.mark.asyncio
+async def test_list_asks_filter_jira_status(client: AsyncClient):
+    await _insert_query_log(question="open ticket q", jira_ticket_key="KAN-900", jira_status="open")
+    await _insert_query_log(question="done ticket q", jira_ticket_key="KAN-901", jira_status="done")
+
+    response = await client.get("/admin/asks?jira_status=open", headers=AUTH_HEADERS)
+    assert response.status_code == 200
+    data = response.json()
+    assert all(a["jira_status"] == "open" for a in data["asks"])
+
+
+@pytest.mark.asyncio
+async def test_list_asks_filter_has_ticket_true(client: AsyncClient):
+    await _insert_query_log(question="has ticket q", jira_ticket_key="KAN-902", jira_status="open")
+    await _insert_query_log(question="no ticket q")
+
+    response = await client.get("/admin/asks?has_ticket=true", headers=AUTH_HEADERS)
+    assert response.status_code == 200
+    data = response.json()
+    assert all(a["jira_ticket_key"] is not None for a in data["asks"])
+
+
+@pytest.mark.asyncio
+async def test_list_asks_filter_has_ticket_false(client: AsyncClient):
+    response = await client.get("/admin/asks?has_ticket=false", headers=AUTH_HEADERS)
+    assert response.status_code == 200
+    data = response.json()
+    assert all(a["jira_ticket_key"] is None for a in data["asks"])
+
+
+# ---------------------------------------------------------------------------
+# PATCH /admin/asks/{ask_id}
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_patch_ask_404_when_not_found(client: AsyncClient):
+    response = await client.patch(
+        "/admin/asks/999999999",
+        json={"jira_status": "open"},
+        headers=AUTH_HEADERS,
+    )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_patch_ask_sets_jira_ticket_key(client: AsyncClient):
+    ask_id = await _insert_query_log(question="workato patch test")
+
+    response = await client.patch(
+        f"/admin/asks/{ask_id}",
+        json={"jira_ticket_key": "KAN-165", "jira_status": "open"},
+        headers=AUTH_HEADERS,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["jira_ticket_key"] == "KAN-165"
+    assert data["jira_status"] == "open"
+    assert data["id"] == ask_id
+
+
+@pytest.mark.asyncio
+async def test_patch_ask_partial_update(client: AsyncClient):
+    ask_id = await _insert_query_log(
+        question="partial patch test",
+        jira_ticket_key="KAN-200",
+        jira_status="open",
+    )
+
+    # Only update jira_status — other fields should be unchanged
+    response = await client.patch(
+        f"/admin/asks/{ask_id}",
+        json={"jira_status": "done"},
+        headers=AUTH_HEADERS,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["jira_status"] == "done"
+    assert data["jira_ticket_key"] == "KAN-200"  # unchanged
+
+
+@pytest.mark.asyncio
+async def test_patch_ask_sets_action_taken_and_sentiment(client: AsyncClient):
+    ask_id = await _insert_query_log(question="sentiment test")
+
+    response = await client.patch(
+        f"/admin/asks/{ask_id}",
+        json={"action_taken": "Promoted to KAN-999", "sentiment": "positive"},
+        headers=AUTH_HEADERS,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["action_taken"] == "Promoted to KAN-999"
+    assert data["sentiment"] == "positive"
+
+
+@pytest.mark.asyncio
+async def test_patch_ask_empty_body_is_noop(client: AsyncClient):
+    ask_id = await _insert_query_log(
+        question="noop patch test",
+        jira_ticket_key="KAN-123",
+        jira_status="in_progress",
+    )
+
+    response = await client.patch(
+        f"/admin/asks/{ask_id}",
+        json={},
+        headers=AUTH_HEADERS,
+    )
+    assert response.status_code == 200
+    data = response.json()
+    assert data["jira_ticket_key"] == "KAN-123"
+    assert data["jira_status"] == "in_progress"

--- a/tests/test_platform_metrics.py
+++ b/tests/test_platform_metrics.py
@@ -1,0 +1,28 @@
+"""KAN-122: Tests for /metrics/latest frontend alias fields."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_metrics_latest_exposes_frontend_aliases(client):
+    """KAN-122: /metrics/latest must include frontend-expected alias fields (additive)."""
+    resp = await client.get("/metrics/latest")
+    assert resp.status_code == 200
+    data = resp.json()
+
+    # Original fields must not be removed
+    assert "repos_tracked" in data
+    assert "repos_with_ai_skills" in data
+    assert "last_sync" in data
+
+    # Additive aliases required by the frontend dashboard
+    assert "total_public_repos" in data, "Missing alias: total_public_repos"
+    assert "repos_with_embeddings" in data, "Missing alias: repos_with_embeddings"
+    assert "snapshot_generated_at" in data, "Missing alias: snapshot_generated_at"
+
+    assert isinstance(data["total_public_repos"], int)
+    assert isinstance(data["repos_with_embeddings"], int)
+    # snapshot_generated_at may be None when no snapshot is loaded in tests
+    assert data["snapshot_generated_at"] is None or isinstance(data["snapshot_generated_at"], str)

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -19,3 +19,41 @@ async def test_health_always_returns_ok(client: AsyncClient):
     for _ in range(5):
         response = await client.get("/health")
         assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_library_full_rate_limit_integration(client: AsyncClient):
+    """KAN-123: /library/full must be reachable and have rate limiting configured.
+
+    Rate limiting is disabled in the test environment (RATELIMIT_ENABLED=0) so
+    we can't trigger a real 429, but we verify:
+    1. The endpoint responds (200 or 404 on empty DB — never 500).
+    2. The per-route limiter decorator is wired by asserting the route exists in
+       the OpenAPI schema.
+    """
+    # Smoke: endpoint must not 500
+    response = await client.get("/library/full", params={"page": 1, "page_size": 1})
+    assert response.status_code in (200, 404), (
+        f"/library/full returned unexpected status {response.status_code}"
+    )
+
+    # Rate limiter must be registered: verify via OpenAPI paths
+    openapi_response = await client.get("/openapi.json")
+    assert openapi_response.status_code == 200
+    paths = openapi_response.json().get("paths", {})
+    assert "/library/full" in paths, (
+        "/library/full must be present in OpenAPI schema — "
+        "missing route means the rate limiter decorator removed the endpoint"
+    )
+
+
+@pytest.mark.asyncio
+async def test_library_full_rate_limit_configuration():
+    """KAN-123: Verify @_limiter.limit('5/minute') is set on library_full handler."""
+    from app.routers.library_full import library_full
+
+    # slowapi stores the rate limit string on the handler via _rate_limit_decorated
+    limit_value = getattr(library_full, "_rate_limit_decorated", None)
+    if limit_value is None:
+        pytest.skip("slowapi decorator introspection not available in this version")
+    assert "5/minute" in str(limit_value)


### PR DESCRIPTION
## Summary

Promote dev to main to ship the Nightly Sync pipeline restore.

## Commits included

- `0e3f659` fix(sync): send X-Ingest-Key header in nightly populate script (#358) — **restores 15 days of silent failures since 2026-04-04**
- `e2caca5` KAN-165: add JIRA integration fields to query_log + GET/PATCH /admin/asks (#356)
- `2e71763` KAN-122: feat: add frontend alias fields to /metrics/latest (#355)
- `184d65d` (merge main→dev)

## Why now

Current deployed revision `reporium-api-00209-ckp` (built 2026-04-16 07:36 UTC) does not include the sync fix. Next scheduled Nightly Sync (07:00 UTC daily cron) will continue to fail silently against the unchanged server contract until this promote lands.

## Risk

Low — all three feature commits shipped through their own PRs with green CI on dev. GITHUB_TOKEN env binding already wired on Cloud Run (for /admin/backfill-community-signals and /admin/backfill-dependencies) via `gcloud run services update`; `deploy.yml` uses `env_vars_update_strategy: merge` so the binding persists.

## Test plan

- [x] CI green on dev for all three commits
- [ ] `deploy.yml` completes on merge
- [ ] Post-deploy smoke: /health 200, /graph/edges has DEPENDS_ON
- [ ] Manually trigger Nightly Sync via workflow_dispatch; verify 1641/1641 ingested and no 403s in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)