### PR TITLE
hotfix: newest/oldest smart route references non-existent `created_at` column

### DIFF
--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -845,8 +845,8 @@ async def _try_smart_route_inner(question: str, db: AsyncSession) -> dict | None
         order_map = {
             "active": "activity_score DESC NULLS LAST",
             "recent": "COALESCE(your_last_push_at, upstream_last_push_at, github_updated_at, updated_at) DESC NULLS LAST",
-            "newest": "created_at DESC NULLS LAST",
-            "oldest": "created_at ASC NULLS LAST",
+            "newest": "COALESCE(github_created_at, upstream_created_at) DESC NULLS LAST",
+            "oldest": "COALESCE(github_created_at, upstream_created_at) ASC NULLS LAST",
             "forked": "COALESCE(forks_count, 0) DESC",
             "starred": "COALESCE(parent_stars, stargazers_count, 0) DESC",
             "popular": "COALESCE(parent_stars, stargazers_count, 0) DESC",


### PR DESCRIPTION
## Summary
- `_ROUTE_MOST_ADJECTIVE` handler referenced `created_at`, which does not exist on the `repos` table
- Caused a 500 on "What are the newest repos?" — one of the 16 curated FAQ suggestions
- Uses `COALESCE(github_created_at, upstream_created_at)` to mirror the `recent` clause's COALESCE pattern over freshness columns

## Repro (before fix)
POST `/intelligence/ask` with `{"question": "What are the newest repos?"}` → HTTP 500.

## Test plan
- [ ] CI green
- [ ] After deploy: `curl /intelligence/ask -d '{"question":"What are the newest repos?"}'` returns `"route": "most_newest"` with 10 rows
- [ ] `/faq` card "What are the newest repos?" renders a list instead of "Server error (500)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)