### PR TITLE
fix: remove misleading X-RateLimit-Policy static header

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -294,7 +294,6 @@ async def log_requests(request: Request, call_next):
 @app.middleware("http")
 async def add_security_headers(request: Request, call_next):
     response = await call_next(request)
-    response.headers["X-RateLimit-Policy"] = "200/hour;30/minute"
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"
     response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"

--- a/tests/test_rate_limiting.py
+++ b/tests/test_rate_limiting.py
@@ -6,11 +6,17 @@ from httpx import AsyncClient
 
 @pytest.mark.asyncio
 async def test_rate_limit_headers_present(client: AsyncClient):
-    """Every response must include rate limit policy header."""
+    """Per-endpoint rate limits are set via @_limiter.limit() decorators.
+
+    slowapi emits accurate X-RateLimit-Limit/Remaining/Reset headers when
+    limits are hit. The static X-RateLimit-Policy header was removed (it
+    contained a hardcoded "200/hour;30/minute" that didn't match actual
+    per-endpoint limits like 60/minute, 10/minute, etc).
+    """
     response = await client.get("/health")
     assert response.status_code == 200
-    assert "X-RateLimit-Policy" in response.headers
-    assert response.headers["X-RateLimit-Policy"] == "200/hour;30/minute"
+    # Verify no misleading static header exists
+    assert "X-RateLimit-Policy" not in response.headers
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Removed the hardcoded `X-RateLimit-Policy: 200/hour;30/minute` header that was unconditionally set on every response.

## Problem

- **Line 297 in app/main.py** was setting a static header claiming limits of "200/hour;30/minute"
- **Actual per-endpoint limits vary widely**: 60/minute (/library/full), 30/minute, 20/minute, 10/minute, 5/minute
- Header was consistently false across all endpoints
- Clients relying on this header would get incorrect limit information

## Solution

**Option A (chosen)**: Removed the static header assignment. slowapi already emits accurate `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` headers per endpoint when limits are hit.

## Changes

- Removed line 297: `response.headers["X-RateLimit-Policy"] = "200/hour;30/minute"`
- Updated test in `tests/test_rate_limiting.py` to verify the misleading header is no longer present

## Test Status

Local pytest infrastructure issue (database connection) prevents running full suite, but:
- Syntax validation: PASS (py_compile on app/main.py)
- Change scope: Only app/main.py and test_rate_limiting.py modified
- No rate-limit values or decorators changed
