### PR TITLE
promote: dev \u2192 main (no-traffic alembic deploy)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,33 +29,32 @@ jobs:
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f27b12cd0b5 # v2.1.4
 
-      - name: Apply database migrations (via Cloud Run Job)
-        # The Cloud SQL instance `reporium-db` is private-IP only (no public IPv4),
-        # so neither direct TCP nor the Cloud SQL Auth Proxy can reach it from a
-        # GitHub-hosted runner — the proxy still needs network path to the
-        # instance endpoint, and the private VPC is unreachable from GitHub's
-        # network. Instead we execute the pre-provisioned `reporium-alembic`
-        # Cloud Run Job, which runs inside the VPC and has direct access.
-        #
-        # `--wait` makes this synchronous and propagates a non-zero exit on
-        # migration failure, so the deploy step below is properly gated.
-        # This replaces the previous `continue-on-error: true` bypass that
-        # silently let schema-dependent code deploy unmigrated.
-        run: |
-          set -euo pipefail
-          echo "Executing reporium-alembic Cloud Run Job (alembic upgrade head)..."
-          gcloud run jobs execute reporium-alembic \
-            --project perditio-platform \
-            --region us-central1 \
-            --wait
-          echo "Migrations completed successfully."
-
+      # Option B1 — no-traffic candidate revision + migrate + promote.
+      #
+      # Prior approach (Option A) deployed the revision to 100% traffic FIRST, then
+      # ran migrations. Codex flagged this: if migrations fail, new code is already
+      # live against the old schema. Option B1 eliminates that window entirely:
+      #
+      #   1. Build + deploy a new revision with `no_traffic: true` and a
+      #      `candidate-<sha>` traffic tag. Current revision keeps 100% of traffic.
+      #   2. Resolve that revision's image URI back from Cloud Run.
+      #   3. Point `reporium-alembic` at that image and `--command=alembic`
+      #      `--args=upgrade,head`.
+      #   4. Execute the job with `--wait`. If migrations fail, the workflow fails
+      #      here — the candidate revision continues to serve 0% traffic and the
+      #      old revision keeps serving users. Nothing is promoted.
+      #   5. Only on migration success, shift traffic to the new revision.
+      #
+      # `no_traffic` and `tag` are supported inputs on
+      # google-github-actions/deploy-cloudrun@v2.7.6 (verified in action.yml).
       - uses: google-github-actions/deploy-cloudrun@251330ba9a8a34bfbc1622895f42e1d53fd14522 # v2.7.6
         id: deploy
         with:
           service: reporium-api
           region: us-central1
           source: .
+          no_traffic: true
+          tag: candidate-${{ github.sha }}
           env_vars: |-
             ENVIRONMENT=production
             GRAPH_SNAPSHOT_BUCKET=perditio-platform-bucket
@@ -75,6 +74,100 @@ jobs:
             --network=default
             --subnet=default
             --vpc-egress=private-ranges-only
+
+      - name: Resolve candidate revision image URI
+        id: image
+        # The candidate revision carries tag `candidate-<sha>` but serves 0% traffic.
+        # Read the image URI from the tagged revision in `status.traffic[]` — do NOT
+        # use `spec.template.spec.containers[0].image`, which reflects the newest
+        # template but not necessarily the revision actually referenced by the tag.
+        # Cross-referencing the tag with `status.traffic[].revisionName` and looking
+        # up that revision's image is bulletproof across Cloud Build naming changes.
+        run: |
+          set -euo pipefail
+          TAG="candidate-${{ github.sha }}"
+          REVISION="$(gcloud run services describe reporium-api \
+            --project=perditio-platform \
+            --region=us-central1 \
+            --format="value(status.traffic.filter(\"tag:${TAG}\").extract(revisionName).flatten())")"
+          if [ -z "${REVISION}" ]; then
+            echo "Failed to resolve revision for tag ${TAG}" >&2
+            gcloud run services describe reporium-api \
+              --project=perditio-platform --region=us-central1 \
+              --format="value(status.traffic)" >&2 || true
+            exit 1
+          fi
+          IMAGE_URI="$(gcloud run revisions describe "${REVISION}" \
+            --project=perditio-platform \
+            --region=us-central1 \
+            --format='value(spec.containers[0].image)')"
+          if [ -z "${IMAGE_URI}" ]; then
+            echo "Failed to resolve image URI for revision ${REVISION}" >&2
+            exit 1
+          fi
+          echo "Candidate revision: ${REVISION}"
+          echo "Candidate image:    ${IMAGE_URI}"
+          echo "revision=${REVISION}" >> "$GITHUB_OUTPUT"
+          echo "uri=${IMAGE_URI}" >> "$GITHUB_OUTPUT"
+
+      - name: Point alembic job at candidate image
+        # Codex audit on PR #392: `gcloud run jobs execute reporium-alembic` runs the
+        # image currently configured on the job, NOT the commit being deployed. New
+        # Alembic revisions would not exist in the stale job image at execute time,
+        # producing a "nothing to do" false success.
+        #
+        # Update the job to the candidate API image (contains this commit's
+        # migrations/ directory and the alembic CLI via requirements.txt).
+        # `--command` / `--args` are set explicitly so behaviour does not depend on
+        # the job's previously-provisioned entrypoint.
+        run: |
+          set -euo pipefail
+          echo "Pointing reporium-alembic job at ${{ steps.image.outputs.uri }}"
+          gcloud run jobs update reporium-alembic \
+            --image="${{ steps.image.outputs.uri }}" \
+            --command=alembic \
+            --args=upgrade,head \
+            --project=perditio-platform \
+            --region=us-central1
+
+      - name: Apply database migrations (via Cloud Run Job)
+        # The Cloud SQL instance `reporium-db` is private-IP only (no public IPv4),
+        # so neither direct TCP nor the Cloud SQL Auth Proxy can reach it from a
+        # GitHub-hosted runner. Instead we execute the pre-provisioned
+        # `reporium-alembic` Cloud Run Job, which runs inside the VPC.
+        #
+        # `--wait` makes this synchronous and propagates a non-zero exit on
+        # migration failure — NO `continue-on-error: true`. If this step fails, the
+        # subsequent traffic-promotion step will NOT run (GitHub Actions stops the
+        # job at the first failed step), so the candidate revision stays at 0%
+        # traffic and the old revision continues serving users.
+        run: |
+          set -euo pipefail
+          echo "Executing reporium-alembic Cloud Run Job (alembic upgrade head)..."
+          gcloud run jobs execute reporium-alembic \
+            --project=perditio-platform \
+            --region=us-central1 \
+            --wait
+          echo "Migrations completed successfully."
+
+      - name: Promote candidate revision to 100% traffic
+        # Only runs if every prior step (including the migration execute) succeeded.
+        # Shifts production traffic from the old revision to the candidate revision
+        # identified by its traffic tag. `--to-tags=candidate-<sha>=100` is precise:
+        # it does not rely on "latest" semantics and is unambiguous about which
+        # revision is being promoted.
+        #
+        # After this succeeds, the tag remains on the revision (harmless) so you can
+        # still curl the tagged URL for post-promotion comparison if needed.
+        run: |
+          set -euo pipefail
+          TAG="candidate-${{ github.sha }}"
+          echo "Promoting tag ${TAG} (revision ${{ steps.image.outputs.revision }}) to 100% traffic"
+          gcloud run services update-traffic reporium-api \
+            --to-tags="${TAG}=100" \
+            --project=perditio-platform \
+            --region=us-central1
+          echo "Traffic shifted to candidate revision."
 
       - name: Prune old container images (keep latest 5)
         if: success()

--- a/migrations/versions/038_missing_indexes.py
+++ b/migrations/versions/038_missing_indexes.py
@@ -11,24 +11,28 @@ Changes:
      used by GET /gaps (ORDER BY skill is done in app code after fetch).
      category column on this table does not exist in the ORM model; using skill.
 
-  3. UNIQUE constraint on repo_commits(sha, repo_id) — uq_repo_commits_sha_repo
+  3. UNIQUE index on repo_commits(sha, repo_id) — uq_repo_commits_sha_repo
      Scoped per repo to prevent re-ingestion duplicates without cross-repo
      false-positive collisions (same SHA can appear in forks).
-     Created as DEFERRABLE INITIALLY DEFERRED so existing duplicate rows
-     (if any) do not cause immediate constraint violation on creation —
-     deferred constraints fire at transaction commit, which an INSERT-only
-     ingest path never triggers for pre-existing rows.
-     If duplicates exist, the migration will still succeed; cleanup SQL is
-     documented in the PR body.
+
+     NOTE: Creating a UNIQUE index (concurrent or not) validates existing rows
+     at build time and WILL fail if duplicates exist. A DEFERRABLE constraint
+     was considered but DEFERRABLE is a CONSTRAINT attribute, not an INDEX
+     attribute — CREATE UNIQUE INDEX ... DEFERRABLE is invalid Postgres DDL.
+     Instead, this migration runs a preflight duplicate check and raises
+     clearly if any (sha, repo_id) duplicates exist so operators can clean
+     them up before re-running.
 
 All DDL uses CONCURRENTLY where possible to avoid table locks in prod.
 CONCURRENTLY is NOT supported inside a transaction block, so each statement
-runs via op.execute() rather than op.create_index() (which wraps in a txn).
+runs inside op.get_context().autocommit_block() which temporarily exits
+Alembic's per-migration transaction.
 
 Revision ID: 038
 Revises: 037
 """
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -39,34 +43,56 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # 1. trend_snapshots.tag — full-scan today, O(1) lookup after
-    op.execute("""
-        CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_trend_snapshots_tag
-        ON trend_snapshots (tag)
-    """)
+    # Preflight: CREATE UNIQUE INDEX CONCURRENTLY still validates existing rows
+    # and will fail if duplicates exist. Fail loudly up-front with a clear
+    # message rather than letting Postgres emit a generic unique-violation.
+    conn = op.get_bind()
+    dupe = conn.execute(
+        sa.text(
+            """
+            SELECT sha, repo_id, COUNT(*) AS n
+            FROM repo_commits
+            GROUP BY sha, repo_id
+            HAVING COUNT(*) > 1
+            LIMIT 1
+            """
+        )
+    ).first()
+    if dupe is not None:
+        raise RuntimeError(
+            "repo_commits has duplicate (sha, repo_id) rows — clean up before "
+            f"running migration 038. Example: sha={dupe[0]!r} repo_id={dupe[1]!r} "
+            f"count={dupe[2]}. See PR body for cleanup SQL."
+        )
 
-    # 2. gap_analysis.skill — no non-PK indexes today
-    #    'skill' is the primary filter column (category column doesn't exist in
-    #    current ORM — verified against migrations/versions/001_initial_schema.py)
-    op.execute("""
-        CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_gap_analysis_skill
-        ON gap_analysis (skill)
-    """)
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
+    # autocommit_block() temporarily exits Alembic's wrapping transaction.
+    with op.get_context().autocommit_block():
+        # 1. trend_snapshots.tag — full-scan today, O(1) lookup after
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_trend_snapshots_tag "
+            "ON trend_snapshots (tag)"
+        )
 
-    # 3. repo_commits(sha, repo_id) UNIQUE — prevents re-ingestion dupes
-    #    DEFERRABLE INITIALLY DEFERRED: fires at transaction commit, not row insert.
-    #    This means an existing duplicate won't block the migration itself —
-    #    only new inserts/updates will enforce uniqueness going forward.
-    #    CONCURRENTLY is not supported for UNIQUE constraints, so we use a
-    #    standard CREATE UNIQUE INDEX CONCURRENTLY instead.
-    op.execute("""
-        CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uq_repo_commits_sha_repo
-        ON repo_commits (sha, repo_id)
-        DEFERRABLE INITIALLY DEFERRED
-    """)
+        # 2. gap_analysis.skill — no non-PK indexes today
+        #    'skill' is the primary filter column (category column doesn't exist
+        #    in current ORM — verified against 001_initial_schema.py)
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_gap_analysis_skill "
+            "ON gap_analysis (skill)"
+        )
+
+        # 3. repo_commits(sha, repo_id) UNIQUE — prevents re-ingestion dupes.
+        #    Plain concurrent unique index; deferrability dropped (see header).
+        op.execute(
+            "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uq_repo_commits_sha_repo "
+            "ON repo_commits (sha, repo_id)"
+        )
 
 
 def downgrade() -> None:
-    op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_trend_snapshots_tag")
-    op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_gap_analysis_skill")
-    op.execute("DROP INDEX CONCURRENTLY IF EXISTS uq_repo_commits_sha_repo")
+    # DROP INDEX CONCURRENTLY also cannot run inside a transaction block.
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_trend_snapshots_tag")
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_gap_analysis_skill")
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS uq_repo_commits_sha_repo")

--- a/tests/golden/.gitignore
+++ b/tests/golden/.gitignore
@@ -1,0 +1,1 @@
+.results/

--- a/tests/golden/README.md
+++ b/tests/golden/README.md
@@ -1,0 +1,151 @@
+# Ask Eval Harness
+
+Baseline measurement infrastructure for the Reporium `/intelligence/ask`
+endpoint. Introduced in **Sprint 0** so later sprints (router layer, semantic
+cache, evidence packs) have a numerical reference to beat.
+
+## What this is
+
+- A hand-curated **golden set** of 50 natural-language questions spanning the
+  query shapes users actually ask (count, lookup, compare, recommend,
+  taxonomy, trend, graph, health, synthesis).
+- A **pytest runner** that fires each question at a running API, records
+  latency, response size, `must_mention` hit rate, and dumps a JSON artifact
+  under `.results/latest.json` for downstream diffing.
+- A stable schema so future sprints can add assertions (route accuracy, cache
+  hit rate, cost regression) without rewriting the dataset.
+
+**All 50 questions are currently `source: synthetic`.** Replace them with
+redacted real traffic from `query_log` as it becomes available.
+
+## 🔒 Privacy boundary (READ BEFORE ADDING QUESTIONS)
+
+This golden set is **synthetic-only** and safe for public CI.
+
+**Do NOT add to this file**:
+- Production logs or real user questions
+- PII, IP addresses, session identifiers, or any user-derived strings
+- API tokens, keys, or any credential material
+- Customer-specific prompts or proprietary query patterns
+
+Sensitive or user-derived eval examples belong in the private overlay repo
+**`perditioinc/reporium-evals`**, which is reserved for exactly that purpose.
+The runner in this repo will be extended in a later sprint to merge the
+public base with the private overlay at load time.
+
+If you are unsure whether a question belongs here or in the private overlay,
+default to the private overlay.
+
+## How to run
+
+The eval is **not** part of the default `pytest` run because it makes real
+network + LLM calls. Opt in with an env var:
+
+```bash
+RUN_GOLDEN_EVAL=1 \
+ASK_EVAL_BASE_URL=http://localhost:8000 \
+ASK_EVAL_APP_TOKEN=<your X-App-Token> \
+    pytest tests/golden/test_ask_eval.py -v -s
+```
+
+- `ASK_EVAL_BASE_URL` defaults to `http://localhost:8000`.
+- `ASK_EVAL_APP_TOKEN` is the `X-App-Token` header value (`APP_API_TOKEN` on
+  the server side). Required in non-dev environments.
+- `-s` is recommended so the per-question table prints inline.
+
+Results are written to `tests/golden/.results/latest.json` (gitignored).
+
+### Rate limit pacing
+
+The `/intelligence/ask` endpoint is rate-limited at **6 requests/minute and
+60 requests/day per IP**. Firing all 50 questions in a tight loop will trip
+the limiter and record false failures (and burn the daily quota on noise).
+The runner exposes two env vars to pace itself:
+
+| env var | default | purpose |
+| --- | --- | --- |
+| `ASK_EVAL_SLEEP_SECONDS` | `11` | Seconds to sleep between requests. `11` keeps us safely under the 6/min ceiling. Set to `0` to opt out entirely (e.g. local runs against a mock). |
+| `ASK_EVAL_MAX_QUESTIONS` | unset (unlimited) | Cap on how many questions the run sends. Useful for a cheap smoke pass before spending the full daily quota. |
+
+Recommended **first baseline** against a live API — short pass to confirm
+the harness is wired correctly before committing 50 questions of quota:
+
+```bash
+ASK_EVAL_MAX_QUESTIONS=10 \
+ASK_EVAL_SLEEP_SECONDS=12 \
+RUN_GOLDEN_EVAL=1 \
+ASK_EVAL_BASE_URL=http://localhost:8000 \
+ASK_EVAL_APP_TOKEN=<your X-App-Token> \
+    pytest tests/golden/test_ask_eval.py -v -s
+```
+
+A full 50-question run at the default 11-second pacing takes ~9 minutes of
+wall clock and uses 50 of the 60 daily requests — plan accordingly.
+
+## Question schema
+
+```yaml
+- id: Q001                         # stable opaque identifier
+  question: "..."                  # the user-facing question
+  category: recommend              # count|lookup|compare|recommend|taxonomy
+                                   # trend|graph|health|synthesis
+  expected_route: recommend        # what Sprint 1's router should pick
+                                   # (NOT asserted yet — placeholder)
+  must_mention: [lowercased]       # substrings required in answer.lower()
+  must_not_mention: []             # substrings that must NOT appear
+  expected_source_ids: []          # optional "owner/name" repo slugs
+  source: synthetic                # synthetic | user_drafted
+  notes: "rationale / origin"
+```
+
+Field-by-field:
+
+| field | asserted in Sprint 0? | notes |
+| --- | --- | --- |
+| `id` | no | Stable across sprints; never reused. |
+| `question` | yes (sent to API) | |
+| `category` | no | Used for grouping in summary output. |
+| `expected_route` | **no** | Router doesn't exist yet — Sprint 1 enables this. |
+| `must_mention` | measured, not gated | Aggregated into `mention_hit_rate`. |
+| `must_not_mention` | measured, not gated | Violations counted, not fatal. |
+| `expected_source_ids` | no | For Sprint 2 precision checks. |
+| `source` | no | Provenance tag; replace synthetic with real over time. |
+| `notes` | no | Freeform. |
+
+## Adding a question
+
+Append to `ask_questions.yaml`:
+
+```yaml
+- id: Q051
+  question: "Your new question here."
+  category: lookup
+  expected_route: lookup
+  must_mention: ["grounding", "substring"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: user_drafted
+  notes: "Where this came from."
+```
+
+Keep `must_mention` lowercased — the runner lowercases the answer before
+checking membership.
+
+## Roadmap
+
+| Sprint | What this harness gains |
+| --- | --- |
+| 0 (this PR) | Baseline latency, response size, mention-hit rate. No quality floor. |
+| 1 | Enable `expected_route` assertion once router lands. Set minimum route accuracy threshold off Sprint 0 data. |
+| 2 | Assert `expected_source_ids` precision once evidence packs exist. |
+| 3 | Add cost ceiling assertion using `tokens_used` from response body. |
+
+## Why isn't this in CI?
+
+Two reasons:
+
+1. **Cost.** Every run bills real Anthropic tokens — 50 questions times the
+   Sonnet/Haiku mix is non-trivial.
+2. **Flakiness.** Model nondeterminism + network latency means a blind CI
+   integration would flap. The right home is a manual trigger or a nightly
+   workflow with budget alerts; that's a Sprint 1+ decision.

--- a/tests/golden/ask_questions.yaml
+++ b/tests/golden/ask_questions.yaml
@@ -1,0 +1,537 @@
+# ---------------------------------------------------------------------------
+# Reporium Ask — Golden Question Set (Sprint 0 baseline)
+# ---------------------------------------------------------------------------
+# version: 0.1.0
+# schema:
+#   id                   string   stable opaque identifier ("Q001" .. "Q050")
+#   question             string   the user-facing natural-language question
+#   category             enum     count | lookup | compare | recommend |
+#                                 taxonomy | trend | graph | health | synthesis
+#   expected_route       enum     router bucket we EXPECT Sprint 1 to pick.
+#                                 NOT asserted in Sprint 0 (router does not
+#                                 exist yet). Left in place so later sprints
+#                                 can enable route-accuracy checks without
+#                                 re-editing this file.
+#   must_mention         list     lowercased substrings that should appear
+#                                 somewhere in answer.lower(). Empty list is
+#                                 allowed but discouraged — every question
+#                                 should have at least one grounding anchor
+#                                 where possible.
+#   must_not_mention     list     lowercased substrings that must NOT appear
+#                                 (hallucination guardrails, wrong-tool names,
+#                                 off-topic drift).
+#   expected_source_ids  list     optional repo slugs ("owner/name") we expect
+#                                 to see in the sources array. Not yet asserted
+#                                 in Sprint 0 — collected for later precision
+#                                 measurement.
+#   source               enum     synthetic | user_drafted. ALL entries in
+#                                 this initial set are synthetic; real traffic
+#                                 logs should replace them incrementally once
+#                                 query_log has consented samples.
+#   notes                string   rationale / origin — where the question came
+#                                 from (which frontend page or endpoint).
+#
+# Distribution target (roughly balanced):
+#   count=4  lookup=8  compare=5  recommend=6  taxonomy=6
+#   trend=5  graph=6   health=5   synthesis=5
+# ---------------------------------------------------------------------------
+
+- id: Q001
+  question: "How many RAG tools do you track?"
+  category: count
+  expected_route: count
+  must_mention: ["rag"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Numeric aggregate; maps to a taxonomy-filtered count, not LLM synthesis."
+
+- id: Q002
+  question: "How many repositories are in the Reporium catalog?"
+  category: count
+  expected_route: count
+  must_mention: []
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Global corpus size — /analytics or /platform/metrics derives this."
+
+- id: Q003
+  question: "How many agent frameworks do you have?"
+  category: count
+  expected_route: count
+  must_mention: ["agent"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Category-scoped count; agent-frameworks is a known taxonomy value."
+
+- id: Q004
+  question: "How many tools are tagged with LangChain?"
+  category: count
+  expected_route: count
+  must_mention: ["langchain"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Integration-tag count; /mentions and /nl_filter touch this shape."
+
+- id: Q005
+  question: "Tell me about LangChain."
+  category: lookup
+  expected_route: lookup
+  must_mention: ["langchain"]
+  must_not_mention: []
+  expected_source_ids: ["langchain-ai/langchain"]
+  source: synthetic
+  notes: "Canonical single-repo lookup — /repos/{slug} underlies this."
+
+- id: Q006
+  question: "What is LlamaIndex used for?"
+  category: lookup
+  expected_route: lookup
+  must_mention: ["llamaindex"]
+  must_not_mention: []
+  expected_source_ids: ["run-llama/llama_index"]
+  source: synthetic
+  notes: "Purpose/description lookup against a known repo."
+
+- id: Q007
+  question: "What does CrewAI do?"
+  category: lookup
+  expected_route: lookup
+  must_mention: ["crewai"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Agent framework lookup — verifies enrichment surfaces the summary."
+
+- id: Q008
+  question: "Explain what Haystack is."
+  category: lookup
+  expected_route: lookup
+  must_mention: ["haystack"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Lookup with a verb-phrased user intent; same target as Q007 pattern."
+
+- id: Q009
+  question: "Describe the AutoGen project."
+  category: lookup
+  expected_route: lookup
+  must_mention: ["autogen"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Microsoft AutoGen; validates cased-name handling."
+
+- id: Q010
+  question: "What is DSPy?"
+  category: lookup
+  expected_route: lookup
+  must_mention: ["dspy"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Short acronym lookup — exercises query normalization."
+
+- id: Q011
+  question: "Give me a summary of Semantic Kernel."
+  category: lookup
+  expected_route: lookup
+  must_mention: ["semantic kernel"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Multi-word name; also in Microsoft orbit."
+
+- id: Q012
+  question: "What can you tell me about vLLM?"
+  category: lookup
+  expected_route: lookup
+  must_mention: ["vllm"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Inference engine lookup; checks non-agent category coverage."
+
+- id: Q013
+  question: "LangChain vs LlamaIndex — which should I use?"
+  category: compare
+  expected_route: compare
+  must_mention: ["langchain", "llamaindex"]
+  must_not_mention: []
+  expected_source_ids: ["langchain-ai/langchain", "run-llama/llama_index"]
+  source: synthetic
+  notes: "Classic head-to-head; /compare endpoint exists for this."
+
+- id: Q014
+  question: "Compare CrewAI and AutoGen for multi-agent orchestration."
+  category: compare
+  expected_route: compare
+  must_mention: ["crewai", "autogen"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Two-tool compare with a use-case qualifier."
+
+- id: Q015
+  question: "How does Haystack differ from LangChain?"
+  category: compare
+  expected_route: compare
+  must_mention: ["haystack", "langchain"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Natural-language phrasing of a compare; router must detect it."
+
+- id: Q016
+  question: "vLLM vs TGI for production inference."
+  category: compare
+  expected_route: compare
+  must_mention: ["vllm"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Inference server comparison; must_mention only one to keep gate loose."
+
+- id: Q017
+  question: "Pinecone vs Weaviate vs Qdrant — pros and cons?"
+  category: compare
+  expected_route: compare
+  must_mention: ["pinecone", "weaviate", "qdrant"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Three-way vector DB compare; stresses multi-entity routing."
+
+- id: Q018
+  question: "What's the best RAG framework for a small team?"
+  category: recommend
+  expected_route: recommend
+  must_mention: ["rag"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Opinionated recommendation with audience qualifier."
+
+- id: Q019
+  question: "Recommend a good tool for building chatbots with memory."
+  category: recommend
+  expected_route: recommend
+  must_mention: []
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Capability-driven recommend; feature keyword 'memory'."
+
+- id: Q020
+  question: "Which agent framework should I pick if I care about observability?"
+  category: recommend
+  expected_route: recommend
+  must_mention: ["agent"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Quality-attribute recommend; exercises secondary-signal weighting."
+
+- id: Q021
+  question: "What's a lightweight alternative to LangChain?"
+  category: recommend
+  expected_route: recommend
+  must_mention: ["langchain"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Alternative-to phrasing; router should NOT treat as lookup."
+
+- id: Q022
+  question: "Best vector database for a serverless stack?"
+  category: recommend
+  expected_route: recommend
+  must_mention: []
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Architecture-constrained recommend; verifies deployment filters."
+
+- id: Q023
+  question: "What should I use to evaluate my LLM app?"
+  category: recommend
+  expected_route: recommend
+  must_mention: []
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Eval-tooling recommend; new-ish category, good regression canary."
+
+- id: Q024
+  question: "What categories exist in Reporium?"
+  category: taxonomy
+  expected_route: taxonomy
+  must_mention: []
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Direct /taxonomy enumeration; should NOT invoke LLM synthesis."
+
+- id: Q025
+  question: "Show me all industries covered in the catalog."
+  category: taxonomy
+  expected_route: taxonomy
+  must_mention: []
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Taxonomy dimension: industries; mirrors a /taxonomy facet."
+
+- id: Q026
+  question: "List the AI development skills you track."
+  category: taxonomy
+  expected_route: taxonomy
+  must_mention: []
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "ai_dev_skills facet; frontend taxonomy page surfaces this."
+
+- id: Q027
+  question: "What tags are used for inference tools?"
+  category: taxonomy
+  expected_route: taxonomy
+  must_mention: ["infer"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Scoped taxonomy query; combines facet + category."
+
+- id: Q028
+  question: "How many categories does Reporium define?"
+  category: taxonomy
+  expected_route: taxonomy
+  must_mention: []
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Count-shaped but over taxonomy metadata, not repos — router edge case."
+
+- id: Q029
+  question: "What programming languages are represented in the catalog?"
+  category: taxonomy
+  expected_route: taxonomy
+  must_mention: ["python"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Language facet; python is guaranteed to appear in any real catalog."
+
+- id: Q030
+  question: "What's trending this week in AI agents?"
+  category: trend
+  expected_route: trend
+  must_mention: ["agent"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "/trends endpoint, 7d window, category-scoped."
+
+- id: Q031
+  question: "Which repos are growing fastest right now?"
+  category: trend
+  expected_route: trend
+  must_mention: []
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Growth-rate trend; no explicit window (router picks default)."
+
+- id: Q032
+  question: "Show me the top trending RAG tools this month."
+  category: trend
+  expected_route: trend
+  must_mention: ["rag"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "30d window + category + ranking; composite intent."
+
+- id: Q033
+  question: "What's newly added in the last 30 days?"
+  category: trend
+  expected_route: trend
+  must_mention: []
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Freshness query; /trends or /repos?sort=new."
+
+- id: Q034
+  question: "Which vector databases are gaining traction?"
+  category: trend
+  expected_route: trend
+  must_mention: []
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Momentum phrasing; routes to trend despite no explicit time word."
+
+- id: Q035
+  question: "What's similar to LangChain?"
+  category: graph
+  expected_route: graph
+  must_mention: ["langchain"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Similarity edge traversal; /graph/similar."
+
+- id: Q036
+  question: "What depends on LangChain?"
+  category: graph
+  expected_route: graph
+  must_mention: ["langchain"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Reverse-dependency edge; DEPENDS_ON edge type (see KG roadmap)."
+
+- id: Q037
+  question: "Show me tools that integrate with Pinecone."
+  category: graph
+  expected_route: graph
+  must_mention: ["pinecone"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "INTEGRATES_WITH edge; taxonomy + graph hybrid."
+
+- id: Q038
+  question: "What are alternatives to Haystack?"
+  category: graph
+  expected_route: graph
+  must_mention: ["haystack"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "ALTERNATIVE_TO edge; distinct from recommend (fact, not opinion)."
+
+- id: Q039
+  question: "Which repos are related to vLLM?"
+  category: graph
+  expected_route: graph
+  must_mention: ["vllm"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Generic related-to — router must pick graph over lookup."
+
+- id: Q040
+  question: "What tools does CrewAI build on top of?"
+  category: graph
+  expected_route: graph
+  must_mention: ["crewai"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Forward dependency edge; inverse of Q036."
+
+- id: Q041
+  question: "Is LangChain still actively maintained?"
+  category: health
+  expected_route: health
+  must_mention: ["langchain"]
+  must_not_mention: []
+  expected_source_ids: ["langchain-ai/langchain"]
+  source: synthetic
+  notes: "Health signal; derived from commits_last_30_days + activity_score."
+
+- id: Q042
+  question: "What's the maintenance status of Haystack?"
+  category: health
+  expected_route: health
+  must_mention: ["haystack"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Synonym of Q041; router should route to same handler."
+
+- id: Q043
+  question: "Is AutoGen abandoned?"
+  category: health
+  expected_route: health
+  must_mention: ["autogen"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Negative-framed health question; answer must not hedge into irrelevance."
+
+- id: Q044
+  question: "How healthy is the vLLM project?"
+  category: health
+  expected_route: health
+  must_mention: ["vllm"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Community-signal health; pulls stars, issues, commit cadence."
+
+- id: Q045
+  question: "Which popular repos haven't shipped a commit in 90 days?"
+  category: health
+  expected_route: health
+  must_mention: []
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Catalog-wide stale-repo filter; exercises health facet aggregation."
+
+- id: Q046
+  question: "Explain the evolution of RAG frameworks over the last two years."
+  category: synthesis
+  expected_route: synthesis
+  must_mention: ["rag"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Open-ended narrative; unavoidably LLM-synthesis (expensive route)."
+
+- id: Q047
+  question: "Give me an overview of the agent framework landscape in 2026."
+  category: synthesis
+  expected_route: synthesis
+  must_mention: ["agent"]
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Survey-shaped ask; forces multi-repo synthesis."
+
+- id: Q048
+  question: "How has the vector database ecosystem changed recently?"
+  category: synthesis
+  expected_route: synthesis
+  must_mention: []
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Trend + synthesis hybrid; router should prefer synthesis for narrative."
+
+- id: Q049
+  question: "What are the main trade-offs between open-source and hosted LLM stacks?"
+  category: synthesis
+  expected_route: synthesis
+  must_mention: []
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Conceptual synthesis; no single-repo anchor."
+
+- id: Q050
+  question: "Summarize how AI coding assistants have evolved in the catalog."
+  category: synthesis
+  expected_route: synthesis
+  must_mention: []
+  must_not_mention: []
+  expected_source_ids: []
+  source: synthetic
+  notes: "Category-scoped synthesis; good regression test for freshness + recall."

--- a/tests/golden/test_ask_eval.py
+++ b/tests/golden/test_ask_eval.py
@@ -1,0 +1,346 @@
+"""
+Ask Eval Harness — Sprint 0 baseline measurement.
+
+Purpose
+-------
+Establishes a repeatable, numerical baseline for the Reporium ``/intelligence/ask``
+endpoint BEFORE Sprints 1-3 introduce the router layer, semantic cache, and
+evidence packs. Every future sprint will rerun this harness and must prove a
+measurable delta (latency, hit rate, or cost) versus the recorded baseline.
+
+Execution policy
+----------------
+This test is **gated behind an env var** and is NOT part of the default pytest
+run. Reason: it issues real network calls to a running API (and transitively to
+Anthropic), which makes it slow, flaky, and expensive. Enable it explicitly:
+
+    RUN_GOLDEN_EVAL=1 \\
+    ASK_EVAL_BASE_URL=http://localhost:8000 \\
+    ASK_EVAL_APP_TOKEN=<your-X-App-Token> \\
+        pytest tests/golden/test_ask_eval.py -v -s
+
+When ``RUN_GOLDEN_EVAL`` is unset, the entire module is skipped at collection
+time so CI default runs stay cheap.
+
+What this measures (Sprint 0)
+-----------------------------
+For each question in ``ask_questions.yaml``:
+    * ``must_mention`` hit rate — fraction of required substrings found in the
+      lowercased answer. Aggregated into a global mention-hit rate.
+    * ``must_not_mention`` violations — any hit is logged but non-fatal (we
+      report, we don't fail the suite on Sprint 0).
+    * Latency (ms) — wall-clock time for the HTTP round-trip.
+    * Response size (bytes) — a coarse token proxy until we wire the structured
+      ``tokens_used`` numbers through (already present in the response, so we
+      record that too when available).
+
+We intentionally do NOT assert ``expected_route`` in Sprint 0 — the router
+layer does not exist yet. That field is carried through untouched so Sprint 1
+can enable a route-accuracy assertion with zero edits to this file.
+
+Artifact
+--------
+Results are written to ``tests/golden/.results/latest.json`` (gitignored) for
+downstream diffing. The pytest session summary prints pass/fail counts,
+median latency, and mention-hit rate.
+"""
+from __future__ import annotations
+
+import json
+import os
+import statistics
+import time
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+# ---------------------------------------------------------------------------
+# Module-level skip — do not run unless explicitly opted in.
+# ---------------------------------------------------------------------------
+_RUN = os.getenv("RUN_GOLDEN_EVAL") == "1"
+
+pytestmark = pytest.mark.skipif(
+    not _RUN,
+    reason=(
+        "Golden-set eval is gated behind RUN_GOLDEN_EVAL=1 because it issues "
+        "real LLM calls (slow + costly). Set RUN_GOLDEN_EVAL=1, "
+        "ASK_EVAL_BASE_URL, and ASK_EVAL_APP_TOKEN to enable."
+    ),
+)
+
+# httpx is already a dev dep (used elsewhere in tests/). Import lazily after
+# the skip guard so collection doesn't fail in environments that don't have it
+# installed for unrelated reasons.
+import httpx  # noqa: E402
+
+GOLDEN_PATH = Path(__file__).parent / "ask_questions.yaml"
+RESULTS_DIR = Path(__file__).parent / ".results"
+RESULTS_PATH = RESULTS_DIR / "latest.json"
+
+ASK_PATH = "/intelligence/ask"
+DEFAULT_TIMEOUT_S = 60.0
+
+# ---------------------------------------------------------------------------
+# Rate-limit pacing
+# ---------------------------------------------------------------------------
+# The `/intelligence/ask` endpoint is rate-limited at 6/minute, 60/day per IP.
+# Fire-and-forget in a tight loop would trip the limiter and record false
+# failures, so the runner paces itself and optionally caps the question count.
+#
+#   ASK_EVAL_SLEEP_SECONDS  seconds to sleep between requests (default 11;
+#                           headroom under the 6/min limit). Set to 0 to
+#                           opt out entirely (e.g. local runs against a mock).
+#   ASK_EVAL_MAX_QUESTIONS  cap on how many questions the run sends. Unset
+#                           = unlimited. Useful for a cheap smoke pass
+#                           before spending the full daily quota.
+_SLEEP = float(os.environ.get("ASK_EVAL_SLEEP_SECONDS", "11"))
+_MAX = os.environ.get("ASK_EVAL_MAX_QUESTIONS")
+_MAX_INT = int(_MAX) if _MAX else None
+
+
+# ---------------------------------------------------------------------------
+# Loading
+# ---------------------------------------------------------------------------
+
+def _load_questions() -> list[dict[str, Any]]:
+    with GOLDEN_PATH.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+    if not isinstance(data, list):
+        raise ValueError(f"{GOLDEN_PATH} must be a YAML list of question dicts")
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Scoring helpers
+# ---------------------------------------------------------------------------
+
+def _mention_hits(answer: str, needles: list[str]) -> tuple[int, int]:
+    """Return (hits, total) for substring membership in lowercased answer."""
+    if not needles:
+        return (0, 0)
+    lc = (answer or "").lower()
+    hits = sum(1 for n in needles if str(n).lower() in lc)
+    return (hits, len(needles))
+
+
+def _forbidden_hits(answer: str, needles: list[str]) -> list[str]:
+    if not needles:
+        return []
+    lc = (answer or "").lower()
+    return [n for n in needles if str(n).lower() in lc]
+
+
+# ---------------------------------------------------------------------------
+# HTTP
+# ---------------------------------------------------------------------------
+
+def _make_client() -> httpx.Client:
+    base_url = os.getenv("ASK_EVAL_BASE_URL", "http://localhost:8000")
+    token = os.getenv("ASK_EVAL_APP_TOKEN", "")
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["X-App-Token"] = token
+    return httpx.Client(base_url=base_url, headers=headers, timeout=DEFAULT_TIMEOUT_S)
+
+
+def _ask(client: httpx.Client, question: str) -> tuple[dict[str, Any], int, float, int]:
+    """POST /intelligence/ask. Returns (payload, status_code, latency_ms, raw_bytes)."""
+    body = {"question": question}
+    t0 = time.perf_counter()
+    resp = client.post(ASK_PATH, json=body)
+    latency_ms = (time.perf_counter() - t0) * 1000.0
+    raw = resp.content or b""
+    try:
+        payload = resp.json() if raw else {}
+    except json.JSONDecodeError:
+        payload = {"_raw": raw.decode("utf-8", errors="replace")[:2000]}
+    return payload, resp.status_code, latency_ms, len(raw)
+
+
+# ---------------------------------------------------------------------------
+# Main eval
+# ---------------------------------------------------------------------------
+
+def test_ask_golden_eval_baseline():
+    """Run the full golden set and emit a baseline results artifact.
+
+    Sprint 0 policy: the suite PASSES as long as every HTTP call returned
+    200. We surface mention-hit rate and latency stats in the summary but
+    do not assert a quality floor yet — that threshold is Sprint 1's job,
+    once we have a baseline number to choose it from.
+    """
+    questions = _load_questions()
+    assert len(questions) == 50, f"Expected 50 questions, got {len(questions)}"
+
+    # Apply the optional cap BEFORE iterating so summary counts match what we
+    # actually sent. The full 50-question YAML is still validated above.
+    if _MAX_INT is not None:
+        questions = questions[:_MAX_INT]
+
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    per_entry: list[dict[str, Any]] = []
+    http_failures: list[dict[str, Any]] = []
+
+    started_at = time.time()
+
+    print(
+        f"[eval] pacing: {_SLEEP}s between requests, "
+        f"max={_MAX_INT if _MAX_INT is not None else 'unlimited'}"
+    )
+
+    with _make_client() as client:
+        for idx, q in enumerate(questions):
+            qid = q.get("id", "?")
+            question = q.get("question", "")
+            category = q.get("category", "?")
+            must_mention = list(q.get("must_mention") or [])
+            must_not_mention = list(q.get("must_not_mention") or [])
+
+            try:
+                payload, status, latency_ms, nbytes = _ask(client, question)
+            except httpx.HTTPError as e:
+                http_failures.append(
+                    {"id": qid, "question": question, "error": repr(e)}
+                )
+                per_entry.append(
+                    {
+                        "id": qid,
+                        "category": category,
+                        "question": question,
+                        "status": None,
+                        "latency_ms": None,
+                        "response_bytes": 0,
+                        "mention_hits": 0,
+                        "mention_total": len(must_mention),
+                        "forbidden_hits": [],
+                        "tokens_used": None,
+                        "error": repr(e),
+                    }
+                )
+                # Still pace after a transport error so repeated failures
+                # don't hammer the endpoint.
+                if _SLEEP > 0 and idx < len(questions) - 1:
+                    time.sleep(_SLEEP)
+                continue
+
+            answer = (payload or {}).get("answer", "") or ""
+            tokens_used = (payload or {}).get("tokens_used")
+
+            hits, total = _mention_hits(answer, must_mention)
+            forbidden = _forbidden_hits(answer, must_not_mention)
+
+            if status != 200:
+                http_failures.append(
+                    {"id": qid, "question": question, "status": status,
+                     "body": json.dumps(payload)[:500]}
+                )
+
+            per_entry.append(
+                {
+                    "id": qid,
+                    "category": category,
+                    "question": question,
+                    "status": status,
+                    "latency_ms": round(latency_ms, 1),
+                    "response_bytes": nbytes,
+                    "mention_hits": hits,
+                    "mention_total": total,
+                    "forbidden_hits": forbidden,
+                    "tokens_used": tokens_used,
+                    "answer_len": len(answer),
+                }
+            )
+
+            # Pace ourselves under the 6/min, 60/day per-IP rate limit.
+            # Skip the trailing sleep after the last question.
+            if _SLEEP > 0 and idx < len(questions) - 1:
+                time.sleep(_SLEEP)
+
+    finished_at = time.time()
+
+    # -----------------------------------------------------------------------
+    # Aggregates
+    # -----------------------------------------------------------------------
+    ok_entries = [e for e in per_entry if e.get("status") == 200]
+    latencies = [e["latency_ms"] for e in ok_entries if e.get("latency_ms") is not None]
+    total_hits = sum(e["mention_hits"] for e in per_entry)
+    total_needles = sum(e["mention_total"] for e in per_entry)
+    mention_hit_rate = (total_hits / total_needles) if total_needles else None
+    forbidden_violations = sum(1 for e in per_entry if e["forbidden_hits"])
+
+    summary = {
+        "version": "sprint0",
+        "started_at": started_at,
+        "finished_at": finished_at,
+        "duration_s": round(finished_at - started_at, 2),
+        "n_questions": len(per_entry),
+        "n_http_ok": len(ok_entries),
+        "n_http_fail": len(per_entry) - len(ok_entries),
+        "mention_hit_rate": mention_hit_rate,
+        "forbidden_violations": forbidden_violations,
+        "latency_ms": {
+            "p50": round(statistics.median(latencies), 1) if latencies else None,
+            "p95": round(_percentile(latencies, 95), 1) if latencies else None,
+            "max": round(max(latencies), 1) if latencies else None,
+            "mean": round(statistics.fmean(latencies), 1) if latencies else None,
+        },
+        "entries": per_entry,
+    }
+
+    RESULTS_PATH.write_text(json.dumps(summary, indent=2, default=str), encoding="utf-8")
+
+    # -----------------------------------------------------------------------
+    # Printable summary (captured by `-s`)
+    # -----------------------------------------------------------------------
+    print("\n" + "=" * 88)
+    print("ASK GOLDEN-SET EVAL — Sprint 0 baseline")
+    print("=" * 88)
+    print(f"{'id':<5} {'cat':<10} {'status':>6} {'ms':>8} {'bytes':>7} {'hits':>7}  question")
+    print("-" * 88)
+    for e in per_entry:
+        print(
+            f"{e['id']:<5} {e['category']:<10} "
+            f"{str(e.get('status') or '-'):>6} "
+            f"{(e.get('latency_ms') or 0):>8.1f} "
+            f"{e.get('response_bytes', 0):>7} "
+            f"{e['mention_hits']}/{e['mention_total']:<5} "
+            f"{(e['question'] or '')[:50]}"
+        )
+    print("-" * 88)
+    print(
+        f"n={summary['n_questions']}  "
+        f"ok={summary['n_http_ok']}  "
+        f"fail={summary['n_http_fail']}  "
+        f"hit_rate={summary['mention_hit_rate']}  "
+        f"forbidden={summary['forbidden_violations']}"
+    )
+    lat = summary["latency_ms"]
+    print(
+        f"latency ms  p50={lat['p50']}  p95={lat['p95']}  "
+        f"mean={lat['mean']}  max={lat['max']}"
+    )
+    print(f"artifact: {RESULTS_PATH}")
+    print("=" * 88)
+
+    # -----------------------------------------------------------------------
+    # Assertions — Sprint 0 is a measurement sprint, not a quality gate.
+    # We only fail the run if the endpoint itself is broken.
+    # -----------------------------------------------------------------------
+    assert not http_failures, (
+        f"{len(http_failures)} question(s) returned non-200 or errored — "
+        f"eval cannot baseline against a broken endpoint. First: {http_failures[0]}"
+    )
+
+
+def _percentile(values: list[float], p: float) -> float:
+    if not values:
+        return 0.0
+    s = sorted(values)
+    k = (len(s) - 1) * (p / 100.0)
+    lo = int(k)
+    hi = min(lo + 1, len(s) - 1)
+    frac = k - lo
+    return s[lo] + (s[hi] - s[lo]) * frac


### PR DESCRIPTION
## Summary
Promotes PR #397 from dev to main. Changes deploy workflow to:

1. `deploy-cloudrun` with `no_traffic: true` + tagged `candidate-<sha>` (0% traffic)
2. Resolve candidate revision's image URI
3. Update `reporium-alembic` Cloud Run Job to that image + set `alembic upgrade head`
4. Execute migrations with `--wait` (fails workflow on migration error)
5. Only on migration success: shift 100% traffic to candidate

Closes Codex audit findings on deploy ordering + stale alembic job image.

## Test plan
- [ ] Deploy workflow runs end-to-end on merge to main
- [ ] Candidate revision created at 0% traffic
- [ ] Alembic job runs against the commit-tagged image
- [ ] Traffic shifts only after migration success
- [ ] On simulated migration failure: old revision keeps 100% traffic

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)