### PR TITLE
fix(migrations): migration 038 autocommit blocks + valid unique DDL

### DIFF
--- a/migrations/versions/038_missing_indexes.py
+++ b/migrations/versions/038_missing_indexes.py
@@ -11,24 +11,28 @@ Changes:
      used by GET /gaps (ORDER BY skill is done in app code after fetch).
      category column on this table does not exist in the ORM model; using skill.
 
-  3. UNIQUE constraint on repo_commits(sha, repo_id) — uq_repo_commits_sha_repo
+  3. UNIQUE index on repo_commits(sha, repo_id) — uq_repo_commits_sha_repo
      Scoped per repo to prevent re-ingestion duplicates without cross-repo
      false-positive collisions (same SHA can appear in forks).
-     Created as DEFERRABLE INITIALLY DEFERRED so existing duplicate rows
-     (if any) do not cause immediate constraint violation on creation —
-     deferred constraints fire at transaction commit, which an INSERT-only
-     ingest path never triggers for pre-existing rows.
-     If duplicates exist, the migration will still succeed; cleanup SQL is
-     documented in the PR body.
+
+     NOTE: Creating a UNIQUE index (concurrent or not) validates existing rows
+     at build time and WILL fail if duplicates exist. A DEFERRABLE constraint
+     was considered but DEFERRABLE is a CONSTRAINT attribute, not an INDEX
+     attribute — CREATE UNIQUE INDEX ... DEFERRABLE is invalid Postgres DDL.
+     Instead, this migration runs a preflight duplicate check and raises
+     clearly if any (sha, repo_id) duplicates exist so operators can clean
+     them up before re-running.
 
 All DDL uses CONCURRENTLY where possible to avoid table locks in prod.
 CONCURRENTLY is NOT supported inside a transaction block, so each statement
-runs via op.execute() rather than op.create_index() (which wraps in a txn).
+runs inside op.get_context().autocommit_block() which temporarily exits
+Alembic's per-migration transaction.
 
 Revision ID: 038
 Revises: 037
 """
 
+import sqlalchemy as sa
 from alembic import op
 
 # revision identifiers, used by Alembic.
@@ -39,34 +43,56 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # 1. trend_snapshots.tag — full-scan today, O(1) lookup after
-    op.execute("""
-        CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_trend_snapshots_tag
-        ON trend_snapshots (tag)
-    """)
+    # Preflight: CREATE UNIQUE INDEX CONCURRENTLY still validates existing rows
+    # and will fail if duplicates exist. Fail loudly up-front with a clear
+    # message rather than letting Postgres emit a generic unique-violation.
+    conn = op.get_bind()
+    dupe = conn.execute(
+        sa.text(
+            """
+            SELECT sha, repo_id, COUNT(*) AS n
+            FROM repo_commits
+            GROUP BY sha, repo_id
+            HAVING COUNT(*) > 1
+            LIMIT 1
+            """
+        )
+    ).first()
+    if dupe is not None:
+        raise RuntimeError(
+            "repo_commits has duplicate (sha, repo_id) rows — clean up before "
+            f"running migration 038. Example: sha={dupe[0]!r} repo_id={dupe[1]!r} "
+            f"count={dupe[2]}. See PR body for cleanup SQL."
+        )
 
-    # 2. gap_analysis.skill — no non-PK indexes today
-    #    'skill' is the primary filter column (category column doesn't exist in
-    #    current ORM — verified against migrations/versions/001_initial_schema.py)
-    op.execute("""
-        CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_gap_analysis_skill
-        ON gap_analysis (skill)
-    """)
+    # CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
+    # autocommit_block() temporarily exits Alembic's wrapping transaction.
+    with op.get_context().autocommit_block():
+        # 1. trend_snapshots.tag — full-scan today, O(1) lookup after
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_trend_snapshots_tag "
+            "ON trend_snapshots (tag)"
+        )
 
-    # 3. repo_commits(sha, repo_id) UNIQUE — prevents re-ingestion dupes
-    #    DEFERRABLE INITIALLY DEFERRED: fires at transaction commit, not row insert.
-    #    This means an existing duplicate won't block the migration itself —
-    #    only new inserts/updates will enforce uniqueness going forward.
-    #    CONCURRENTLY is not supported for UNIQUE constraints, so we use a
-    #    standard CREATE UNIQUE INDEX CONCURRENTLY instead.
-    op.execute("""
-        CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uq_repo_commits_sha_repo
-        ON repo_commits (sha, repo_id)
-        DEFERRABLE INITIALLY DEFERRED
-    """)
+        # 2. gap_analysis.skill — no non-PK indexes today
+        #    'skill' is the primary filter column (category column doesn't exist
+        #    in current ORM — verified against 001_initial_schema.py)
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ix_gap_analysis_skill "
+            "ON gap_analysis (skill)"
+        )
+
+        # 3. repo_commits(sha, repo_id) UNIQUE — prevents re-ingestion dupes.
+        #    Plain concurrent unique index; deferrability dropped (see header).
+        op.execute(
+            "CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS uq_repo_commits_sha_repo "
+            "ON repo_commits (sha, repo_id)"
+        )
 
 
 def downgrade() -> None:
-    op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_trend_snapshots_tag")
-    op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_gap_analysis_skill")
-    op.execute("DROP INDEX CONCURRENTLY IF EXISTS uq_repo_commits_sha_repo")
+    # DROP INDEX CONCURRENTLY also cannot run inside a transaction block.
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_trend_snapshots_tag")
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS ix_gap_analysis_skill")
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS uq_repo_commits_sha_repo")


### PR DESCRIPTION
## Summary

Fixes two P1 bugs in `migrations/versions/038_missing_indexes.py` flagged by Codex review. These were blocking integration-tests on reporium-api#398 (dev->main) and reporium-ingestion#63.

### Bug 1 — `CREATE INDEX CONCURRENTLY` inside Alembic's transaction

Alembic wraps every migration in a transaction by default. `op.execute()` does NOT escape it, so every `CREATE INDEX CONCURRENTLY` / `DROP INDEX CONCURRENTLY` statement in `upgrade()` / `downgrade()` would fail with:

> `CREATE INDEX CONCURRENTLY cannot run inside a transaction block`

**Fix**: wrap the concurrent DDL in `with op.get_context().autocommit_block():`, which temporarily exits the wrapping transaction. One block per function (upgrade / downgrade); Alembic docs allow multiple statements inside a single autocommit_block, and nesting is disallowed anyway.

### Bug 2 — invalid `DEFERRABLE INITIALLY DEFERRED` on `CREATE UNIQUE INDEX`

`DEFERRABLE` is a CONSTRAINT attribute, not an INDEX attribute. `CREATE UNIQUE INDEX ... DEFERRABLE INITIALLY DEFERRED` is not valid Postgres DDL. Separately, the previous header comment claimed duplicates wouldn't block the migration — that's wrong regardless of syntax: a unique index build validates existing rows at creation time.

**Picked Option A** (drop deferrability + preflight duplicate check). Rationale:
- Grepped the repo for `SET CONSTRAINTS` / `DEFERRED` usage — no hits outside the migration itself.
- No test fixtures rely on deferred uniqueness across a transaction.
- `repo_commits` is an ingest dedupe table; the real contract is "prevent duplicates," not "defer the check to commit time."

Option B (create a deferrable `UNIQUE` constraint `USING INDEX`) would have been warranted only if there was evidence of deferred-constraint semantics being required — there isn't.

The migration now runs a preflight query and raises a clear `RuntimeError` listing an example duplicate if any `(sha, repo_id)` collisions exist, so operators can clean up before re-running rather than getting a generic unique-violation from Postgres.

### Cleanup SQL (if preflight trips)

```sql
-- Keep the lowest-id row per (sha, repo_id), delete the rest.
DELETE FROM repo_commits a
USING repo_commits b
WHERE a.sha = b.sha
  AND a.repo_id = b.repo_id
  AND a.id > b.id;
```

## Changes

- Wrapped all `CREATE INDEX CONCURRENTLY` / `DROP INDEX CONCURRENTLY` statements in `op.get_context().autocommit_block()`.
- Dropped `DEFERRABLE INITIALLY DEFERRED` from the unique index DDL.
- Added preflight duplicate check on `repo_commits(sha, repo_id)` that raises `RuntimeError` with an example duplicate.
- Corrected the header docstring (was factually wrong about deferrable semantics and duplicate validation).
- Preserved `revision = "038"`, `down_revision = "037"`, structural intent, and index names.

## Test plan

- [x] File parses (`python -m ast`).
- [ ] CI on this PR — `integration-tests` job should now get past migration apply.
- [ ] Once green, reporium-api#398 and reporium-ingestion#63 should re-run green for the same reason.

Not enabling auto-merge.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>