### PR TITLE
infra: gate deploy on real Alembic migrations (stop continue-on-error bypass)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,30 +26,29 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
-      - name: Start Cloud SQL Proxy for migrations
-        run: |
-          curl -sSLo cloud-sql-proxy \
-            https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v2.13.0/cloud-sql-proxy.linux.amd64
-          chmod +x cloud-sql-proxy
-          # Private IP only — proxy will fail if runner can't reach private VPC range.
-          # This is expected for GitHub-hosted runners. Migrations run via Cloud Run Job.
-          ./cloud-sql-proxy --port 5432 --private-ip \
-            perditio-platform:us-central1:reporium-db &
-          sleep 5
-          echo "Cloud SQL Proxy started (PID $!)"
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f27b12cd0b5 # v2.1.4
 
-      - name: Apply database migrations
-        continue-on-error: true
-        env:
-          ENVIRONMENT: production
-          GCP_PROJECT: perditio-platform
-          DATABASE_URL: postgresql+asyncpg://postgres:${{ secrets.CLOUDSQL_PG_PASS }}@127.0.0.1:5432/reporium
+      - name: Apply database migrations (via Cloud Run Job)
+        # The Cloud SQL instance `reporium-db` is private-IP only (no public IPv4),
+        # so neither direct TCP nor the Cloud SQL Auth Proxy can reach it from a
+        # GitHub-hosted runner — the proxy still needs network path to the
+        # instance endpoint, and the private VPC is unreachable from GitHub's
+        # network. Instead we execute the pre-provisioned `reporium-alembic`
+        # Cloud Run Job, which runs inside the VPC and has direct access.
+        #
+        # `--wait` makes this synchronous and propagates a non-zero exit on
+        # migration failure, so the deploy step below is properly gated.
+        # This replaces the previous `continue-on-error: true` bypass that
+        # silently let schema-dependent code deploy unmigrated.
         run: |
-          # Migrations run against local proxy (port 5432).
-          # On GitHub-hosted runners the proxy cannot reach the private Cloud SQL IP,
-          # so this step is best-effort. Run migrations manually via the
-          # reporium-alembic Cloud Run Job when adding new migrations.
-          alembic upgrade head || echo "Migration step skipped (runner cannot reach private Cloud SQL)"
+          set -euo pipefail
+          echo "Executing reporium-alembic Cloud Run Job (alembic upgrade head)..."
+          gcloud run jobs execute reporium-alembic \
+            --project perditio-platform \
+            --region us-central1 \
+            --wait
+          echo "Migrations completed successfully."
 
       - uses: google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522 # v2.7.6
         id: deploy


### PR DESCRIPTION
## What was broken

`.github/workflows/deploy.yml` had a migrate step with `continue-on-error: true` and a Cloud SQL Auth Proxy invoked with `--private-ip`. From a GitHub-hosted runner this could never work: the Cloud SQL instance `reporium-db` is **private-IP only** (verified: `gcloud sql instances describe reporium-db` shows `PRIVATE 10.14.0.3` and `ipv4Enabled=False`), and the proxy — despite IAM auth — still needs a TCP path to the instance's endpoint inside the VPC. So every deploy printed "Migration step skipped" and carried on. Schema-dependent API changes could deploy to prod unmigrated.

## How it's fixed

Replace the broken proxy + `alembic upgrade head` step with a synchronous execution of the pre-provisioned `reporium-alembic` **Cloud Run Job**, which already runs inside the VPC and has direct access to Cloud SQL:

```yaml
- name: Apply database migrations (via Cloud Run Job)
  run: |
    gcloud run jobs execute reporium-alembic       --project perditio-platform       --region us-central1       --wait
```

- `--wait` blocks until the job finishes and propagates non-zero exit on migration failure.
- `continue-on-error: true` is **removed** — migrations MUST succeed for the deploy step to run.
- Added `google-github-actions/setup-gcloud@v2.1.4` so the `gcloud` CLI is on PATH.

## Why not the Cloud SQL Auth Proxy?

Considered; doesn't work here. The instance has no public IP, and GitHub-hosted runners have no route to the VPC's 10.14.0.0/24 range. The proxy would start but every connection attempt to 10.14.0.3:3307 would hang/fail. Using the existing Cloud Run Job is the right pattern — it's what the previous comment in the workflow already told operators to do manually.

## IAM prerequisites

Verified on `perditio-platform` project IAM:
- Auth uses `secrets.GCP_SA_KEY` (key JSON). That SA needs `roles/run.developer` (or `roles/run.admin`) on the project / job to execute Cloud Run Jobs. The key belongs to `gcloud-service-account@perditio-platform.iam.gserviceaccount.com`, which already has `roles/editor` — so job execution permission is covered. **No IAM changes required.**
- The job itself runs as `reporium-api@perditio-platform.iam.gserviceaccount.com`, which already holds `roles/cloudsql.client` and `roles/cloudsql.instanceUser`. Good.

## Secrets / env vars

**No additions.** `CLOUDSQL_PG_PASS` is no longer read here (the Cloud Run Job pulls creds its own way via the VPC connection). Existing `GCP_SA_KEY`, `INGESTION_API_KEY`, `ADMIN_API_KEY` unchanged.

## Testing

- YAML parses cleanly (`python -c "import yaml; yaml.safe_load(...)"`).
- Can't dry-run job execution from a PR; the step runs on push to `main` only. The Cloud Run Job `reporium-alembic` was last executed successfully on 2026-04-15 per `gcloud run jobs list`, so the vehicle is known-working.

## Rollback

`git revert` this PR. The deploy will go back to the broken-but-non-blocking behavior (worse, but known).

## Coordination

Another agent is adding `METRICS_REQUIRE_AUTH=1` to the same file. If that lands first, rebase this on top and keep their env-var addition intact.

---

Do **not** auto-merge. Requires human review (affects deploys).