### PR TITLE
fix(ask): use upstream canonical name for forked repos in prompt context

### DIFF
--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -1322,9 +1322,15 @@ def _build_sources_block(repos: list[dict]) -> str:
       - readme_summary, problem_solved
       - language, license_spdx, activity_score
       - has_tests, has_ci, relevance_score
-      - forked_from, secondary_category lists
+      - secondary_category lists
       - embedding arrays, timestamps
       - trust_score computation internals, ingestion_id, admin-only flags
+
+    Fork canonicalization: when a repo has `forked_from` set (we mirror many
+    upstream projects under the perditioinc account for evaluation), feed
+    Claude the upstream `parent_owner/repo_name` rather than `perditioinc/repo`.
+    Keeps answer text aligned with how users know the project, matching the
+    card display in formatRepoDisplay() on the frontend.
 
     Output format:
       1. owner/repo (1.2k★, Category): Description text
@@ -1336,7 +1342,11 @@ def _build_sources_block(repos: list[dict]) -> str:
     for i, repo in enumerate(repos, 1):
         name = repo.get("name") or ""
         owner = repo.get("owner") or ""
-        full_name = f"{owner}/{name}" if owner else name
+        forked_from = repo.get("forked_from")
+        if forked_from:
+            full_name = forked_from
+        else:
+            full_name = f"{owner}/{name}" if owner else name
         category = repo.get("primary_category")
         stars = repo.get("stars")
         description = repo.get("description") or ""

--- a/tests/test_ask_context_hygiene.py
+++ b/tests/test_ask_context_hygiene.py
@@ -8,9 +8,13 @@ Excluded for cost/noise reasons:
   - readme_summary, problem_solved
   - language, license_spdx, activity_score
   - has_tests, has_ci, relevance_score
-  - forked_from, secondary_category lists
+  - secondary_category lists
   - embedding arrays
   - created_at / updated_at / last_push_at timestamps
+
+`forked_from` is INCLUDED, but only used to canonicalize the displayed
+owner/name (perditioinc mirror → upstream). It must not leak as a separate
+field in the prompt text.
 """
 from app.routers.intelligence import _build_sources_block, _format_stars, _SOURCES_DESCRIPTION_MAX
 
@@ -94,6 +98,57 @@ def test_multiple_repos_numbered():
     assert "\n2. " in block
     assert "langchain" in block
     assert "llamaindex" in block
+
+
+def test_perditioinc_fork_uses_upstream_canonical_name():
+    """Forks of upstream projects mirrored under perditioinc should be
+    presented to Claude as `upstream_owner/repo`, not `perditioinc/repo`.
+
+    Bug: Claude's answer text said `perditioinc/whylogs` for repos that users
+    know as `whylabs/whylogs`. Cards already canonicalize via formatRepoDisplay
+    on the frontend; the prompt context must do the same so the LLM matches.
+    """
+    fork = {
+        "name": "whylogs",
+        "owner": "perditioinc",
+        "forked_from": "whylabs/whylogs",
+        "primary_category": "Observability",
+        "stars": 2400,
+        "description": "An open-source library for logging any kind of data.",
+    }
+    block = _build_sources_block([fork])
+    assert "whylabs/whylogs" in block
+    assert "perditioinc/whylogs" not in block
+    assert "perditioinc" not in block  # owner field must not leak elsewhere
+
+
+def test_non_fork_keeps_owner_slash_name():
+    """A first-party perditioinc repo (not a fork) keeps its real owner."""
+    original = {
+        "name": "reporium",
+        "owner": "perditioinc",
+        "forked_from": None,
+        "primary_category": "Tooling",
+        "stars": 12,
+        "description": "Trust-first GitHub registry.",
+    }
+    block = _build_sources_block([original])
+    assert "perditioinc/reporium" in block
+
+
+def test_fork_field_is_not_emitted_as_text():
+    """forked_from is consumed for canonicalization but never echoed verbatim
+    as a 'forked_from: ...' line in the prompt body."""
+    fork = {
+        "name": "whylogs",
+        "owner": "perditioinc",
+        "forked_from": "whylabs/whylogs",
+        "primary_category": "Observability",
+        "stars": 2400,
+        "description": "Logging data.",
+    }
+    block = _build_sources_block([fork])
+    assert "forked_from" not in block.lower()
 
 
 def test_missing_optional_fields_are_omitted():


### PR DESCRIPTION
## Summary

Claude's answer text was saying \`perditioinc/whylogs\` for repos users know as \`whylabs/whylogs\`. The frontend cards already mapped perditioinc-owned forks to their upstream owner via \`formatRepoDisplay()\`, but the prompt context fed to Claude in \`_build_sources_block\` did not — so the LLM had no way to know the upstream name.

## What changed

\`app/routers/intelligence.py\` — when a repo has \`forked_from\` set, use it as the displayed \`full_name\`. First-party perditioinc repos (\`forked_from=NULL\`) keep their owner unchanged.

\`tests/test_ask_context_hygiene.py\` — 3 new tests:
- fork uses upstream canonical name
- non-fork perditioinc repo keeps its owner
- \`forked_from\` is consumed but never echoed as a separate prompt field

## Test plan

- [x] Unit tests pass: \`pytest tests/test_ask_context_hygiene.py\` (9/9 green)
- [ ] On preview after deploy: ask a question that surfaces a known fork (e.g. whylogs) and confirm answer text shows upstream owner

🤖 Generated with [Claude Code](https://claude.com/claude-code)