### PR TITLE
security: enable metrics auth + reduce Sentry PII exposure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,7 @@ jobs:
             GRAPH_SNAPSHOT_BUCKET=perditio-platform-bucket
             GRAPH_SNAPSHOT_OBJECT=reporium/graph/knowledge-graph.json
             EMBEDDINGS_AVAILABLE=true
+            METRICS_REQUIRE_AUTH=1
           env_vars_update_strategy: merge
           flags: >-
             --memory=2Gi

--- a/app/main.py
+++ b/app/main.py
@@ -67,10 +67,13 @@ def _configure_logging() -> None:
 _configure_logging()
 logger = logging.getLogger(__name__)
 
+# Sentry: sample 10% of traces (enough to detect P99 regressions at a fraction
+# of the cost) and disable default PII capture so user identifiers from
+# ask/audit surfaces don't leak into error reports.
 sentry_sdk.init(
     dsn=os.getenv("SENTRY_DSN"),
-    traces_sample_rate=1.0,
-    send_default_pii=True,
+    traces_sample_rate=0.1,
+    send_default_pii=False,
     environment=os.getenv("ENVIRONMENT", "production"),
 )
 


### PR DESCRIPTION
## Summary

Two independent security/privacy hardening fixes on `reporium-api`.

### Fix 1 — Enable metrics/audit auth in production

`.github/workflows/deploy.yml` does not set `METRICS_REQUIRE_AUTH`, so `app/auth.py::require_metrics_access()` is a no-op and `/metrics/*` and `/audit/status` are internet-reachable without auth — leaking spend, latency, and corpus stats.

Adds `METRICS_REQUIRE_AUTH=1` to the `env_vars` block, preserving existing entries. `deploy/service.yaml` has no env_vars block so no parity change needed (and it is documentation-only anyway — the workflow is authoritative).

### Fix 2 — Tune Sentry for privacy

`app/main.py` initializes Sentry with `traces_sample_rate=1.0` and `send_default_pii=True`. This is a privacy concern on ask/audit surfaces and also unnecessarily costly.

- `traces_sample_rate=1.0` → `0.1` (10% sampling is sufficient to detect P99 regressions)
- `send_default_pii=True` → `False`
- Added a comment explaining the rationale

## Test plan
- [x] `pytest tests/ -q` — change is baseline-equivalent; pre-existing ConnectionRefused errors (known apr9 blocker) unchanged in count and shape. No Sentry-specific tests exist to regress.
- [ ] After deploy: verify `curl https://reporium-api.../metrics/slo` returns 403 without the metrics key.
- [ ] After deploy: verify Sentry trace volume drops ~10x and no PII fields appear in new events.