### PR TITLE
KAN-XX: emit latency_ms on /intelligence/ask/stream done events

### DIFF
--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -1731,7 +1731,10 @@ class StreamEvent(BaseModel):
 
     - ``sources``: initial event carrying the retrieved ``sources`` list
     - ``token``: incremental answer chunk in ``text``
-    - ``done``: terminal success event carrying ``tokens`` usage and ``model``
+    - ``done``: terminal success event carrying ``tokens`` usage, ``model``,
+      ``latency_ms`` (wall time from request start), and optionally ``route``
+      / ``cache_hit`` / ``cache_source`` when a smart-router or cache path
+      answered the query.
     - ``error``: terminal failure event carrying ``message``
     """
     type: Literal["sources", "token", "done", "error"]
@@ -1740,6 +1743,10 @@ class StreamEvent(BaseModel):
     message: str | None = None
     tokens: dict | None = None
     model: str | None = None
+    latency_ms: int | None = None
+    route: str | None = None
+    cache_hit: bool | None = None
+    cache_source: str | None = None
 
 
 class TaxonomyGapSignal(BaseModel):
@@ -2889,7 +2896,7 @@ async def intelligence_ask_stream(
                 logger.info("off-topic query rejected (stream): %s", req.question[:80])
                 yield f"data: {json.dumps({'type': 'sources', 'sources': []})}\n\n"
                 yield f"data: {json.dumps({'type': 'token', 'text': _OFF_TOPIC_RESPONSE})}\n\n"
-                yield f"data: {json.dumps({'type': 'done', 'tokens': {'input': 0, 'output': 0}, 'model': 'off-topic'})}\n\n"
+                yield f"data: {json.dumps({'type': 'done', 'tokens': {'input': 0, 'output': 0, 'total': 0}, 'model': 'off-topic', 'latency_ms': int((time.monotonic() - _started_at) * 1000)})}\n\n"
                 return
 
             qctx = await _prepare_query(
@@ -2926,14 +2933,17 @@ async def intelligence_ask_stream(
                 done_event = {
                     'type': 'done',
                     'tokens': cached.get("tokens_used", {'input': 0, 'output': 0, 'total': 0}),
+                    'latency_ms': int((time.monotonic() - _started_at) * 1000),
                 }
                 if cached.get("cache_hit"):
                     done_event['cache_hit'] = True
                     done_event['cache_source'] = cache_source
                 if route:
                     done_event['route'] = route
-                if not route:
-                    done_event['model'] = qctx.model
+                # Always emit the model so the UI can show what answered the
+                # query — even when a smart-router path took over (in which
+                # case the "model" is really the router label).
+                done_event['model'] = route or qctx.model
                 yield f"data: {json.dumps(done_event)}\n\n"
 
                 asyncio.create_task(_log_query(
@@ -2970,7 +2980,7 @@ async def intelligence_ask_stream(
                     chunk = word + (" " if i < len(words) - 1 else "")
                     yield f"data: {json.dumps({'type': 'token', 'text': chunk})}\n\n"
                     await asyncio.sleep(0)
-                yield f"data: {json.dumps({'type': 'done', 'tokens': {'input': 0, 'output': 0, 'total': 0}, 'model': 'early-exit'})}\n\n"
+                yield f"data: {json.dumps({'type': 'done', 'tokens': {'input': 0, 'output': 0, 'total': 0}, 'model': 'early-exit', 'latency_ms': int((time.monotonic() - _started_at) * 1000)})}\n\n"
                 if qctx.redis_cache_key:
                     asyncio.create_task(cache.set(qctx.redis_cache_key, {
                         "answer": _EARLY_EXIT_ANSWER,
@@ -3115,7 +3125,8 @@ async def intelligence_ask_stream(
                     input_tokens = payload.usage.input_tokens
                     output_tokens = payload.usage.output_tokens
                     tokens_info = {'input': input_tokens, 'output': output_tokens, 'total': input_tokens + output_tokens}
-                    yield f"data: {json.dumps({'type': 'done', 'tokens': tokens_info, 'model': qctx.model})}\n\n"
+                    _latency_ms = int((time.monotonic() - _started_at) * 1000)
+                    yield f"data: {json.dumps({'type': 'done', 'tokens': tokens_info, 'model': qctx.model, 'latency_ms': _latency_ms})}\n\n"
                     # Record actual token-based cost
                     _stream_est_cost = _estimate_cost(input_tokens, output_tokens, qctx.model)
                     await record_cost(_stream_est_cost, model=qctx.model)


### PR DESCRIPTION
## Summary
PR2/4 of the Ask UX series. Backend half — adds `latency_ms` (and tightens `model` emission) on every terminal `done` event of the `/intelligence/ask/stream` SSE endpoint, so the frontend can show users how long each answer took and what produced it.

- All four `done` paths (streaming Claude, cache-hit, off-topic, early-exit) now emit `latency_ms` measured from the request start (`time.monotonic()`).
- `StreamEvent` Pydantic schema declares `latency_ms`, `route`, `cache_hit`, `cache_source` as proper typed fields (previously only some paths emitted them; the schema didn't know).
- Cache-hit path now always emits `model` — using the route label (e.g. `comparison`, `category-filter`) when the smart router answered, so the UI never has to guess.
- Off-topic / early-exit done events now also include `total: 0` in the tokens dict so the frontend's `tokens.total > 0` guards work uniformly.

Pairs with the frontend PR in `perditioinc/reporium` (claude/feature/ask-ux-pr2-telemetry). Frontend is forward-compatible — it already gracefully hides any field this PR doesn't supply, so deploys can land in either order.

## Test plan
- [x] Existing pytest suite still passes for `app/routers/intelligence.py`
- [ ] Manual smoke once deployed to Cloud Run: comparison query → footer shows `⚡ comparison · Xms · 2 repos`
- [ ] Manual smoke: open-ended LLM-routed query → footer shows `Haiku 4.5 · X.Ys · NN tokens (in↑ out↓) · M repos`

## Notes
Targeting `main` because the upstream `dev` branch was pruned (see CLAUDE.md GitFlow — that doc is stale; promotion path is now feature → main directly until dev is restored).

KAN-XX is a placeholder — will be replaced with the real ticket once the Sprint 2 epic is broken out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)