### PR TITLE
hotfix: raise /library/full rate limit 5/min -> 60/min

### DIFF
--- a/app/routers/library_full.py
+++ b/app/routers/library_full.py
@@ -1330,7 +1330,10 @@ async def _fetch_aggregates(db: AsyncSession) -> dict:
 
 
 @router.get("/library/full", response_model=dict)
-@_limiter.limit("5/minute")
+# 60/minute: the frontend paginates (page_size=500, ~4 pages) so a single
+# homepage load consumes ~4 requests. 5/minute caused 429s on any refresh.
+# Responses are served from Redis + in-memory cache so cost is negligible.
+@_limiter.limit("60/minute")
 async def library_full(
     request: Request,
     response: Response,


### PR DESCRIPTION
## Summary
Fixes homepage "Live data is unavailable right now — showing your last cached snapshot" banner.

**Root cause:** frontend paginates /library/full with page_size=500. With 1,825 repos in the corpus, a single homepage load fires 4 parallel requests. Rate limit was 5/minute, so one refresh consumed 4/5 of quota. Any second refresh or nav-back within 60s hit 429 -> fallback to static JSON -> degraded banner.

**Fix:** raise limit to 60/minute. Responses are served from Redis + in-memory cache so compute cost is negligible regardless of rate.

## Test plan
- [x] curl /library/full 5x in a row returns 200s (no 429)
- [ ] Homepage on reposhark.vercel.app / reporium.com no longer shows degraded banner on refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)