### PR TITLE
fix(cors): allow reposhark.vercel.app (public frontend)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -243,7 +243,7 @@ if os.getenv("ENVIRONMENT") != "production":
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_ALLOWED_ORIGINS,
-    allow_origin_regex=r"https://reporium(-[a-z0-9]+)*\.vercel\.app",
+    allow_origin_regex=r"https://(reporium|reposhark)(-[a-z0-9]+)*\.vercel\.app",
     allow_methods=["GET", "POST"],
     allow_headers=["Authorization", "Content-Type", "X-Admin-Key", "X-Ingest-Key", "X-App-Token", "X-Sandbox", "Accept"],
 )

--- a/tests/test_cors.py
+++ b/tests/test_cors.py
@@ -26,6 +26,27 @@ async def test_cors_allowed_origin_github_pages(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_cors_allowed_origin_reposhark_vercel(client: AsyncClient):
+    """reposhark.vercel.app (public frontend) must be allowed."""
+    response = await client.get("/health", headers={"Origin": "https://reposhark.vercel.app"})
+    assert response.headers.get("access-control-allow-origin") == "https://reposhark.vercel.app"
+
+
+@pytest.mark.asyncio
+async def test_cors_allowed_origin_reposhark_preview(client: AsyncClient):
+    """reposhark-<hash>.vercel.app preview deploys must be allowed."""
+    response = await client.get("/health", headers={"Origin": "https://reposhark-git-main.vercel.app"})
+    assert response.headers.get("access-control-allow-origin") == "https://reposhark-git-main.vercel.app"
+
+
+@pytest.mark.asyncio
+async def test_cors_allowed_origin_reporium_vercel(client: AsyncClient):
+    """Legacy reporium.vercel.app must remain allowed."""
+    response = await client.get("/health", headers={"Origin": "https://reporium.vercel.app"})
+    assert response.headers.get("access-control-allow-origin") == "https://reporium.vercel.app"
+
+
+@pytest.mark.asyncio
 async def test_cors_blocked_unknown_origin(client: AsyncClient):
     """Unknown origins must not receive allow-origin header."""
     response = await client.get("/health", headers={"Origin": "https://evil.example.com"})


### PR DESCRIPTION
## Why
The public frontend redirects `reporium.vercel.app` → `reposhark.vercel.app`, but the API CORS regex only matched `reporium(-*).vercel.app`. Every browser API call from the live site was preflight-blocked, so HomePageClient fell into its degraded-API fallback and displayed:

> Live data is unavailable right now — showing your last cached snapshot.

Verified: `curl -X OPTIONS -H 'Origin: https://reposhark.vercel.app' ...` returns 400 with no `access-control-allow-origin` header.

## Change
```
- allow_origin_regex=r"https://reporium(-[a-z0-9]+)*\.vercel\.app"
+ allow_origin_regex=r"https://(reporium|reposhark)(-[a-z0-9]+)*\.vercel\.app"
```

Plus three new CORS tests: reposhark apex, reposhark preview hash, legacy reporium still allowed.