### PR TITLE
fix(evaluation): surface hn_mentions_count (#369)

### DIFF
--- a/app/routers/repos.py
+++ b/app/routers/repos.py
@@ -11,6 +11,7 @@ from sqlalchemy.orm import selectinload
 
 from app.cache import CACHE_TTL_REPO_DETAIL, cache
 from app.database import get_db
+from app.models.mention import RepoMention
 from app.models.repo import (
     Repo,
     RepoAIDevSkill,
@@ -376,6 +377,13 @@ async def repo_evaluation(
     if repo.pros_cons is None:
         raise HTTPException(status_code=404, detail="No evaluation available for this repository")
 
+    hn_count_stmt = (
+        select(func.count())
+        .select_from(RepoMention)
+        .where(RepoMention.repo_id == repo.id, RepoMention.source == "hackernews")
+    )
+    hn_mentions_count = (await db.execute(hn_count_stmt)).scalar() or 0
+
     return {
         "repo": repo.name,
         "owner": repo.owner,
@@ -387,6 +395,7 @@ async def repo_evaluation(
         "issue_close_rate": repo.issue_close_rate,
         "pr_merge_rate": repo.pr_merge_rate,
         "community_health_pct": repo.community_health_pct,
+        "hn_mentions_count": hn_mentions_count,
     }
 
 

--- a/tests/test_pros_cons.py
+++ b/tests/test_pros_cons.py
@@ -365,3 +365,5 @@ async def test_evaluation_endpoint_surfaces_community_health_fields(client: Asyn
     assert body["issue_close_rate"] == 85.0
     assert body["pr_merge_rate"] == 72.5
     assert body["community_health_pct"] == 90
+    # #369: HN mentions count defaults to 0 when the repo has no mentions.
+    assert body["hn_mentions_count"] == 0


### PR DESCRIPTION
## Summary
Closes #369. Adds `hn_mentions_count` to the `/repos/{id}/evaluation` response. Queries `repo_mentions` filtered to `source='hackernews'` for the evaluated repo.

## Context
Per #369, the trust-probe could not observe the Quality dimension because HN mention data was not exposed alongside the AI-generated evaluation. Other requested fields (`community_health_pct`, `contributors_count`, `issue_close_rate`, `pr_merge_rate`) were already surfaced — only `hn_mentions` was missing.

## Test plan
- [x] Existing `test_evaluation_endpoint_surfaces_community_health_fields` asserts new field is `0` when no mentions exist.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)