### PR TITLE
test(ask): add forbidden_repos primitive to golden-set gate (#367)

### DIFF
--- a/tests/golden_set_ask.yaml
+++ b/tests/golden_set_ask.yaml
@@ -1097,6 +1097,44 @@
       pr_merge_rate: 0.67
 
 # ---------------------------------------------------------------------------
+# Regression guard: "alternatives to X" negation queries.
+# Issue #365 — /ask returned `pinecone-python-client` as the top-1 source for
+# "vector database alternatives to pinecone" (the queried product itself, not
+# an alternative). The `forbidden_repos` field is a hard assertion that a
+# given "owner/name" MUST NOT appear in `sources`. This is the only gate we
+# have for negated-token retrieval bugs, so treat it as a must-pass.
+# ---------------------------------------------------------------------------
+
+- question: "vector database alternatives to pinecone"
+  expected_themes: ["vector", "alternative"]
+  expected_repos: ["weaviate/weaviate"]
+  forbidden_repos: ["pinecone-io/pinecone-python-client"]
+  difficulty: medium
+  max_tokens_soft_budget: 3500
+  fixture_repos:
+    - owner: weaviate
+      name: weaviate
+      description: "Open-source vector database"
+      problem_solved: "Store, search and manage vectors at scale with hybrid filtering"
+      similarity: 0.88
+      stars: 12000
+      integration_tags: [vector-db, hybrid-search, open-source]
+    - owner: qdrant
+      name: qdrant
+      description: "High-performance vector similarity search engine"
+      problem_solved: "Rust-based vector DB with payload filtering and sharding"
+      similarity: 0.86
+      stars: 20000
+      integration_tags: [vector-db, rust, embedded]
+    - owner: chroma-core
+      name: chroma
+      description: "AI-native embedding database"
+      problem_solved: "Lightweight local vector store for prototyping RAG apps"
+      similarity: 0.84
+      stars: 17000
+      integration_tags: [vector-db, embeddings, rag]
+
+# ---------------------------------------------------------------------------
 # Edge cases — these assert HTTP behavior rather than quality scores.
 # ---------------------------------------------------------------------------
 

--- a/tests/test_ask_golden_numeric.py
+++ b/tests/test_ask_golden_numeric.py
@@ -24,6 +24,10 @@ How it works
      - Total tokens across the suite is ``<= 1.2x`` the sum of per-entry
        ``max_tokens_soft_budget`` values.
      - Every ``expect_status`` edge case returns the expected HTTP code.
+     - No entry's ``forbidden_repos`` list appears in ``sources``. This is a
+       hard fail — used to catch retrieval bugs where a negated token (e.g.
+       "alternatives to pinecone") still returns the negated product as a
+       top source. See issue #365 / #367.
 
 Scoring weights (per entry) — ``quality_score`` in ``[0, 1]``:
     0.5 * fraction of ``expected_themes`` substrings present (case-insensitive)
@@ -225,6 +229,10 @@ async def test_ask_golden_set_numeric_gate(client_no_db: AsyncClient):
 
     scored_results: list[dict[str, Any]] = []
     status_results: list[dict[str, Any]] = []
+    # #367: `forbidden_repos` assertions. Any source slug in `forbidden_repos`
+    # appearing in the response fails the whole gate — this is the primitive
+    # for catching #365-style "alternatives to X returns X" retrieval bugs.
+    forbidden_violations: list[dict[str, Any]] = []
     total_tokens = 0
     total_budget = 0
 
@@ -276,6 +284,18 @@ async def test_ask_golden_set_numeric_gate(client_no_db: AsyncClient):
         sources = data.get("sources") or []
         tokens = data.get("tokens_used") or {}
         used = int(tokens.get("total") or 0)
+
+        forbidden = entry.get("forbidden_repos") or []
+        if forbidden:
+            source_slugs = {
+                f"{(s.get('owner') or '').lower()}/{(s.get('name') or '').lower()}"
+                for s in sources
+            }
+            leaked = [f for f in forbidden if str(f).lower() in source_slugs]
+            if leaked:
+                forbidden_violations.append(
+                    {"idx": idx, "question": question[:60], "leaked": leaked}
+                )
 
         score = _score_entry(entry, answer, sources)
         total_tokens += used
@@ -344,6 +364,18 @@ async def test_ask_golden_set_numeric_gate(client_no_db: AsyncClient):
     # Edge-case statuses must all match.
     bad_statuses = [r for r in status_results if not r["pass"]]
     assert not bad_statuses, f"Edge-case status mismatches: {bad_statuses}"
+
+    # #367: forbidden_repos violations are hard failures. Unlike the aggregate
+    # quality_score (which can absorb a few misses), a repo explicitly
+    # forbidden appearing in sources means a retrieval bug — e.g. the queried
+    # product itself returned as an "alternative" (#365).
+    assert not forbidden_violations, (
+        "forbidden_repos leaked into sources: "
+        + "; ".join(
+            f"#{v['idx']} ({v['question']!r}) leaked {v['leaked']}"
+            for v in forbidden_violations
+        )
+    )
 
     assert scored_results, "No scored entries — golden set produced zero quality samples"
 


### PR DESCRIPTION
## Summary
#367 reports the ask quality gate stayed green despite #365 shipping (\`/ask\` returning the queried product itself as the top-1 \"alternative\"). Root cause: the gate had no primitive to assert a repo **must not** appear in \`sources\`.

## Change
- New field \`forbidden_repos: [\"owner/name\"]\` in \`tests/golden_set_ask.yaml\` entries.
- Hard assertion in \`tests/test_ask_golden_numeric.py\`: any slug in \`forbidden_repos\` that appears in response \`sources\` fails the whole gate with a per-entry violation list.
- First use: a \"vector database alternatives to pinecone\" entry that forbids \`pinecone-io/pinecone-python-client\`.

## What this closes of #367
- [x] Reusable primitive for #365-style negated-token regressions
- [ ] Graph edge-precision gate (#362/#363/#364) — **out of scope**. Those are post-deploy, live-data checks; a nightly watchdog against prod \`/metrics/graph-quality\` is the right shape, not a PR gate. Tracked separately; will comment on #367.

## Test plan
- [ ] CI: the new golden-set entry runs under the existing \`Ask Quality Gate\` workflow (gated by \`ANTHROPIC_API_KEY\`)
- [ ] Intentional fail: temporarily add \`pinecone-io/pinecone-python-client\` to \`fixture_repos\` and confirm the gate fails with the violation message

Part of #367.