### PR TITLE
fix(ask): route "X with the most stars" through smart-router to bypass similarity early-exit

### DIFF
--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -214,6 +214,16 @@ _ROUTE_TOP_STARRED = re.compile(
     r"^(what|which|show|list)\s+(are\s+)?(the\s+)?(?:top|most[- ]starred|popular|best)\s+(\d+\s+)?(repos?|repositories|tools?|projects?)?\?*$",
     re.IGNORECASE,
 )
+# KAN-ask-stars-topic: sibling route for "X with the most stars" phrasing.
+# MiniLM-L6-v2 embeds "stars" toward the celestial sense, so vector retrieval
+# falls below _MIN_RETRIEVAL_SIMILARITY and the LLM early-exits. Catching the
+# shape here bypasses retrieval entirely. Captures an optional topic / category
+# ("RAG tools", "AI agents") so the SQL can narrow by primary_category.
+_ROUTE_TOP_STARRED_BY_TOPIC = re.compile(
+    r"^(?:what|which|show|list|give|tell)\s+(?:me\s+)?(?:are\s+)?(?:the\s+)?"
+    r"(?P<topic>.+?)\s+with\s+(?:the\s+)?(?:most|highest|top)\s+stars\s*\?*$",
+    re.IGNORECASE,
+)
 _ROUTE_REPO_INFO = re.compile(
     r"^(what is|tell me about|describe|info about|explain)\s+(?:the\s+)?(?:repo(?:sitory)?\s+)?(?P<name>[a-zA-Z0-9_-]+(?:/[a-zA-Z0-9_-]+)?)\s*\?*$",
     re.IGNORECASE,
@@ -556,20 +566,58 @@ async def _try_smart_route_inner(question: str, db: AsyncSession) -> dict | None
             "route": "list_categories",
         }
 
-    # --- Top starred repos ---
-    m = _ROUTE_TOP_STARRED.match(q)
-    if m:
-        limit = int(m.group(4).strip()) if m.group(4) else 10
+    # --- Top starred repos (with optional topic filter) ---
+    # KAN-ask-stars-topic: check the "X with the most stars" shape FIRST so we
+    # can narrow by category; fall back to the bare _ROUTE_TOP_STARRED shape
+    # for plain "top/most starred repos" queries.
+    topic_match = _ROUTE_TOP_STARRED_BY_TOPIC.match(q)
+    bare_match = _ROUTE_TOP_STARRED.match(q)
+    if topic_match or bare_match:
+        topic: str | None = None
+        if topic_match:
+            raw_topic = topic_match.group("topic").strip().lower()
+            # Strip trailing generic noun so "RAG tools" → "rag", "AI agent repos" → "ai agent".
+            raw_topic = re.sub(
+                r"\s*(?:repos?|repositories|tools?|projects?|libraries?|frameworks?)\s*$",
+                "",
+                raw_topic,
+            ).strip()
+            topic = raw_topic or None
+
+        limit = 10
+        if bare_match and bare_match.group(4):
+            limit = int(bare_match.group(4).strip())
         limit = min(limit, 25)  # cap
-        result = await db.execute(text("""
-            SELECT name, owner, COALESCE(parent_stars, stargazers_count, 0) as stars,
-                   primary_category, description
-            FROM repos
-            WHERE is_private = false
-            ORDER BY COALESCE(parent_stars, stargazers_count, 0) DESC
-            LIMIT :limit
-        """), {"limit": limit})
+
+        if topic:
+            sql = text("""
+                SELECT name, owner, COALESCE(parent_stars, stargazers_count, 0) as stars,
+                       primary_category, description
+                FROM repos
+                WHERE is_private = false
+                  AND LOWER(primary_category) LIKE :topic
+                ORDER BY COALESCE(parent_stars, stargazers_count, 0) DESC
+                LIMIT :limit
+            """)
+            params = {"limit": limit, "topic": f"%{topic}%"}
+        else:
+            sql = text("""
+                SELECT name, owner, COALESCE(parent_stars, stargazers_count, 0) as stars,
+                       primary_category, description
+                FROM repos
+                WHERE is_private = false
+                ORDER BY COALESCE(parent_stars, stargazers_count, 0) DESC
+                LIMIT :limit
+            """)
+            params = {"limit": limit}
+
+        result = await db.execute(sql, params)
         rows = result.fetchall()
+        # If a topic was specified but nothing matched, fall through to the LLM
+        # rather than dead-ending with "Top 10 ... in <topic>" and an empty list.
+        if topic and not rows:
+            return None
+
         parts = []
         sources = []
         for row in rows:
@@ -583,8 +631,13 @@ async def _try_smart_route_inner(question: str, db: AsyncSession) -> dict | None
                 "forked_from": None, "problem_solved": None,
                 "integration_tags": [],
             })
+        header = (
+            f"Top {len(rows)} most-starred repos in \"{topic}\":"
+            if topic
+            else f"Top {limit} most-starred repos in Reporium:"
+        )
         return {
-            "answer": f"Top {limit} most-starred repos in Reporium:\n\n" + "\n".join(parts),
+            "answer": f"{header}\n\n" + "\n".join(parts),
             "sources": sources,
             "route": "top_starred",
         }

--- a/tests/test_intelligence_router_units.py
+++ b/tests/test_intelligence_router_units.py
@@ -29,6 +29,8 @@ import pytest
 from app.routers.intelligence import (
     _MODEL_HAIKU,
     _MODEL_SONNET,
+    _ROUTE_TOP_STARRED,
+    _ROUTE_TOP_STARRED_BY_TOPIC,
     _build_community_signals_snippet,
     _build_pros_cons_snippet,
     _coerce_cached_sources,
@@ -396,3 +398,49 @@ class TestHasEncodedPayloadFalsePositives:
     def test_rot13_requires_word_boundary(self):
         """Naively matching 'rot13' inside 'carrot13k' would be a false positive."""
         assert _has_encoded_payload("the carrot13k library is great") is False
+
+
+# ---------------------------------------------------------------------------
+# _ROUTE_TOP_STARRED_BY_TOPIC — regression guard for the MiniLM "stars"
+# celestial-sense drift that dropped "show me X with the most stars" below
+# _MIN_RETRIEVAL_SIMILARITY and triggered the early-exit canned response.
+# ---------------------------------------------------------------------------
+
+class TestRouteTopStarredByTopic:
+    """The new sibling route must catch 'X with the most stars' shapes and
+    leave the canonical 'top/most-starred repos' shape to the original route.
+    """
+
+    def test_rag_tools_with_most_stars_matches_topic_route(self):
+        """Reported production regression: canned not-enough-info response."""
+        m = _ROUTE_TOP_STARRED_BY_TOPIC.match("Show me RAG tools with the most stars")
+        assert m is not None
+        assert m.group("topic").strip().lower() == "rag tools"
+
+    def test_ai_agent_repos_with_most_stars_matches_topic_route(self):
+        m = _ROUTE_TOP_STARRED_BY_TOPIC.match(
+            "what are the AI agent repos with the most stars"
+        )
+        assert m is not None
+        assert m.group("topic").strip().lower() == "ai agent repos"
+
+    def test_bare_tools_with_most_stars_matches_with_generic_topic(self):
+        """No specific topic — captured 'tools' is stripped to empty by the
+        handler's noun-suffix cleanup, so it behaves like the bare route.
+        """
+        m = _ROUTE_TOP_STARRED_BY_TOPIC.match("show tools with the most stars")
+        assert m is not None
+        assert m.group("topic").strip().lower() == "tools"
+
+    def test_canonical_top_starred_still_matches_original_route(self):
+        """Regression guard: the original shape must keep matching the
+        original regex after the sibling route was added.
+        """
+        assert _ROUTE_TOP_STARRED.match("show the top 10 repos") is not None
+        assert _ROUTE_TOP_STARRED.match("what are the most starred repos") is not None
+
+    def test_repo_info_query_does_not_match_topic_route(self):
+        """'tell me about kestra' must fall through to the repo-info route,
+        not get swallowed by the new stars-topic pattern.
+        """
+        assert _ROUTE_TOP_STARRED_BY_TOPIC.match("tell me about kestra") is None


### PR DESCRIPTION
## Repro

Production `/intelligence/ask` query:
> **Show me RAG tools with the most stars**

…returns the canned fallback:
> *I don't have enough relevant information in the Reporium knowledge base to answer that question. Try asking about specific AI dev tools, libraries, or repository categories.*

## Root cause

- `app/routers/intelligence.py:152` sets `_MIN_RETRIEVAL_SIMILARITY = 0.40`. When every retrieved source scores below that floor, `_should_early_exit(...)` fires and we return `_EARLY_EXIT_ANSWER` without calling the LLM.
- MiniLM-L6-v2 embeds the token **"stars"** toward the **celestial-object** sense, pulling the query vector away from the repo-oriented corpus. All cosine similarities come back under 0.40, so the early-exit triggers.
- Smart-router regexes bypass vector retrieval and the similarity check entirely — if a query lands a route, it never sees the embedding model.
- Existing `_ROUTE_TOP_STARRED` (line ~213) only matches **"top / most-starred / popular / best repos"** phrasing. It does **not** match the **"X with the most stars"** shape, so the query falls through to retrieval and hits the early-exit.

## Fix

Add a sibling route `_ROUTE_TOP_STARRED_BY_TOPIC` next to `_ROUTE_TOP_STARRED` and fold both into one handler.

### Regex diff

```diff
 _ROUTE_TOP_STARRED = re.compile(
     r"^(what|which|show|list)\s+(are\s+)?(the\s+)?(?:top|most[- ]starred|popular|best)\s+(\d+\s+)?(repos?|repositories|tools?|projects?)?\?*$",
     re.IGNORECASE,
 )
+# KAN-ask-stars-topic: sibling route for "X with the most stars" phrasing.
+# MiniLM-L6-v2 embeds "stars" toward the celestial sense, so vector retrieval
+# falls below _MIN_RETRIEVAL_SIMILARITY and the LLM early-exits. Catching the
+# shape here bypasses retrieval entirely. Captures an optional topic / category
+# ("RAG tools", "AI agents") so the SQL can narrow by primary_category.
+_ROUTE_TOP_STARRED_BY_TOPIC = re.compile(
+    r"^(?:what|which|show|list|give|tell)\s+(?:me\s+)?(?:are\s+)?(?:the\s+)?"
+    r"(?P<topic>.+?)\s+with\s+(?:the\s+)?(?:most|highest|top)\s+stars\s*\?*$",
+    re.IGNORECASE,
+)
```

### Handler

The handler now:
1. Tries the topic route first, then the bare `_ROUTE_TOP_STARRED`.
2. Extracts `topic` from the named group, strips a trailing generic noun (`repos`, `tools`, `projects`, `libraries`, `frameworks`), lowercases.
3. If `topic` is set, adds `AND LOWER(primary_category) LIKE :topic` to the SQL and uses a topic-aware header; otherwise falls back to the original no-filter query and header.
4. If a topic filter returns zero rows, returns `None` so the LLM can take a shot instead of dead-ending with "Top 10 … in `<topic>`" and an empty list.

### Not done (out of scope)

- `_MIN_RETRIEVAL_SIMILARITY = 0.40` is untouched — lowering it is a separate ADR decision.
- `_EARLY_EXIT_ANSWER` text is untouched.

## Tests

5 new cases in `tests/test_intelligence_router_units.py` (class `TestRouteTopStarredByTopic`):

- `test_rag_tools_with_most_stars_matches_topic_route` — the reported query, topic == `"rag tools"`.
- `test_ai_agent_repos_with_most_stars_matches_topic_route` — second shape, topic == `"ai agent repos"`.
- `test_bare_tools_with_most_stars_matches_with_generic_topic` — `"show tools with the most stars"` captures `"tools"`, which the handler's noun-suffix strip reduces to empty so the query behaves like the bare route.
- `test_canonical_top_starred_still_matches_original_route` — regression guard: `"show the top 10 repos"` and `"what are the most starred repos"` still match `_ROUTE_TOP_STARRED`.
- `test_repo_info_query_does_not_match_topic_route` — negative case: `"tell me about kestra"` does not match.

Local pytest: **62 passed** in `tests/test_intelligence_router_units.py`, `tests/test_intelligence.py` clean (14 passed, 28 DB-skipped, no failures).

## Test plan

- [ ] CI green on this branch.
- [ ] Once merged to `dev` and deployed, curl `/intelligence/ask` with the reproducing query and confirm route `top_starred` + a non-early-exit answer.
- [ ] Spot-check `"what are the top 10 repos"` still returns the canonical top-starred answer.
- [ ] Spot-check `"tell me about kestra"` still hits the `repo_info` route.

**Do not deploy on merge** — user wants review before this ships to production.

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>