### PR TITLE
fix(migrations): enable autocommit_block() support in async env

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,17 +45,48 @@ jobs:
 
       - run: pip install pytest pytest-asyncio==0.24.0 httpx pytest-timeout==2.3.1
 
-      # Alembic migration smoke test: run `alembic upgrade head` against the
-      # pgvector service BEFORE pytest. Catches deploy-blocking migration bugs
-      # in CI (e.g. bad DDL, autocommit_block misuse, missing env support) that
-      # previously only surfaced in the production deploy job or ingestion CI.
-      # See #400/#403/#404 — several escaped unit tests.
-      - name: Alembic upgrade head (migration smoke test)
-        run: alembic upgrade head
-        timeout-minutes: 3
-
       - run: pytest tests/ -v --timeout=60
         timeout-minutes: 10
+
+  # Alembic migration smoke test: run `alembic upgrade head` against a
+  # dedicated pgvector service. Catches deploy-blocking migration bugs
+  # (bad DDL, autocommit_block misuse, missing env support) that previously
+  # only surfaced in production deploy or ingestion CI. See #400/#403/#404.
+  #
+  # Runs in its own job so the preloaded schema doesn't pollute the test DB
+  # used by pytest (which expects to manage schema via fixtures).
+  migration-smoke:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: reporium_migrate_test
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5433/reporium_migrate_test
+      ENVIRONMENT: test
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: '3.12'
+      - run: pip install -r requirements.txt
+      - name: Alembic upgrade head
+        run: alembic upgrade head
+        timeout-minutes: 3
+      - name: Alembic downgrade -1 / upgrade head (idempotency)
+        run: |
+          alembic downgrade -1
+          alembic upgrade head
+        timeout-minutes: 3
 
   notify-on-failure:
     needs: test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,6 +45,15 @@ jobs:
 
       - run: pip install pytest pytest-asyncio==0.24.0 httpx pytest-timeout==2.3.1
 
+      # Alembic migration smoke test: run `alembic upgrade head` against the
+      # pgvector service BEFORE pytest. Catches deploy-blocking migration bugs
+      # in CI (e.g. bad DDL, autocommit_block misuse, missing env support) that
+      # previously only surfaced in the production deploy job or ingestion CI.
+      # See #400/#403/#404 — several escaped unit tests.
+      - name: Alembic upgrade head (migration smoke test)
+        run: alembic upgrade head
+        timeout-minutes: 3
+
       - run: pytest tests/ -v --timeout=60
         timeout-minutes: 10
 

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -31,14 +31,25 @@ def run_migrations_offline() -> None:
 
 
 def do_run_migrations(connection) -> None:
-    context.configure(connection=connection, target_metadata=target_metadata)
-    with context.begin_transaction():
-        context.run_migrations()
+    # transaction_per_migration=True is REQUIRED for op.get_context().autocommit_block()
+    # to work. autocommit_block() suspends the current Alembic-managed transaction and
+    # runs DDL in AUTOCOMMIT mode — needed for CREATE INDEX CONCURRENTLY (migration 038).
+    # Without this flag, autocommit_block() raises AssertionError because there's no
+    # Alembic-scoped transaction to suspend.
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        transaction_per_migration=True,
+    )
+    context.run_migrations()
 
 
 async def run_async_migrations() -> None:
+    # Use engine.connect() (not .begin()) so Alembic owns transaction boundaries via
+    # transaction_per_migration=True. engine.begin() would start a wrapping transaction
+    # that autocommit_block() can't suspend.
     engine = create_async_engine(settings.database_url)
-    async with engine.begin() as conn:
+    async with engine.connect() as conn:
         await conn.run_sync(do_run_migrations)
     await engine.dispose()
 


### PR DESCRIPTION
## Summary
Codex audit on #63 integration test rerun surfaced AssertionError inside \`op.get_context().autocommit_block()\` during migration 038. The async Alembic env wrapped everything in \`engine.begin()\` + \`context.begin_transaction()\`, leaving autocommit_block() with no Alembic-scoped transaction to suspend.

## Fix
- \`context.configure(..., transaction_per_migration=True)\`: Alembic owns per-migration transactions that \`autocommit_block()\` can suspend.
- \`engine.connect()\` instead of \`engine.begin()\`: removes the outer wrapping transaction so transaction_per_migration takes effect.

## Trade-off
Each migration commits independently. If migration N fails, 1..N-1 are already committed. This is the canonical pattern for autocommit-requiring DDL (CREATE INDEX CONCURRENTLY) and matches production Alembic setups.

## Test plan
- [ ] CI green
- [ ] Post-merge production deploy: candidate promotes to 100% traffic (full Option B1 flow succeeds)
- [ ] #63 integration tests pass on rerun

🤖 Generated with [Claude Code](https://claude.com/claude-code)