### PR TITLE
fix(ci): correct setup-gcloud SHA pin blocking all deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
           pip install -r requirements.txt
 
       - name: Set up gcloud
-        uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f27b12cd0b5 # v2.1.4
+        uses: google-github-actions/setup-gcloud@77e7a554d41e2ee56fc945c52dfd3f33d12def9a # v2.1.4
 
       # Option B1 — no-traffic candidate revision + migrate + promote.
       #


### PR DESCRIPTION
## Summary
- setup-gcloud SHA pin in deploy.yml pointed at a non-existent commit (\`77e7a554...3f27b12cd0b5\`), causing every push to main to fail with \"Unable to resolve action\" before any deploy logic runs.
- Corrected to actual v2.1.4 SHA \`77e7a554...3f33d12def9a\` (verified via GitHub refs API).

## Impact
- Blocks all production deploys. Discovered on first deploy triggered by #398 merge.

## Test plan
- [ ] CI green on this PR
- [ ] After merge, re-deploy triggers Option B1 no-traffic candidate flow end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)