### PR TITLE
KAN-XX: thumbs up/down feedback for /intelligence/ask

### DIFF
--- a/app/models/query_log.py
+++ b/app/models/query_log.py
@@ -57,5 +57,9 @@ class QueryLog(Base):
     action_taken: Mapped[str | None] = mapped_column(Text, nullable=True)
     # Computed spend in cents (input_tokens + output_tokens × model rate)
     cost_cents: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    # "positive" | "negative" | "neutral" — optional, written by Workato
+    # "positive" | "negative" | "neutral" — written by Workato OR by the
+    # POST /intelligence/feedback endpoint (PR3 of Ask UX series).
     sentiment: Mapped[str | None] = mapped_column(String(16), nullable=True)
+    # UUID4 minted at request start, emitted in the streamed `done` event,
+    # and used as the lookup key for thumbs up/down feedback.
+    query_id: Mapped[str | None] = mapped_column(String(36), nullable=True, index=True)

--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -19,6 +19,7 @@ import unicodedata
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Literal
+import uuid
 from uuid import UUID
 
 import anthropic
@@ -1446,6 +1447,7 @@ async def _log_query(
     model: str,
     question_embedding: np.ndarray | None = None,
     cache_hit: bool = False,
+    query_id: str | None = None,
 ) -> None:
     """Fire-and-forget: write one row to query_log. Never raises."""
     # Redact PII from the persisted copy; the original text was already sent
@@ -1467,7 +1469,8 @@ async def _log_query(
                         latency_ms,
                         model,
                         cache_hit,
-                        question_embedding_vec
+                        question_embedding_vec,
+                        query_id
                     ) VALUES (
                         :question,
                         :answer_truncated,
@@ -1480,7 +1483,8 @@ async def _log_query(
                         :latency_ms,
                         :model,
                         :cache_hit,
-                        CAST(:question_embedding_vec AS vector)
+                        CAST(:question_embedding_vec AS vector),
+                        CAST(:query_id AS uuid)
                     )
                 """),
                 {
@@ -1496,6 +1500,7 @@ async def _log_query(
                     "model": model,
                     "cache_hit": cache_hit,
                     "question_embedding_vec": vec_to_pg(question_embedding) if question_embedding is not None else None,
+                    "query_id": query_id,
                 },
             )
             await session.commit()
@@ -1732,12 +1737,14 @@ class StreamEvent(BaseModel):
     - ``sources``: initial event carrying the retrieved ``sources`` list
     - ``token``: incremental answer chunk in ``text``
     - ``done``: terminal success event carrying ``tokens`` usage, ``model``,
-      ``latency_ms`` (wall time from request start), and optionally ``route``
-      / ``cache_hit`` / ``cache_source`` when a smart-router or cache path
-      answered the query.
+      ``latency_ms`` (wall time from request start), ``query_id`` (UUID4
+      handle for posting thumbs feedback to /intelligence/feedback), and
+      optionally ``route`` / ``cache_hit`` / ``cache_source`` when a
+      smart-router or cache path answered the query.
     - ``error``: terminal failure event carrying ``message``
     """
     type: Literal["sources", "token", "done", "error"]
+    query_id: str | None = None
     sources: list[dict] | None = None
     text: str | None = None
     message: str | None = None
@@ -2889,6 +2896,10 @@ async def intelligence_ask_stream(
 
     async def event_generator():
         _started_at = time.monotonic()
+        # PR3 (Ask UX): mint a stable handle for this query so the client can
+        # post thumbs feedback later. Sent in every `done` event below; written
+        # to query_log.query_id by _log_query for the eventual UPDATE.
+        _query_id = str(uuid.uuid4())
 
         try:
             # --- Off-topic domain boundary filter (pre-Claude, $0) ---
@@ -2896,7 +2907,7 @@ async def intelligence_ask_stream(
                 logger.info("off-topic query rejected (stream): %s", req.question[:80])
                 yield f"data: {json.dumps({'type': 'sources', 'sources': []})}\n\n"
                 yield f"data: {json.dumps({'type': 'token', 'text': _OFF_TOPIC_RESPONSE})}\n\n"
-                yield f"data: {json.dumps({'type': 'done', 'tokens': {'input': 0, 'output': 0, 'total': 0}, 'model': 'off-topic', 'latency_ms': int((time.monotonic() - _started_at) * 1000)})}\n\n"
+                yield f"data: {json.dumps({'type': 'done', 'tokens': {'input': 0, 'output': 0, 'total': 0}, 'model': 'off-topic', 'latency_ms': int((time.monotonic() - _started_at) * 1000), 'query_id': _query_id})}\n\n"
                 return
 
             qctx = await _prepare_query(
@@ -2934,6 +2945,7 @@ async def intelligence_ask_stream(
                     'type': 'done',
                     'tokens': cached.get("tokens_used", {'input': 0, 'output': 0, 'total': 0}),
                     'latency_ms': int((time.monotonic() - _started_at) * 1000),
+                    'query_id': _query_id,
                 }
                 if cached.get("cache_hit"):
                     done_event['cache_hit'] = True
@@ -2955,6 +2967,7 @@ async def intelligence_ask_stream(
                     model=qctx.model,
                     question_embedding=np.array(qctx.query_embedding) if qctx.query_embedding else None,
                     cache_hit=cached.get("cache_hit", False),
+                    query_id=_query_id,
                 )).add_done_callback(_task_done_callback)
                 total_ms = int((time.monotonic() - _started_at) * 1000)
                 logger.info(
@@ -2980,7 +2993,7 @@ async def intelligence_ask_stream(
                     chunk = word + (" " if i < len(words) - 1 else "")
                     yield f"data: {json.dumps({'type': 'token', 'text': chunk})}\n\n"
                     await asyncio.sleep(0)
-                yield f"data: {json.dumps({'type': 'done', 'tokens': {'input': 0, 'output': 0, 'total': 0}, 'model': 'early-exit', 'latency_ms': int((time.monotonic() - _started_at) * 1000)})}\n\n"
+                yield f"data: {json.dumps({'type': 'done', 'tokens': {'input': 0, 'output': 0, 'total': 0}, 'model': 'early-exit', 'latency_ms': int((time.monotonic() - _started_at) * 1000), 'query_id': _query_id})}\n\n"
                 if qctx.redis_cache_key:
                     asyncio.create_task(cache.set(qctx.redis_cache_key, {
                         "answer": _EARLY_EXIT_ANSWER,
@@ -3000,6 +3013,7 @@ async def intelligence_ask_stream(
                     model="early-exit",
                     question_embedding=None,
                     cache_hit=False,
+                    query_id=_query_id,
                 )).add_done_callback(_task_done_callback)
                 return
 
@@ -3126,7 +3140,7 @@ async def intelligence_ask_stream(
                     output_tokens = payload.usage.output_tokens
                     tokens_info = {'input': input_tokens, 'output': output_tokens, 'total': input_tokens + output_tokens}
                     _latency_ms = int((time.monotonic() - _started_at) * 1000)
-                    yield f"data: {json.dumps({'type': 'done', 'tokens': tokens_info, 'model': qctx.model, 'latency_ms': _latency_ms})}\n\n"
+                    yield f"data: {json.dumps({'type': 'done', 'tokens': tokens_info, 'model': qctx.model, 'latency_ms': _latency_ms, 'query_id': _query_id})}\n\n"
                     # Record actual token-based cost
                     _stream_est_cost = _estimate_cost(input_tokens, output_tokens, qctx.model)
                     await record_cost(_stream_est_cost, model=qctx.model)
@@ -3167,6 +3181,7 @@ async def intelligence_ask_stream(
                         latency_ms=int((time.monotonic() - _started_at) * 1000),
                         model=qctx.model,
                         question_embedding=_stream_log_embedding,
+                        query_id=_query_id,
                     )).add_done_callback(_task_done_callback)
                     # Save turn to session for multi-turn continuity (KAN-158).
                     # Skip negative answers so follow-ups don't start from "I don't know".
@@ -3212,6 +3227,70 @@ async def intelligence_ask_stream(
             "X-Accel-Buffering": "no",  # disable Nginx buffering
         },
     )
+
+
+# ---------------------------------------------------------------------------
+# PR3 (Ask UX): thumbs up/down feedback
+#
+# The streamed `done` event includes a `query_id` (UUID4) that the frontend
+# stores. When the user clicks 👍 / 👎, the frontend POSTs here. Sending
+# `sentiment: null` clears the existing value (toggle-off behavior — clicking
+# the already-active thumb deselects it).
+#
+# This endpoint deliberately does NOT require X-App-Token: feedback is
+# anonymous and additive, gated only by rate-limit. We MUST NOT leak whether
+# a query_id exists in the database (that would allow scraping recent ask
+# activity), so unknown query_ids return 200 OK with no-op semantics — same
+# response shape as a successful update. The rate-limit caps the cost of
+# scraping attempts.
+# ---------------------------------------------------------------------------
+
+
+class FeedbackRequest(BaseModel):
+    query_id: str  # UUID4 from the streamed done event
+    # Allow null to clear an existing thumb selection (toggle-off).
+    # "neutral" is reserved for future use (auto-classified) and is rejected
+    # here so the API surface stays small.
+    sentiment: Literal["positive", "negative"] | None = None
+
+
+class FeedbackResponse(BaseModel):
+    ok: bool
+
+
+@router.post("/feedback", response_model=FeedbackResponse)
+@_limiter.limit("30/minute")
+async def ask_feedback(
+    request: Request,
+    body: FeedbackRequest,
+    db: AsyncSession = Depends(get_db),
+):
+    """Set or clear the sentiment on a previously-answered query."""
+    # Reject malformed UUIDs early — keeps the SQL parameter clean and avoids
+    # noisy DB-level cast errors in logs.
+    try:
+        UUID(body.query_id)
+    except (ValueError, AttributeError):
+        raise HTTPException(status_code=400, detail="Invalid query_id format")
+
+    try:
+        async with async_session_factory() as session:
+            await session.execute(
+                text("""
+                    UPDATE query_log
+                    SET sentiment = :sentiment
+                    WHERE query_id = CAST(:query_id AS uuid)
+                """),
+                {"sentiment": body.sentiment, "query_id": body.query_id},
+            )
+            await session.commit()
+    except Exception:
+        log_nonfatal("ask_feedback update")
+        # Don't surface the failure — the user already got their answer; a
+        # silently-dropped feedback click is annoying but not blocking. The
+        # ok=true response keeps the UI optimistic.
+
+    return FeedbackResponse(ok=True)
 
 
 @router.get("/suggestions")

--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -1731,7 +1731,10 @@ class StreamEvent(BaseModel):
 
     - ``sources``: initial event carrying the retrieved ``sources`` list
     - ``token``: incremental answer chunk in ``text``
-    - ``done``: terminal success event carrying ``tokens`` usage and ``model``
+    - ``done``: terminal success event carrying ``tokens`` usage, ``model``,
+      ``latency_ms`` (wall time from request start), and optionally ``route``
+      / ``cache_hit`` / ``cache_source`` when a smart-router or cache path
+      answered the query.
     - ``error``: terminal failure event carrying ``message``
     """
     type: Literal["sources", "token", "done", "error"]
@@ -1740,6 +1743,10 @@ class StreamEvent(BaseModel):
     message: str | None = None
     tokens: dict | None = None
     model: str | None = None
+    latency_ms: int | None = None
+    route: str | None = None
+    cache_hit: bool | None = None
+    cache_source: str | None = None
 
 
 class TaxonomyGapSignal(BaseModel):
@@ -2889,7 +2896,7 @@ async def intelligence_ask_stream(
                 logger.info("off-topic query rejected (stream): %s", req.question[:80])
                 yield f"data: {json.dumps({'type': 'sources', 'sources': []})}\n\n"
                 yield f"data: {json.dumps({'type': 'token', 'text': _OFF_TOPIC_RESPONSE})}\n\n"
-                yield f"data: {json.dumps({'type': 'done', 'tokens': {'input': 0, 'output': 0}, 'model': 'off-topic'})}\n\n"
+                yield f"data: {json.dumps({'type': 'done', 'tokens': {'input': 0, 'output': 0, 'total': 0}, 'model': 'off-topic', 'latency_ms': int((time.monotonic() - _started_at) * 1000)})}\n\n"
                 return
 
             qctx = await _prepare_query(
@@ -2926,14 +2933,17 @@ async def intelligence_ask_stream(
                 done_event = {
                     'type': 'done',
                     'tokens': cached.get("tokens_used", {'input': 0, 'output': 0, 'total': 0}),
+                    'latency_ms': int((time.monotonic() - _started_at) * 1000),
                 }
                 if cached.get("cache_hit"):
                     done_event['cache_hit'] = True
                     done_event['cache_source'] = cache_source
                 if route:
                     done_event['route'] = route
-                if not route:
-                    done_event['model'] = qctx.model
+                # Always emit the model so the UI can show what answered the
+                # query — even when a smart-router path took over (in which
+                # case the "model" is really the router label).
+                done_event['model'] = route or qctx.model
                 yield f"data: {json.dumps(done_event)}\n\n"
 
                 asyncio.create_task(_log_query(
@@ -2970,7 +2980,7 @@ async def intelligence_ask_stream(
                     chunk = word + (" " if i < len(words) - 1 else "")
                     yield f"data: {json.dumps({'type': 'token', 'text': chunk})}\n\n"
                     await asyncio.sleep(0)
-                yield f"data: {json.dumps({'type': 'done', 'tokens': {'input': 0, 'output': 0, 'total': 0}, 'model': 'early-exit'})}\n\n"
+                yield f"data: {json.dumps({'type': 'done', 'tokens': {'input': 0, 'output': 0, 'total': 0}, 'model': 'early-exit', 'latency_ms': int((time.monotonic() - _started_at) * 1000)})}\n\n"
                 if qctx.redis_cache_key:
                     asyncio.create_task(cache.set(qctx.redis_cache_key, {
                         "answer": _EARLY_EXIT_ANSWER,
@@ -3115,7 +3125,8 @@ async def intelligence_ask_stream(
                     input_tokens = payload.usage.input_tokens
                     output_tokens = payload.usage.output_tokens
                     tokens_info = {'input': input_tokens, 'output': output_tokens, 'total': input_tokens + output_tokens}
-                    yield f"data: {json.dumps({'type': 'done', 'tokens': tokens_info, 'model': qctx.model})}\n\n"
+                    _latency_ms = int((time.monotonic() - _started_at) * 1000)
+                    yield f"data: {json.dumps({'type': 'done', 'tokens': tokens_info, 'model': qctx.model, 'latency_ms': _latency_ms})}\n\n"
                     # Record actual token-based cost
                     _stream_est_cost = _estimate_cost(input_tokens, output_tokens, qctx.model)
                     await record_cost(_stream_est_cost, model=qctx.model)

--- a/migrations/versions/039_query_log_query_id.py
+++ b/migrations/versions/039_query_log_query_id.py
@@ -1,0 +1,51 @@
+"""Add query_id UUID handle to query_log for thumbs feedback (PR3 of Ask UX).
+
+Adds a stable client-facing identifier so the frontend can post a sentiment
+update for a specific answered query. The existing BIGINT primary key is
+unsuitable because:
+
+  1. The /intelligence/ask/stream INSERT is fire-and-forget — the response is
+     yielded to the client BEFORE the row is committed, so the PK isn't yet
+     known when we need to send it.
+  2. Exposing the monotonic PK to clients leaks query volume metadata.
+
+A UUID is generated at the start of every ask request, emitted in the
+streamed `done` event, and written into this column. The new feedback
+endpoint then updates the `sentiment` column WHERE query_id = ?.
+
+Changes:
+  1. ADD COLUMN query_id UUID NULL  — populated for new rows; older rows
+     (pre-this migration) stay NULL and aren't addressable by feedback.
+  2. CREATE UNIQUE INDEX ... WHERE query_id IS NOT NULL  — sparse, so the
+     historical NULL rows don't block the unique constraint.
+
+Revision ID: 039
+Revises: 038
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "039"
+down_revision = "038"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("query_log", sa.Column("query_id", postgresql.UUID(as_uuid=False), nullable=True))
+    # Sparse unique index so old NULL rows don't conflict, but every newly
+    # written query_id is guaranteed unique (defends against accidental reuse
+    # if a client retries with the same UUID).
+    op.execute("""
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_query_log_query_id
+        ON query_log (query_id)
+        WHERE query_id IS NOT NULL
+    """)
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS uq_query_log_query_id")
+    op.drop_column("query_log", "query_id")

--- a/tests/test_intelligence.py
+++ b/tests/test_intelligence.py
@@ -501,3 +501,51 @@ async def test_run_query_raises_504_on_claude_timeout():
 
     assert exc_info.value.status_code == 504
     assert "did not respond" in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# /intelligence/feedback (PR3 of Ask UX series)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_feedback_rejects_invalid_uuid(client: AsyncClient):
+    """POST /intelligence/feedback with non-UUID query_id must return 400."""
+    response = await client.post(
+        "/intelligence/feedback",
+        json={"query_id": "not-a-uuid", "sentiment": "positive"},
+    )
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_feedback_rejects_invalid_sentiment(client: AsyncClient):
+    """sentiment must be 'positive', 'negative', or null — anything else is 422."""
+    response = await client.post(
+        "/intelligence/feedback",
+        json={"query_id": "00000000-0000-4000-8000-000000000000", "sentiment": "meh"},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_feedback_accepts_null_sentiment(client: AsyncClient):
+    """Sending sentiment: null clears the existing thumb (toggle-off)."""
+    # Even with no matching row in DB, we return 200 OK to avoid leaking
+    # whether a query_id exists (anti-scrape — see endpoint docstring).
+    response = await client.post(
+        "/intelligence/feedback",
+        json={"query_id": "00000000-0000-4000-8000-000000000000", "sentiment": None},
+    )
+    # 200 on success, or 503 if DB unavailable in the test env. Either is
+    # acceptable evidence that the schema validated and routing worked.
+    assert response.status_code in (200, 503)
+
+
+@pytest.mark.asyncio
+async def test_feedback_unknown_query_id_returns_ok(client: AsyncClient):
+    """Unknown query_ids must return 200 OK, NOT 404 — anti-scrape."""
+    response = await client.post(
+        "/intelligence/feedback",
+        json={"query_id": "11111111-1111-4111-8111-111111111111", "sentiment": "positive"},
+    )
+    assert response.status_code in (200, 503)


### PR DESCRIPTION
## Summary
PR3/4 of the Ask UX series. Backend half — adds a `query_id` UUID handle to every answered query and a new `POST /intelligence/feedback` endpoint so the frontend can record 👍 / 👎 against a specific answer.

**Stacked on [reporium-api#416](https://github.com/perditioinc/reporium-api/pull/416)** (PR2 — telemetry). Review/merge that one first.

What's included:

- **Migration 039** — `query_log.query_id UUID NULL` + sparse unique index. Older rows stay NULL and aren't addressable by feedback (acceptable — those answers predate the feature).
- **`/intelligence/ask/stream`** — mints a UUID4 per request; emits it on every terminal `done` event (Claude streaming, cache-hit, off-topic, early-exit) and writes it into `query_log` via `_log_query`.
- **`POST /intelligence/feedback`** — `{query_id, sentiment}` where sentiment ∈ {`positive`, `negative`, `null`}. `null` clears (toggle-off semantics).
  - Rejects malformed UUIDs with 400 (clean param, no DB cast errors).
  - **Returns 200 OK for unknown query_ids on purpose** — leaking row existence would let scrapers map recent ask volume. The 30/min rate-limit caps the cost of probing.
  - Swallows DB errors silently — a dropped feedback click is annoying but never blocks the user's already-delivered answer.
- **`StreamEvent`** Pydantic schema gains the `query_id` field; docstring updated.

Pairs with frontend PR (link below). Forward-compatible on both sides.

## Test plan
- [x] 4 new tests in `tests/test_intelligence.py` (rejects bad UUID, rejects bad sentiment, accepts null, returns OK on unknown id) — register correctly; skipped locally with the rest of the DB-dependent suite. Will run in CI.
- [x] Module imports clean
- [ ] Migration 039 runs cleanly against staging Cloud SQL
- [ ] Manual curl smoke after deploy: `POST /intelligence/feedback` with a recently-issued query_id, verify `sentiment` column populated

## Notes
KAN-XX is a placeholder.

🤖 Generated with [Claude Code](https://claude.com/claude-code)