### PR TITLE
fix(test): remove dead ALTER TABLE firing per insert in platform_metrics helper

### DIFF
--- a/tests/test_platform_metrics.py
+++ b/tests/test_platform_metrics.py
@@ -28,9 +28,6 @@ async def _insert_repo(
     async with async_session_factory() as session:
         repo_id = str(uuid.uuid4())
         await session.execute(
-            text("ALTER TABLE repos ADD COLUMN IF NOT EXISTS integration_tags JSONB")
-        )
-        await session.execute(
             text(
                 """
                 INSERT INTO repos (id, name, owner, github_url, forked_from, is_fork, is_private, integration_tags)


### PR DESCRIPTION
## Summary

- Removes the redundant `ALTER TABLE repos ADD COLUMN IF NOT EXISTS integration_tags JSONB` from `_insert_repo` in `tests/test_platform_metrics.py`.
- The column is already created by migration [`002_add_enrichment_columns.py`](migrations/versions/002_add_enrichment_columns.py#L23) in production and by `Base.metadata.create_all()` in [`tests/conftest.py:87`](tests/conftest.py#L87), so the ALTER is a no-op — but it still takes an ACCESS EXCLUSIVE lock on `repos` every time a test calls `_insert_repo`.

## Why this unblocks #407

Under the default pytest test-collection order on GitHub-hosted runners, `test_platform_metrics.py::test_metrics_backfill_reports_progress` and `::test_metrics_graph_quality_reports_exact_and_proxy_metrics` intermittently time out with `asyncpg TimeoutError` / "Event loop is closed". The failure reproduced on 3 consecutive CI runs for #407 (which only touches `tests/golden/*`) while dev was green on the same SHA. Removing the lock-acquisition per insert removes the contention source.

## Test plan

- [ ] CI: full `pytest tests/ -v --timeout=60` passes
- [ ] #407 rerun passes after this merges
- [ ] No regression in other tests that use `_insert_repo`

🤖 Generated with [Claude Code](https://claude.com/claude-code)