### PR TITLE
fix(api): surface community-health fields + include tags/categories in taxonomy ingest

### DIFF
--- a/app/routers/ingest.py
+++ b/app/routers/ingest.py
@@ -66,6 +66,11 @@ _TAXONOMY_DIMENSION_MAP = {
     "modalities": "modality",
     "ai_trends": "ai_trend",
     "deployment_context": "deployment_context",
+    # Tags and categories are stored in their own junction tables (repo_tags,
+    # repo_categories) but also need to flow into repo_taxonomy so the /taxonomy
+    # endpoints and rebuild job can surface them as dimensions.
+    "tags": "tag",
+    "categories": "category",
 }
 
 
@@ -286,6 +291,15 @@ async def _upsert_repo_taxonomy(db: AsyncSession, repo_id, item_dict: dict) -> N
         for raw_value in values:
             if not raw_value:
                 continue
+            # Categories arrive as dicts (category_id/category_name/is_primary);
+            # flatten to the human-readable name so the taxonomy surface is
+            # consistent with how other dimensions store raw_value as a string.
+            if isinstance(raw_value, dict):
+                raw_value = raw_value.get("category_name") or raw_value.get("category_id")
+                if not raw_value:
+                    continue
+            if not isinstance(raw_value, str):
+                raw_value = str(raw_value)
             await db.execute(
                 _text(
                     "INSERT INTO repo_taxonomy (repo_id, dimension, raw_value, assigned_by) "

--- a/app/routers/repos.py
+++ b/app/routers/repos.py
@@ -381,6 +381,12 @@ async def repo_evaluation(
         "owner": repo.owner,
         "evaluation": repo.pros_cons,
         "generated_at": repo.pros_cons_generated_at.isoformat() if repo.pros_cons_generated_at else None,
+        # Community-health signals — surface alongside AI-generated evaluation so
+        # consumers can cross-reference the model's verdict with raw metrics.
+        "contributors_count": repo.contributors_count,
+        "issue_close_rate": repo.issue_close_rate,
+        "pr_merge_rate": repo.pr_merge_rate,
+        "community_health_pct": repo.community_health_pct,
     }
 
 

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -241,3 +241,45 @@ async def test_repo_ingested_event_skips_embed_failure_and_still_returns_200(cli
     assert data["portfolio_insights"]["taxonomy_gap_count"] == 4
     assert invalidate_cache.await_count == 3
     invalidate_memory.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_ingest_flows_tags_and_categories_into_repo_taxonomy(client: AsyncClient):
+    """Regression: tags and categories from the ingest payload must be written
+    into repo_taxonomy so /taxonomy/* endpoints can surface them as dimensions.
+    Previously these were excluded alongside junction-table fields, leaving
+    /taxonomy blind to them.
+    """
+    from sqlalchemy import text as _text
+    import app.database as db_module
+
+    fixture = {
+        **TEST_REPO_FIXTURE,
+        "name": "taxonomy-flow-repo",
+        "github_url": "https://github.com/testuser/taxonomy-flow-repo",
+        "tags": ["ai", "rag", "vector-db"],
+        "categories": [
+            {"category_id": "ai-agents", "category_name": "AI Agents", "is_primary": True},
+            {"category_id": "dev-tools", "category_name": "Developer Tools", "is_primary": False},
+        ],
+    }
+
+    response = await client.post("/ingest/repos", json=[fixture], headers=AUTH_HEADERS)
+    assert response.status_code == 200
+    assert response.json()["upserted"] == 1
+
+    async with db_module.async_session_factory() as session:
+        result = await session.execute(
+            _text(
+                "SELECT dimension, raw_value FROM repo_taxonomy rt "
+                "JOIN repos r ON r.id = rt.repo_id WHERE r.name = :name"
+            ),
+            {"name": "taxonomy-flow-repo"},
+        )
+        rows = {(dim, val) for dim, val in result.all()}
+
+    assert ("tag", "ai") in rows
+    assert ("tag", "rag") in rows
+    assert ("tag", "vector-db") in rows
+    assert ("category", "AI Agents") in rows
+    assert ("category", "Developer Tools") in rows

--- a/tests/test_pros_cons.py
+++ b/tests/test_pros_cons.py
@@ -304,3 +304,61 @@ async def test_evaluation_endpoint_returns_404_when_no_evaluation(client: AsyncC
     response = await client.get("/repos/eval-test-no-pros/evaluation")
     assert response.status_code == 404
     assert "No evaluation" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_evaluation_endpoint_surfaces_community_health_fields(client: AsyncClient):
+    """Success path: evaluation response must include community-health signals
+    (contributors_count, issue_close_rate, pr_merge_rate, community_health_pct)
+    alongside the AI-generated pros/cons.
+    """
+    from sqlalchemy import text as _text
+
+    # Seed a repo
+    await client.post(
+        "/ingest/repos",
+        json=[{
+            "name": "eval-test-with-pros",
+            "owner": "testowner",
+            "description": "Test repo with evaluation",
+            "is_fork": False,
+            "primary_language": "Python",
+            "github_url": "https://github.com/testowner/eval-test-with-pros",
+            "tags": ["ai"],
+        }],
+        headers=AUTH_HEADERS,
+    )
+
+    # Write pros_cons + community-health fields directly via DB
+    import app.database as db_module
+    async with db_module.async_session_factory() as session:
+        await session.execute(
+            _text(
+                "UPDATE repos SET pros_cons = :pc, pros_cons_generated_at = NOW(), "
+                "contributors_count = :cc, issue_close_rate = :icr, "
+                "pr_merge_rate = :pmr, community_health_pct = :chp "
+                "WHERE name = :name"
+            ),
+            {
+                "pc": json.dumps(_GOOD_EVALUATION),
+                "cc": 42,
+                "icr": 85.0,
+                "pmr": 72.5,
+                "chp": 90,
+                "name": "eval-test-with-pros",
+            },
+        )
+        await session.commit()
+
+    response = await client.get("/repos/eval-test-with-pros/evaluation")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["repo"] == "eval-test-with-pros"
+    assert body["owner"] == "testowner"
+    assert body["evaluation"]["pros"] == _GOOD_EVALUATION["pros"]
+    assert body["generated_at"] is not None
+    # New fields — the core assertion of this regression test
+    assert body["contributors_count"] == 42
+    assert body["issue_close_rate"] == 85.0
+    assert body["pr_merge_rate"] == 72.5
+    assert body["community_health_pct"] == 90


### PR DESCRIPTION
## Summary
- `/repos/{repo_id}/evaluation` now returns `contributors_count`, `issue_close_rate`, `pr_merge_rate`, `community_health_pct` alongside the AI-generated pros/cons so consumers can cross-reference the verdict with raw metrics without a second call.
- Ingest pipeline now routes `tags` and `categories` into `repo_taxonomy` via `_TAXONOMY_DIMENSION_MAP` (dimensions `tag` / `category`). Previously `/taxonomy/*` endpoints and the rebuild job were blind to these values even though they live in junction tables. Categories are flattened to `category_name` (with `category_id` fallback) to keep `raw_value` TEXT-compatible.

## Schema implications
- No migration required. `repo_taxonomy.dimension` is unconstrained `TEXT` (see migration 013), so the new `tag` / `category` values drop in without DDL.

## Test plan
- [x] Added `test_evaluation_endpoint_surfaces_community_health_fields` — success-path assertion that all four new fields appear in the response.
- [x] Added `test_ingest_flows_tags_and_categories_into_repo_taxonomy` — asserts tag + category rows land in `repo_taxonomy` after ingest.
- [ ] CI (with Postgres service) to run full `pytest tests/ -q` — local run blocked by no local Postgres.

Fixes #N/A (scoped tactical fix)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>