### PR TITLE
security: rate-limit missing /ingest/* + /ingest/events/* endpoints

### DIFF
--- a/.github/workflows/ask-quality-gate.yml
+++ b/.github/workflows/ask-quality-gate.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/backfill_built_repos.yml
+++ b/.github/workflows/backfill_built_repos.yml
@@ -11,11 +11,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
-      - uses: google-github-actions/auth@v2
+      - uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.9
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 

--- a/.github/workflows/data-quality.yml
+++ b/.github/workflows/data-quality.yml
@@ -13,14 +13,14 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.9
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,11 +13,11 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 
-      - uses: google-github-actions/auth@v2
+      - uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.9
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
@@ -51,7 +51,7 @@ jobs:
           # reporium-alembic Cloud Run Job when adding new migrations.
           alembic upgrade head || echo "Migration step skipped (runner cannot reach private Cloud SQL)"
 
-      - uses: google-github-actions/deploy-cloudrun@v2
+      - uses: google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522 # v2.7.6
         id: deploy
         with:
           service: reporium-api

--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -30,7 +30,7 @@ jobs:
       REDIS_URL: ""
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
       - run: pip install -r requirements.txt pytest pytest-asyncio httpx pytest-timeout==2.3.1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           fetch-depth: 20
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
       - run: pip install git+https://github.com/perditioinc/reporium-security.git

--- a/.github/workflows/sync_from_db.yml
+++ b/.github/workflows/sync_from_db.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 

--- a/.github/workflows/warmup.yml
+++ b/.github/workflows/warmup.yml
@@ -7,6 +7,9 @@ on:
     - cron: '*/10 0-2 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   ping:
     runs-on: ubuntu-latest

--- a/app/routers/ingest.py
+++ b/app/routers/ingest.py
@@ -400,7 +400,9 @@ async def ingest_repos(
 
 
 @router.post("/repos/{name}/enrich", response_model=dict)
+@limiter.limit("600/minute")  # belt-and-suspenders; endpoint is X-Ingest-Key gated
 async def enrich_repo(
+    request: Request,
     name: str,
     item: RepoEnrichItem,
     db: AsyncSession = Depends(get_db),
@@ -445,7 +447,9 @@ async def enrich_repo(
 
 
 @router.post("/trends/snapshot", response_model=list[TrendSnapshotOut])
+@limiter.limit("600/minute")  # belt-and-suspenders; endpoint is X-Ingest-Key gated
 async def ingest_trend_snapshot(
+    request: Request,
     items: list[TrendSnapshotIn],
     db: AsyncSession = Depends(get_db),
 ) -> list[TrendSnapshotOut]:
@@ -466,7 +470,9 @@ async def ingest_trend_snapshot(
 
 
 @router.post("/gaps", response_model=list[GapAnalysisOut])
+@limiter.limit("600/minute")  # belt-and-suspenders; endpoint is X-Ingest-Key gated
 async def ingest_gaps(
+    request: Request,
     items: list[GapAnalysisIn],
     db: AsyncSession = Depends(get_db),
 ) -> list[GapAnalysisOut]:
@@ -486,7 +492,9 @@ async def ingest_gaps(
 
 
 @router.post("/log", response_model=IngestionLogOut)
+@limiter.limit("600/minute")  # belt-and-suspenders; endpoint is X-Ingest-Key gated
 async def ingest_log(
+    request: Request,
     item: IngestionLogIn,
     db: AsyncSession = Depends(get_db),
 ) -> IngestionLogOut:
@@ -524,6 +532,7 @@ async def ingest_log(
 
 
 @events_router.post("/repo-ingested", response_model=dict)
+@limiter.limit("600/minute")  # belt-and-suspenders; endpoint is X-Ingest-Key gated
 async def repo_ingested_event(
     request: Request,
     db: AsyncSession = Depends(get_db),
@@ -569,6 +578,7 @@ async def repo_ingested_event(
 # ---------------------------------------------------------------------------
 
 @events_router.post("/repo-added", response_model=dict)
+@limiter.limit("600/minute")  # belt-and-suspenders; endpoint is X-Ingest-Key gated
 async def repo_added_event(
     request: Request,
     db: AsyncSession = Depends(get_db),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,6 @@
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
 timeout = 30
+markers = [
+    "invariants: nightly data-invariant tests — only run when STAGING_API_URL is set",
+]

--- a/tests/test_rate_limit_regression.py
+++ b/tests/test_rate_limit_regression.py
@@ -1,0 +1,102 @@
+"""
+Regression guard: rate-limit decorators on ingest/* and ingest/events/* endpoints.
+
+These tests assert the presence of the @limiter.limit decorator on every
+POST/PUT/DELETE endpoint in ingest.py that was missing rate limiting (P1 finding
+from security-sweep-batch1, 2026-04-20).
+
+Strategy: inspect source code of each handler to confirm the decorator literal
+is present. This prevents silent revert of rate-limit decorators.
+
+Note: RATELIMIT_ENABLED=0 in the test environment, so 429 responses are not
+triggered. We're verifying the decorator is wired, not functional behavior.
+"""
+
+import inspect
+
+import pytest
+
+
+def _get_limit_string(handler) -> str:
+    """Extract the rate-limit string from a slowapi-decorated handler's source."""
+    return inspect.getsource(handler)
+
+
+class TestIngestRateLimitDecorators:
+    """Asserts that each previously-unprotected ingest endpoint has a rate-limit decorator."""
+
+    def test_enrich_repo_has_rate_limit(self):
+        from app.routers import ingest
+        src = _get_limit_string(ingest.enrich_repo)
+        assert "600/minute" in src, (
+            "enrich_repo must have @limiter.limit('600/minute') — "
+            "P1 security finding: missing rate limit on X-Ingest-Key gated endpoint"
+        )
+
+    def test_ingest_trend_snapshot_has_rate_limit(self):
+        from app.routers import ingest
+        src = _get_limit_string(ingest.ingest_trend_snapshot)
+        assert "600/minute" in src, (
+            "ingest_trend_snapshot must have @limiter.limit('600/minute') — "
+            "P1 security finding: missing rate limit on X-Ingest-Key gated endpoint"
+        )
+
+    def test_ingest_gaps_has_rate_limit(self):
+        from app.routers import ingest
+        src = _get_limit_string(ingest.ingest_gaps)
+        assert "600/minute" in src, (
+            "ingest_gaps must have @limiter.limit('600/minute') — "
+            "P1 security finding: missing rate limit on X-Ingest-Key gated endpoint"
+        )
+
+    def test_ingest_log_has_rate_limit(self):
+        from app.routers import ingest
+        src = _get_limit_string(ingest.ingest_log)
+        assert "600/minute" in src, (
+            "ingest_log must have @limiter.limit('600/minute') — "
+            "P1 security finding: missing rate limit on X-Ingest-Key gated endpoint"
+        )
+
+    def test_repo_ingested_event_has_rate_limit(self):
+        from app.routers import ingest
+        src = _get_limit_string(ingest.repo_ingested_event)
+        assert "600/minute" in src, (
+            "repo_ingested_event must have @limiter.limit('600/minute') — "
+            "P1 security finding: missing rate limit on X-Ingest-Key gated event endpoint"
+        )
+
+    def test_repo_added_event_has_rate_limit(self):
+        from app.routers import ingest
+        src = _get_limit_string(ingest.repo_added_event)
+        assert "600/minute" in src, (
+            "repo_added_event must have @limiter.limit('600/minute') — "
+            "P1 security finding: missing rate limit on X-Ingest-Key gated event endpoint"
+        )
+
+    def test_ingest_repos_existing_rate_limit_unchanged(self):
+        """Verify the pre-existing 200/minute limit on /ingest/repos was not changed."""
+        from app.routers import ingest
+        src = _get_limit_string(ingest.ingest_repos)
+        assert "200/minute" in src, (
+            "ingest_repos must retain @limiter.limit('200/minute') — "
+            "do not change existing rate limits"
+        )
+
+    def test_all_newly_limited_endpoints_have_request_param(self):
+        """slowapi requires `request: Request` as first param for the limiter to work."""
+        from app.routers import ingest
+
+        handlers = [
+            ("enrich_repo", ingest.enrich_repo),
+            ("ingest_trend_snapshot", ingest.ingest_trend_snapshot),
+            ("ingest_gaps", ingest.ingest_gaps),
+            ("ingest_log", ingest.ingest_log),
+            ("repo_ingested_event", ingest.repo_ingested_event),
+            ("repo_added_event", ingest.repo_added_event),
+        ]
+        for name, handler in handlers:
+            sig = inspect.signature(handler)
+            params = list(sig.parameters.keys())
+            assert "request" in params, (
+                f"{name} must have `request: Request` parameter for slowapi to function"
+            )


### PR DESCRIPTION
## Summary

Addresses P1 from `.audit/2026-04-20/security-sweep-batch1.md`.

## Validation Results (pre-fix analysis)

All 6 endpoints flagged in the audit are gated by `X-Ingest-Key` at the router level (`dependencies=[Depends(verify_api_key), Depends(require_ingest_key)]`). Per security brief, auth-gated endpoints receive `@limiter.limit("600/minute")` as belt-and-suspenders defense-in-depth.

| Endpoint | Auth Gate | Rate Limit Added |
|---|---|---|
| `POST /ingest/repos` | X-Ingest-Key | ✓ Already had 200/minute (unchanged) |
| `POST /ingest/repos/{name}/enrich` | X-Ingest-Key | ✓ Added 600/minute |
| `POST /ingest/trends/snapshot` | X-Ingest-Key | ✓ Added 600/minute |
| `POST /ingest/gaps` | X-Ingest-Key | ✓ Added 600/minute |
| `POST /ingest/log` | X-Ingest-Key | ✓ Added 600/minute |
| `POST /ingest/events/repo-ingested` | X-Ingest-Key + PubSub | ✓ Added 600/minute |
| `POST /ingest/events/repo-added` | X-Ingest-Key + PubSub | ✓ Added 600/minute |

Note: `/admin/*` and `/taxonomy/*` endpoints are all `X-Admin-Key` gated — no changes needed there.

## Files Changed

- `app/routers/ingest.py` — 6 new `@limiter.limit("600/minute")` decorators; 4 handlers gained `request: Request` param required by slowapi
- `tests/test_rate_limit_regression.py` — **new file**: 8 tests assert decorator presence via `inspect.getsource()` to prevent silent revert
- `.github/workflows/*.yml` (9 files) — SHA-pin all `actions/*` and `google-github-actions/*`; add `permissions: { contents: read }` to `warmup.yml`

## Test Results

- **Rate limit regression tests**: 8/8 pass (pure unit tests, no DB required)
- **Full pytest suite**: DB-connection-dependent tests fail locally (no Cloud SQL in local env — same pre-existing condition on `dev` baseline)
- **CI will run** the full suite on push against the test DB

## CORS note

Audit finding P2 (CORS regex breadth) is deliberately not addressed here — it's a P2, not P1, and the regex is correctly scoped per `.audit/2026-04-20/security-sweep-batch1.md` assessment.