### PR TITLE
fix(deploy): set ENVIRONMENT on alembic Cloud Run Job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,10 +123,15 @@ jobs:
         run: |
           set -euo pipefail
           echo "Pointing reporium-alembic job at ${{ steps.image.outputs.uri }}"
+          # ENVIRONMENT=production triggers app/config.py._resolve_database_url()
+          # to fetch DATABASE_URL from Secret Manager (reporium-db-url-async).
+          # Without it, the container falls back to localhost:5432 and hits
+          # ConnectionRefusedError. Matches env vars on the reporium-api service.
           gcloud run jobs update reporium-alembic \
             --image="${{ steps.image.outputs.uri }}" \
             --command=alembic \
             --args=upgrade,head \
+            --set-env-vars=ENVIRONMENT=production,GCP_PROJECT=perditio-platform \
             --project=perditio-platform \
             --region=us-central1
 


### PR DESCRIPTION
## Summary
First end-to-end run of Option B1 (after #398+#401+#402) failed at the migrate step:
\`ConnectionRefusedError: [Errno 111] Connect call failed ('127.0.0.1', 5432)\`

**Root cause:** The alembic Cloud Run Job has no env vars. \`app/config.py._resolve_database_url()\` only loads \`DATABASE_URL\` from Secret Manager when \`ENVIRONMENT=production\` is set — otherwise it returns the dev localhost URL. The reporium-api service has \`ENVIRONMENT=production\`; the job didn't.

**Fix:** \`--set-env-vars=ENVIRONMENT=production,GCP_PROJECT=perditio-platform\` on the job-update step.

## Invariant held ✅
The no-traffic + migrate + promote pattern worked as designed: migration failure kept the candidate at 0% traffic, the old revision kept serving users, no broken code went live.

## Test plan
- [ ] CI green
- [ ] Post-merge deploy completes migrate + promote end-to-end
- [ ] reporium-api service serves traffic on new revision after promotion

🤖 Generated with [Claude Code](https://claude.com/claude-code)