### PR TITLE
fix(library): make stats.total_forks / languages corpus-wide (#344)

### DIFF
--- a/app/routers/library.py
+++ b/app/routers/library.py
@@ -110,16 +110,40 @@ async def get_library(
     result = await db.execute(stmt)
     repos = result.scalars().all()
 
-    total_stmt = select(func.count(Repo.id)).where(Repo.is_private == False)  # noqa: E712
+    public_repos = Repo.is_private == False  # noqa: E712
+
+    total_stmt = select(func.count(Repo.id)).where(public_repos)
     total_result = await db.execute(total_stmt)
     total = total_result.scalar_one()
 
-    # Build per-page stats (language distribution uses the current page only)
-    lang_counts: dict[str, int] = {}
+    # #344: total_forks / total_non_forks / languages are named "total_*" and
+    # must reflect the full public corpus, not just the current page. Previously
+    # these were computed with `sum(1 for r in repos if r.is_fork)` over the
+    # paginated page, which made `total_forks` track `limit` instead of reality
+    # (e.g. `?limit=1` returned total_forks=1).
+    total_forks = (
+        await db.execute(
+            select(func.count(Repo.id)).where(Repo.is_fork == True, public_repos)  # noqa: E712
+        )
+    ).scalar_one()
+    total_non_forks = total - total_forks
+
+    lang_rows = (
+        await db.execute(
+            select(Repo.primary_language, func.count().label("cnt"))
+            .where(Repo.primary_language.is_not(None))
+            .where(public_repos)
+            .group_by(Repo.primary_language)
+            .order_by(func.count().desc())
+        )
+    ).all()
+    lang_counts: dict[str, int] = {row.primary_language: row.cnt for row in lang_rows}
+
+    # tag_metrics stays page-scoped (count + commit_velocity are derived from
+    # the current page's repos). The field is not named "total_*" so the
+    # page-scoped semantics are consistent with its name.
     page_tag_commit_map: dict[str, dict] = {}
     for repo in repos:
-        if repo.primary_language:
-            lang_counts[repo.primary_language] = lang_counts.get(repo.primary_language, 0) + 1
         for t in repo.tags:
             if t.tag not in page_tag_commit_map:
                 page_tag_commit_map[t.tag] = {"count": 0, "commits": 0}
@@ -160,8 +184,8 @@ async def get_library(
 
     stats = LibraryStats(
         total_repos=total,
-        total_forks=sum(1 for r in repos if r.is_fork),
-        total_non_forks=sum(1 for r in repos if not r.is_fork),
+        total_forks=total_forks,
+        total_non_forks=total_non_forks,
         languages=lang_counts,
         top_tags=global_top_tags,
     )

--- a/tests/test_library.py
+++ b/tests/test_library.py
@@ -1,0 +1,91 @@
+"""Regression tests for /library (issue #344).
+
+The /library response includes a `stats` object whose fields are named
+`total_repos`, `total_forks`, `total_non_forks`, `languages`, etc. Historically
+`total_forks`, `total_non_forks`, and `languages` were computed over the
+paginated page (e.g. `sum(1 for r in repos if r.is_fork)`), which made
+`total_forks` track `limit` instead of the true corpus count. A request of
+`/library?limit=1` would return `stats.total_forks == 1`.
+
+These tests pin the corpus-wide semantics so the fields can't drift again.
+"""
+
+import pytest
+from httpx import AsyncClient
+
+from tests.conftest import AUTH_HEADERS, TEST_REPO_FIXTURE
+
+
+@pytest.mark.asyncio
+async def test_library_stats_totals_are_corpus_wide_not_page_scoped(client: AsyncClient):
+    fork_payloads = [
+        {
+            **TEST_REPO_FIXTURE,
+            "name": f"lib-fork-{i}",
+            "github_url": f"https://github.com/testuser/lib-fork-{i}",
+            "is_fork": True,
+            "is_private": False,
+        }
+        for i in range(3)
+    ]
+    non_fork_payload = {
+        **TEST_REPO_FIXTURE,
+        "name": "lib-builtbyme-1",
+        "github_url": "https://github.com/testuser/lib-builtbyme-1",
+        "is_fork": False,
+        "forked_from": None,
+        "is_private": False,
+    }
+
+    baseline = (await client.get("/library?limit=1")).json()["stats"]
+
+    r = await client.post(
+        "/ingest/repos",
+        json=[*fork_payloads, non_fork_payload],
+        headers=AUTH_HEADERS,
+    )
+    assert r.status_code == 200
+
+    # Request with limit=1 — before the #344 fix this would return
+    # total_forks=1 because the sum iterated only the paginated page.
+    resp = await client.get("/library?limit=1")
+    assert resp.status_code == 200
+    stats = resp.json()["stats"]
+
+    assert stats["total_forks"] == baseline["total_forks"] + 3
+    assert stats["total_non_forks"] == baseline["total_non_forks"] + 1
+    assert stats["total_repos"] == baseline["total_repos"] + 4
+    assert stats["total_forks"] + stats["total_non_forks"] == stats["total_repos"]
+
+
+@pytest.mark.asyncio
+async def test_library_stats_languages_are_corpus_wide(client: AsyncClient):
+    """languages dict on /library.stats must reflect the whole public corpus."""
+    payload = {
+        **TEST_REPO_FIXTURE,
+        "name": "lib-rust-probe",
+        "github_url": "https://github.com/testuser/lib-rust-probe",
+        "primary_language": "Rust",
+        "is_private": False,
+    }
+
+    baseline_rust = (
+        (await client.get("/library?limit=1")).json()["stats"]["languages"].get("Rust", 0)
+    )
+
+    r = await client.post("/ingest/repos", json=[payload], headers=AUTH_HEADERS)
+    assert r.status_code == 200
+
+    # Paginated page of 1 should NOT cap the language bucket at 1.
+    stats = (await client.get("/library?limit=1")).json()["stats"]
+    assert stats["languages"].get("Rust", 0) == baseline_rust + 1
+
+
+@pytest.mark.asyncio
+async def test_library_stats_matches_stats_endpoint(client: AsyncClient):
+    """/library.stats totals must agree with /stats on the same corpus."""
+    stats_endpoint = (await client.get("/stats")).json()
+    library_stats = (await client.get("/library?limit=1")).json()["stats"]
+
+    assert library_stats["total_repos"] == stats_endpoint["total_repos"]
+    assert library_stats["total_forks"] == stats_endpoint["total_forks"]


### PR DESCRIPTION
## Summary
Root cause for #344 — not a cache/TTL issue. `/library.stats.total_forks`, `total_non_forks`, and `languages` were computed over the *paginated page*, not the full corpus. A request to `/library?limit=1` returned `total_forks=1`; `/library?limit=500` could return up to `500`. Production right now: `/library.stats.total_forks=1` vs `/stats.total_forks=1837`.

## Fix
- Replace per-page sums with corpus-wide queries (mirrors `/stats`).
- Keep `tag_metrics` page-scoped — its field name and `commit_velocity` calculation are consistent with that scope.
- Regression tests ingest known fork/non-fork fixtures and assert `/library.stats` agrees with `/stats` on the same revision.

## Reproduction (prod, pre-fix)
```
curl .../stats                 → total_forks: 1837
curl .../library?limit=1       → stats.total_forks: 1  ← drift
curl .../library?limit=100     → stats.total_forks: ~60 (= forks-in-page)
```

## Test plan
- [ ] CI green on reporium-api
- [ ] After deploy: `/library?limit=1` returns `stats.total_forks == stats.total_repos - stats.total_non_forks` matching `/stats`

Closes #344.