### PR TITLE
fix(deploy): strip stale traffic tags after promotion

### DIFF
--- a/.audit/2026-04-23/candidate-tag-bypass.md
+++ b/.audit/2026-04-23/candidate-tag-bypass.md
@@ -1,0 +1,142 @@
+# Public candidate-revision bypass in reporium-api Cloud Run
+
+**Finding.** After a promoted deploy, Cloud Run leaves the
+`candidate-<short_sha>` traffic tag on the previous revision. Because
+`reporium-api` is invoker=`allUsers`, each tagged revision exposes a permanent
+public URL of the form:
+
+```
+https://candidate-<short_sha>---reporium-api-573778300586.us-central1.run.app
+```
+
+These URLs keep serving pre-promotion code against the **current** production
+database. Observed: an old tagged revision returned `/stats = 1899 repos / 62 …`
+while `main` returned `1855 / 18` (aggregate counts from before the private-repo
+filter hotfix). Anyone who knows the old short SHAs — every merged commit is
+public on GitHub — can bypass every subsequent hotfix.
+
+## Why it exists
+
+`.github/workflows/deploy.yml` intentionally deploys each new revision at
+`no_traffic: true` with a `candidate-<sha>` tag (Option B1: no-traffic
+candidate → migrate → promote). The tag is required for the promote step
+(`gcloud run services update-traffic --to-tags=<tag>=100`). The prior comment
+in the workflow claimed leaving the tag behind was "harmless" — it is not;
+Cloud Run makes tagged revisions publicly addressable independent of traffic
+split.
+
+## Fix (this PR)
+
+Two new steps in `deploy.yml`, both `continue-on-error: true` (cleanup must
+never block a successful promotion):
+
+1. **Remove stale `candidate-*` traffic tags from non-serving revisions.**
+   Uses `gcloud run services describe --format=json | jq` to enumerate every
+   traffic entry with `percent == 0` and a `candidate-*` tag, then issues a
+   single `gcloud run services update-traffic --remove-tags=tag1,tag2,…`. The
+   just-promoted revision has `percent == 100` so its tag is preserved.
+   Operator-added tags (`stable`, `rollback`, etc.) do not match the prefix
+   and are left alone.
+2. **Verify no public candidate-\* bypass URLs remain.** Re-describes the
+   service and emits `::warning::` annotations if any `candidate-*` tag still
+   sits on a `percent=0` revision. Surfaces regressions (e.g. future gcloud
+   flag changes) without failing the deploy.
+
+The no-traffic candidate → migrate → promote invariant is untouched; the new
+steps run only *after* the successful promotion step.
+
+## Validation
+
+### Prove old candidate URLs are no longer reachable after promotion
+
+Run (from a workstation with `gcloud` auth to `perditio-platform`):
+
+```bash
+# List every currently-tagged revision URL on the service.
+gcloud run services describe reporium-api \
+  --project=perditio-platform \
+  --region=us-central1 \
+  --format=json \
+  | jq -r '.status.traffic[]
+           | select(.tag != null)
+           | "\(.percent)%  tag=\(.tag)  rev=\(.revisionName)"'
+```
+
+After a post-fix deploy, exactly one `candidate-*` entry should be present and
+it must show `100%` (the live revision). Any `0%  tag=candidate-*` row is a
+regression.
+
+Independently verify each stale URL returns `404` (Cloud Run's response when a
+tag is absent):
+
+```bash
+# Replace <sha> with a previously-tagged short SHA.
+curl -sI \
+  "https://candidate-<sha>---reporium-api-573778300586.us-central1.run.app/stats" \
+  | head -n1
+# Expected: HTTP/2 404
+```
+
+And the base URL continues to serve the new code:
+
+```bash
+curl -s https://reporium-api-573778300586.us-central1.run.app/stats | jq .
+# Expected: current production counts (e.g. 1855 / 18)
+```
+
+### Confirm main deploy flow still works
+
+No change to the promotion semantics. On the next merge to `main`:
+
+1. Watch the `Deploy to Cloud Run` workflow in GitHub Actions.
+2. `Promote candidate revision to 100% traffic` must succeed (unchanged).
+3. `Remove stale candidate-* traffic tags from non-serving revisions` should
+   print `Removing stale candidate traffic tags: candidate-…,candidate-…` (or
+   `No stale candidate-* traffic tags to remove.` on a clean service).
+4. `Verify no public candidate-* bypass URLs remain` must print
+   `No stale candidate-* tags on non-serving revisions — bypass paths closed.`
+5. Post-deploy `Smoke test graph endpoint` step must still pass as before.
+
+Rollback path is unchanged: `gcloud run services update-traffic
+reporium-api --to-revisions=<prior-revision>=100` (the prior revision still
+exists; only its *tag* was removed).
+
+## Manual cleanup required for already-existing candidate tags
+
+The new workflow steps only run on *future* deploys. To close the bypass
+*today*, run this one-time cleanup against the current service:
+
+```bash
+gcloud run services describe reporium-api \
+  --project=perditio-platform \
+  --region=us-central1 \
+  --format=json \
+  | jq -r '.status.traffic[]
+           | select(.percent == 0 and .tag != null and (.tag | startswith("candidate-")))
+           | .tag' \
+  | sort -u \
+  | paste -sd',' - \
+  | xargs -I{} gcloud run services update-traffic reporium-api \
+      --remove-tags={} \
+      --project=perditio-platform \
+      --region=us-central1
+```
+
+Then re-run the validation query above — every `candidate-*` entry should be
+`100%`. Confirm at least one previously-known stale URL (e.g.
+`candidate-ca63b22---…`) returns HTTP 404.
+
+No revision is deleted; only the tags are stripped. The base URL
+(`reporium-api-…run.app`) and the live tag are untouched.
+
+## Risk assessment
+
+- **Blast radius of the PR:** post-promotion workflow steps only; no runtime
+  code change; no change to traffic-split behavior during promotion.
+- **Failure mode of the cleanup step:** `continue-on-error: true`. If gcloud
+  flakes, the deploy still succeeds; the next deploy will retry cleanup.
+- **Failure mode of the verify step:** warning-only. Does not gate traffic.
+- **Not mitigated here:** the underlying invoker=`allUsers` posture. Tagged
+  URLs are a *Cloud Run feature*, not a misconfiguration — the only durable
+  fix is to remove the tag after promotion (this PR) or make the service
+  authenticated (a larger change tracked separately).

--- a/.audit/2026-04-25/strip-stale-candidate-tags-jira.md
+++ b/.audit/2026-04-25/strip-stale-candidate-tags-jira.md
@@ -1,0 +1,113 @@
+# JIRA draft — strip stale candidate-* Cloud Run traffic tags
+
+> Created in lieu of JIRA (no Atlassian MCP wired into this session).
+> Promote to a real ticket when the Workato Atlassian recipe is back online.
+
+## Summary
+
+After every promoted deploy, Cloud Run leaves `candidate-<short_sha>` traffic
+tags on prior `reporium-api` revisions. Because the service is invoker
+`allUsers`, every leftover tagged URL
+(`https://candidate-<sha>---reporium-api-wypbzj5gpa-uc.a.run.app`) is a public
+bypass that serves pre-promotion code against the live database.
+
+## Type / priority
+
+- Type: **Bug** (security / data-integrity)
+- Priority: **P1** (public exposure of pre-hotfix behavior)
+- Component: `reporium-api` deploy pipeline / Cloud Run posture
+
+## Reproduction (pre-fix)
+
+1. Merge any PR that hotfixes user-visible behavior (e.g. PR #433
+   private-repo filter).
+2. After deploy completes, find a previous merge's short SHA (every commit
+   on `main` is public on GitHub).
+3. `curl -s
+   "https://candidate-<old_sha>---reporium-api-wypbzj5gpa-uc.a.run.app/stats"
+   | jq .` returns aggregate counts from before the hotfix while the base URL
+   returns the post-fix counts.
+
+## Root cause
+
+`gcloud run services update-traffic --to-tags=candidate-<sha>=100` shifts
+traffic but **does not remove the tag** from previously-tagged revisions.
+Cloud Run keeps tag → revision URL bindings independent of traffic split, so
+the public bypass URL remains addressable indefinitely until manually
+removed. Comment in `deploy.yml` previously claimed the leftover tag was
+"harmless" — it is not.
+
+## Fix shipped — PR #436 + refinement commit `bbb69ac`
+
+`.github/workflows/deploy.yml`, two new post-promotion steps:
+
+1. **Remove stale candidate-* traffic tags from non-serving revisions.**
+   `gcloud run services describe ... --format=json | jq` enumerates every
+   traffic entry with `percent == 0` and `tag` prefix `candidate-`, then
+   strips them with one `update-traffic --remove-tags=…` call. Operator
+   tags (`stable`, `rollback`) are not matched and are preserved.
+2. **Verify no public candidate-* bypass URLs remain.** Re-describes the
+   service and emits `::warning::` if any `candidate-*` tag still sits on a
+   `percent=0` revision. Non-blocking (deploy already succeeded).
+
+Both steps are `if: success()` + `continue-on-error: true`. The
+no-traffic-candidate → migrate → promote invariant (Option B1, PR #397) is
+untouched.
+
+## Acceptance criteria
+
+- [ ] Next deploy after merge logs either
+      `No stale candidate-* traffic tags to remove.` or
+      `Removing stale candidate traffic tags: candidate-…,candidate-…`.
+- [ ] Verify step logs
+      `No stale candidate-* tags on non-serving revisions — bypass paths closed.`
+- [ ] `gcloud run services describe reporium-api --format=json | jq
+      '.status.traffic[] | select(.tag != null)'` shows exactly one entry
+      with `percent: 100`.
+- [ ] At least one previously-known stale URL
+      (e.g. `candidate-ca63b22---…/stats`) returns HTTP 404.
+- [ ] Base URL `reporium-api-wypbzj5gpa-uc.a.run.app/stats` continues to
+      return current production counts (currently 405 for HEAD; GET returns
+      JSON).
+
+## Out of scope (track separately)
+
+- Service invoker is `allUsers`. Tagged URLs being public is a Cloud Run
+  feature, not a misconfiguration. Long-term durable fix is to require
+  authentication. Open as a follow-up; this ticket only closes the
+  short-term bypass.
+- No revision GC. We keep revisions for rollback; only tags are stripped.
+
+## Today's manual cleanup (one-time)
+
+`gcloud` shows live state at audit time has only one tagged revision
+(`candidate-58ab8cd` at 100%, the serving one). Probe of the
+previously-cited stale URL `candidate-ca63b22---…` returns HTTP 404,
+confirming someone already stripped it manually. **No further manual
+cleanup required pre-merge.** The fix is preventive against the next
+deploy re-introducing the bypass.
+
+If on a future audit a stale tag reappears before #436 is merged, run:
+
+```bash
+gcloud run services describe reporium-api \
+  --project=perditio-platform \
+  --region=us-central1 \
+  --format=json \
+  | jq -r '.status.traffic[]
+           | select(.percent == 0 and .tag != null and (.tag | startswith("candidate-")))
+           | .tag' \
+  | sort -u \
+  | paste -sd',' - \
+  | xargs -I{} gcloud run services update-traffic reporium-api \
+      --remove-tags={} \
+      --project=perditio-platform \
+      --region=us-central1
+```
+
+## Links
+
+- PR: https://github.com/perditioinc/reporium-api/pull/436
+- Underlying invariant: PR #397 (no-traffic candidate Option B1)
+- Hotfix that surfaced the leak: PR #433 (newest/oldest smart route)
+- Audit detail: `.audit/2026-04-23/candidate-tag-bypass.md`

--- a/.audit/2026-04-25/strip-stale-candidate-tags-pr436-review.md
+++ b/.audit/2026-04-25/strip-stale-candidate-tags-pr436-review.md
@@ -1,0 +1,166 @@
+# PR #436 review — strip stale candidate-* traffic tags
+
+**Lane:** `reporium-api #436` review and refine
+**Reviewer:** Claude (Opus 4.7)
+**Date:** 2026-04-25
+**Recommendation:** ✅ **GO** — push refinement commit `bbb69ac`, then merge.
+
+## State at review time
+
+- Base branch: `main` (HEAD `1feeb0f` — `test(ask): add forbidden_repos primitive…` #367)
+- PR head branch (remote): `fix/deploy-strip-stale-traffic-tags` @ `5235333`
+- PR head branch (local): `5235333 → bbb69ac` (refinement commit, **unpushed**)
+- PR mergeable: `MERGEABLE`
+- CI on `5235333`: all green (Ask Quality Gate, Dev Tests, Tests, migration-smoke)
+- No reviews / comments yet
+- Owned files only: `.github/workflows/deploy.yml`, `.audit/2026-04-25/*` ✅
+- No other lane is editing `deploy.yml` (last touch on main: `b84c8e9` Apr 17)
+
+## Live Cloud Run state at review time
+
+```
+spec.traffic     : [percent=100 rev=…00252-fop, tag=candidate-58ab8cd rev=…00252-fop]
+status.traffic   : [percent=100 tag=candidate-58ab8cd rev=…00252-fop url=…run.app]
+```
+
+Only the serving revision carries a `candidate-*` tag right now. Probe of the
+previously-cited stale URL `candidate-ca63b22---reporium-api-wypbzj5gpa-uc.a.run.app/stats`
+returns **HTTP/2 404** — someone already manually stripped that tag between
+the original audit (Apr 23) and now. The base URL serves normally.
+
+**Implication:** the immediate bypass is closed *today*, but the next deploy
+*without* #436 would re-introduce it. The fix is correct as a preventive
+measure. No emergency manual cleanup is required pre-merge.
+
+## Correctness review of `bbb69ac` (current local PR head)
+
+The refinement commit hardens `5235333` along three vectors:
+
+| Concern | `5235333` (PR remote head) | `bbb69ac` (local refinement) | Verdict |
+|---|---|---|---|
+| Tag scope | All `tag != null && percent=0` — would also strip operator tags `stable` / `rollback` | `tag` prefix-matches `candidate-` only | ✅ Necessary — class-of-tags safety |
+| `gcloud --format` reliability | `value(...filter('percent=0').extract(tag).flatten())` — fragile across gcloud versions, separator differs | `--format=json | jq` over `.status.traffic[]` | ✅ Robust; `jq` preinstalled on `ubuntu-latest` |
+| Regression visibility | None — silent if cleanup fails | Verify step emits `::warning::` if any `candidate-*` tag remains on a `percent=0` revision | ✅ Surfaces future flag/permission regressions in Actions UI |
+| Failure mode | `continue-on-error: true` — won't block deploy | Both steps `continue-on-error: true` | ✅ Same posture, no new blocking surface |
+| Comment hygiene | Promote step still claims leftover tag is "harmless" | Removes the misleading comment | ✅ Aligns code comment with security reality |
+
+### Edge cases checked
+
+1. **First deploy after merge (no prior candidate tags):** cleanup step
+   selects nothing → prints `No stale candidate-* traffic tags to remove.`
+   and exits 0. Verify step prints `bypass paths closed.` ✅
+2. **Operator-set `stable` / `rollback` tags on rolled-back revisions:**
+   prefix filter excludes them; not stripped. ✅
+3. **Same SHA re-deployed (cherry-pick):** `--tag candidate-<sha>` on
+   `gcloud run deploy` moves the tag to the new revision rather than
+   creating a duplicate; selection set is empty. ✅
+4. **Promotion fails (migration error, etc.):** cleanup step is gated by
+   `if: success()` — does not run; tag state on the service is unchanged
+   regardless. ✅
+5. **`jq` upstream change:** `jq -r` and `startswith` are baseline syntax
+   shipped with every `jq ≥1.6` in `ubuntu-latest`. No risk. ✅
+6. **Race with concurrent deploy:** the deploy job's GCP service account
+   has the only role here; concurrent deploys are serialized by the
+   workflow `concurrency:` group at the top of `deploy.yml`. Already in
+   place. ✅
+7. **`--remove-tags` for a no-longer-existing tag:** gcloud no-ops
+   gracefully on missing tags within the same call; `continue-on-error`
+   covers any edge that doesn't. ✅
+
+### Patch needed?
+
+**No additional `deploy.yml` change.** The refinement commit `bbb69ac` is
+the safest minimal fix. The remaining action is a `git push` to publish
+`bbb69ac` so PR #436 reflects the hardened version before merge. (Pushing
+is shared-state and is left to the human owner of the PR per session
+guidance.)
+
+## Stop-condition check
+
+- ✅ No GCP-side change required — fix is workflow-only.
+- ✅ Patch does not broaden the deploy flow beyond the tag-cleanup concern.
+  Two new steps, both post-promotion, both `continue-on-error`. No new
+  permissions, secrets, or behavior changes outside tag lifecycle.
+- ✅ No other lane is editing `deploy.yml`.
+
+## Merge recommendation
+
+**GO.** Push `bbb69ac`, await CI green on the refined head, then merge to
+`main`. Do not merge before push — the remote head still has the looser
+tag-prefix logic and the fragile `--format` projection.
+
+### Pre-merge actions (human owner)
+
+```bash
+git push origin fix/deploy-strip-stale-traffic-tags
+# CI re-runs against bbb69ac — wait for green, then merge via the queue.
+```
+
+## Post-merge / next-deploy verification checklist
+
+Run on the first merge to `main` after #436 lands.
+
+1. **Watch the workflow run.**
+   - `Promote candidate revision to 100% traffic` — succeeds (unchanged).
+   - `Remove stale candidate-* traffic tags from non-serving revisions` —
+     prints either `No stale candidate-* traffic tags to remove.` or
+     `Removing stale candidate traffic tags: candidate-…[,candidate-…]`.
+   - `Verify no public candidate-* bypass URLs remain` — prints
+     `No stale candidate-* tags on non-serving revisions — bypass paths closed.`
+     If it emits `::warning::`, treat as a follow-up bug, not a deploy
+     failure.
+
+2. **Inspect live traffic state.**
+
+   ```bash
+   gcloud run services describe reporium-api \
+     --project=perditio-platform \
+     --region=us-central1 \
+     --format=json \
+   | jq -r '.status.traffic[] | "\(.percent)%  tag=\(.tag // "<none>")  rev=\(.revisionName)"'
+   ```
+
+   Expected: exactly one row with `tag=candidate-<new_sha>` at `100%`.
+   Any `0%  tag=candidate-*` row is a regression.
+
+3. **Probe a previously-known stale URL.**
+
+   ```bash
+   curl -sI "https://candidate-58ab8cd---reporium-api-wypbzj5gpa-uc.a.run.app/stats" | head -n1
+   # Expected after a *subsequent* deploy: HTTP/2 404
+   ```
+
+   (`candidate-58ab8cd` is the current serving tag at audit time. After the
+   next deploy it should become a 404.)
+
+4. **Probe the base URL.**
+
+   ```bash
+   curl -s https://reporium-api-wypbzj5gpa-uc.a.run.app/stats | jq .
+   # Expected: current production counts (e.g. ~1855 / 18 from the
+   # private-repo-filter-aware path)
+   ```
+
+5. **Smoke test rollback path is unaffected.**
+   No action needed — `--remove-tags` strips tags only; revisions are
+   retained per existing image-prune step (keep latest 5). Rollback via
+   `gcloud run services update-traffic --to-revisions=<prior>=100` still
+   works.
+
+## Out-of-scope follow-ups (do not gate this PR)
+
+- **Long-term durable fix:** require auth on `reporium-api` (remove
+  `allUsers` invoker). Tagged URLs being public is a Cloud Run feature,
+  not a misconfig. Track as a separate epic — significant client/CI
+  surface change.
+- **Backfill audit log:** there is no record of who/when stripped the
+  `candidate-ca63b22` tag manually. Consider enabling Cloud Audit Logs
+  for `run.googleapis.com/Service.UpdateTraffic` if not already on.
+
+## Files touched in this lane (owned scope)
+
+- `.audit/2026-04-25/strip-stale-candidate-tags-jira.md`
+- `.audit/2026-04-25/strip-stale-candidate-tags-pr436-review.md` (this file)
+
+No `deploy.yml` change made by this review — the existing `bbb69ac` patch
+is the recommended state.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -178,32 +178,64 @@ jobs:
             --region=us-central1
           echo "Traffic shifted to candidate revision."
 
-      - name: Remove stale traffic tags from non-serving revisions
+      - name: Remove stale candidate-* traffic tags from non-serving revisions
         # Cloud Run leaves `candidate-<sha>` traffic tags on previous revisions after
         # promotion. Because `reporium-api` has `allUsers` invoker, those tagged URLs
-        # remain publicly reachable and can serve pre-hotfix code against the current
-        # database — e.g. leaking stale aggregate counts from before a private-repo
-        # filter fix. Strip tags from every revision that is not currently serving
-        # traffic so only the active revision has a tagged URL.
+        # (e.g. `https://candidate-ca63b22---reporium-api-....run.app`) remain
+        # publicly reachable and serve pre-hotfix code against the current database —
+        # e.g. leaking stale aggregate counts from before a private-repo filter fix.
+        #
+        # Strip only `candidate-*` tags from revisions that are not currently serving
+        # traffic. The just-promoted revision has percent=100 so its tag is preserved.
+        # Operator-set tags (e.g. `stable`, `rollback`) do not match the prefix and
+        # are left intact. Uses JSON + jq (preinstalled on ubuntu-latest) instead of
+        # gcloud's projection filter syntax for robustness across gcloud versions.
         if: success()
         continue-on-error: true
         run: |
           set -euo pipefail
-          STALE_TAGS=$(gcloud run services describe reporium-api \
+          STALE_TAGS="$(gcloud run services describe reporium-api \
             --project=perditio-platform \
             --region=us-central1 \
-            --format="value(status.traffic.filter('percent=0').extract(tag).flatten())" \
-            | tr ';' '\n' | grep -v '^$' || true)
+            --format=json \
+            | jq -r '.status.traffic[]
+                     | select(.percent == 0 and .tag != null and (.tag | startswith("candidate-")))
+                     | .tag' \
+            | sort -u)"
           if [ -z "${STALE_TAGS}" ]; then
-            echo "No stale traffic tags to remove."
+            echo "No stale candidate-* traffic tags to remove."
             exit 0
           fi
-          REMOVE_LIST=$(echo "${STALE_TAGS}" | paste -sd',' -)
-          echo "Removing stale traffic tags: ${REMOVE_LIST}"
+          REMOVE_LIST="$(echo "${STALE_TAGS}" | paste -sd',' -)"
+          echo "Removing stale candidate traffic tags: ${REMOVE_LIST}"
           gcloud run services update-traffic reporium-api \
             --remove-tags="${REMOVE_LIST}" \
             --project=perditio-platform \
             --region=us-central1
+
+      - name: Verify no public candidate-* bypass URLs remain
+        # Regression guard. After the cleanup step above, no non-serving revision
+        # should carry a `candidate-*` tag. If any remain, the public bypass URL
+        # is still live — surface a workflow warning so the operator notices. Does
+        # not fail the deploy (promotion already succeeded) but is visible in the
+        # Actions UI and greppable in logs.
+        if: success()
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          LINGERING="$(gcloud run services describe reporium-api \
+            --project=perditio-platform \
+            --region=us-central1 \
+            --format=json \
+            | jq -r '.status.traffic[]
+                     | select(.percent == 0 and .tag != null and (.tag | startswith("candidate-")))
+                     | .tag')"
+          if [ -n "${LINGERING}" ]; then
+            echo "::warning::Stale candidate traffic tags still present after cleanup — public bypass URLs may remain reachable:"
+            echo "${LINGERING}"
+          else
+            echo "No stale candidate-* tags on non-serving revisions — bypass paths closed."
+          fi
 
       - name: Prune old container images (keep latest 5)
         if: success()

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -168,9 +168,6 @@ jobs:
         # identified by its traffic tag. `--to-tags=candidate-<sha>=100` is precise:
         # it does not rely on "latest" semantics and is unambiguous about which
         # revision is being promoted.
-        #
-        # After this succeeds, the tag remains on the revision (harmless) so you can
-        # still curl the tagged URL for post-promotion comparison if needed.
         run: |
           set -euo pipefail
           TAG="candidate-${{ steps.meta.outputs.short_sha }}"
@@ -180,6 +177,33 @@ jobs:
             --project=perditio-platform \
             --region=us-central1
           echo "Traffic shifted to candidate revision."
+
+      - name: Remove stale traffic tags from non-serving revisions
+        # Cloud Run leaves `candidate-<sha>` traffic tags on previous revisions after
+        # promotion. Because `reporium-api` has `allUsers` invoker, those tagged URLs
+        # remain publicly reachable and can serve pre-hotfix code against the current
+        # database — e.g. leaking stale aggregate counts from before a private-repo
+        # filter fix. Strip tags from every revision that is not currently serving
+        # traffic so only the active revision has a tagged URL.
+        if: success()
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          STALE_TAGS=$(gcloud run services describe reporium-api \
+            --project=perditio-platform \
+            --region=us-central1 \
+            --format="value(status.traffic.filter('percent=0').extract(tag).flatten())" \
+            | tr ';' '\n' | grep -v '^$' || true)
+          if [ -z "${STALE_TAGS}" ]; then
+            echo "No stale traffic tags to remove."
+            exit 0
+          fi
+          REMOVE_LIST=$(echo "${STALE_TAGS}" | paste -sd',' -)
+          echo "Removing stale traffic tags: ${REMOVE_LIST}"
+          gcloud run services update-traffic reporium-api \
+            --remove-tags="${REMOVE_LIST}" \
+            --project=perditio-platform \
+            --region=us-central1
 
       - name: Prune old container images (keep latest 5)
         if: success()


### PR DESCRIPTION
## Summary
- After `update-traffic --to-tags=candidate-<sha>=100`, Cloud Run leaves the tag on previous revisions. Those tagged URLs remain publicly reachable (service is `allUsers`-invoker) and can serve pre-hotfix code against the current DB.
- New step after promotion: list all revisions with `percent=0` that still have a tag and strip them with `--remove-tags`.
- `continue-on-error: true` so a tag-cleanup blip never blocks a deploy.

## Why this matters
Observed during hotfix #433: tagged candidate URLs from earlier revisions were still reachable and would have served pre-fix counts on `/repos?sort=newest`.

## Test plan
- [ ] Next deploy: check the step logs show either "No stale traffic tags to remove." or a list of tags removed
- [ ] After deploy: `gcloud run services describe reporium-api ... --format='value(status.traffic)'` shows tags only on the serving revision