### PR TITLE
fix(health): NullPool-safe pool telemetry on /health (#354 follow-up)

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -342,6 +342,7 @@ if __name__ == "__main__":
 @limiter.limit("60/minute")
 async def health(request: Request):
     from sqlalchemy import text
+    from app.database import engine
 
     db_error: str | None = None
     try:
@@ -351,6 +352,16 @@ async def health(request: Request):
         db_error = str(e)
         logger.warning(f"DB health check failed: {e}")
 
+    # #354: surface pool stats so Cloud Monitoring alerts can probe saturation
+    # without hitting Cloud SQL directly. `.size()` returns the configured
+    # pool_size; `.checkedout()` is the number of currently-held connections.
+    pool = engine.pool
+    pool_stats = {
+        "size": pool.size(),
+        "checked_out": pool.checkedout(),
+        "overflow": pool.overflow(),
+    }
+
     if db_error:
         return JSONResponse(
             status_code=503,
@@ -358,10 +369,12 @@ async def health(request: Request):
                 "status": "degraded",
                 "db": "error",
                 "detail": "database check failed",
+                "pool": pool_stats,
             },
         )
 
     return {
         "status": "ok",
         "db": "ok",
+        "pool": pool_stats,
     }

--- a/app/main.py
+++ b/app/main.py
@@ -338,6 +338,26 @@ if __name__ == "__main__":
     uvicorn.run("app.main:app", host="0.0.0.0", port=port)
 
 
+def _pool_stats(pool) -> dict:
+    # #354 follow-up: NullPool (used in CI/tests) does not implement size()/
+    # checkedout()/overflow(). Probe each counter defensively so /health stays
+    # 200 in any pool configuration; AsyncAdaptedQueuePool returns real ints.
+    def _safe(name):
+        method = getattr(pool, name, None)
+        if not callable(method):
+            return None
+        try:
+            return method()
+        except Exception:
+            return None
+
+    return {
+        "size": _safe("size"),
+        "checked_out": _safe("checkedout"),
+        "overflow": _safe("overflow"),
+    }
+
+
 @app.get("/health")
 @limiter.limit("60/minute")
 async def health(request: Request):
@@ -352,15 +372,7 @@ async def health(request: Request):
         db_error = str(e)
         logger.warning(f"DB health check failed: {e}")
 
-    # #354: surface pool stats so Cloud Monitoring alerts can probe saturation
-    # without hitting Cloud SQL directly. `.size()` returns the configured
-    # pool_size; `.checkedout()` is the number of currently-held connections.
-    pool = engine.pool
-    pool_stats = {
-        "size": pool.size(),
-        "checked_out": pool.checkedout(),
-        "overflow": pool.overflow(),
-    }
+    pool_stats = _pool_stats(engine.pool)
 
     if db_error:
         return JSONResponse(

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,7 +1,7 @@
 import pytest
 from httpx import ASGITransport, AsyncClient
 
-from app.main import app
+from app.main import _pool_stats, app
 import app.main as main_module
 
 
@@ -32,6 +32,9 @@ class _Factory:
         return self._session
 
 
+_POOL_KEYS = {"size", "checked_out", "overflow"}
+
+
 @pytest.mark.asyncio
 async def test_health_returns_ok_when_database_query_succeeds(monkeypatch):
     monkeypatch.setattr(main_module, "async_session_factory", _Factory(_SuccessfulSession()))
@@ -40,7 +43,10 @@ async def test_health_returns_ok_when_database_query_succeeds(monkeypatch):
         response = await client.get("/health")
 
     assert response.status_code == 200
-    assert response.json() == {"status": "ok", "db": "ok"}
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body["db"] == "ok"
+    assert set(body["pool"].keys()) == _POOL_KEYS
 
 
 @pytest.mark.asyncio
@@ -51,5 +57,49 @@ async def test_health_returns_503_when_database_query_fails(monkeypatch):
         response = await client.get("/health")
 
     assert response.status_code == 503
-    assert response.json()["status"] == "degraded"
-    assert response.json()["db"] == "error"
+    body = response.json()
+    assert body["status"] == "degraded"
+    assert body["db"] == "error"
+    assert set(body["pool"].keys()) == _POOL_KEYS
+
+
+def test_pool_stats_returns_none_for_nullpool_without_counter_attrs():
+    # NullPool stand-in: no size/checkedout/overflow attrs.
+    class _NullPoolLike:
+        pass
+
+    stats = _pool_stats(_NullPoolLike())
+
+    assert stats == {"size": None, "checked_out": None, "overflow": None}
+
+
+def test_pool_stats_returns_none_when_counter_methods_raise():
+    class _BrokenPool:
+        def size(self):
+            raise RuntimeError("pool not initialized")
+
+        def checkedout(self):
+            raise RuntimeError("pool not initialized")
+
+        def overflow(self):
+            raise RuntimeError("pool not initialized")
+
+    stats = _pool_stats(_BrokenPool())
+
+    assert stats == {"size": None, "checked_out": None, "overflow": None}
+
+
+def test_pool_stats_reports_counters_from_queue_pool_like():
+    class _QueuePoolLike:
+        def size(self):
+            return 5
+
+        def checkedout(self):
+            return 2
+
+        def overflow(self):
+            return 1
+
+    stats = _pool_stats(_QueuePoolLike())
+
+    assert stats == {"size": 5, "checked_out": 2, "overflow": 1}


### PR DESCRIPTION
## Summary

PR #435 added `pool.size()`, `pool.checkedout()`, and `pool.overflow()` calls to `/health` for saturation alerting. Those methods are not callable on SQLAlchemy `NullPool`, which is the engine pool class CI uses. Result: `/health` returned 500 and both `Tests` and `Dev Tests` workflows on PR #435 went red.

This branch is a self-contained replacement for #435: it includes the original telemetry plus a defensive `_pool_stats` helper that probes each counter with `getattr` + try/except so `/health` stays green under any pool class.

## NullPool vs pooled runtime

- **Production / pooled runtime** (`AsyncAdaptedQueuePool`, the default for `create_async_engine`): `size()`, `checkedout()`, `overflow()` return real ints — `_pool_stats` returns the same numbers as before.
- **CI / tests** (`NullPool`): those methods are not callable. `_pool_stats` returns `{"size": null, "checked_out": null, "overflow": null}`, so the `pool` key shape stays stable for clients/alerts and `/health` does not 500.
- **Any future pool class**: `getattr(pool, name, None)` + `try/except` keeps the endpoint resilient without coupling to a specific pool implementation.

## Owned scope

- `app/main.py` — added `_pool_stats` helper, called from `/health`.
- `tests/test_health.py` — covers the success/degraded paths and the three pool shapes.

## Test plan

- [x] `tests/test_health.py` — 5 tests pass locally:
  - `test_health_returns_ok_when_database_query_succeeds`
  - `test_health_returns_503_when_database_query_fails`
  - `test_pool_stats_returns_none_for_nullpool_without_counter_attrs`
  - `test_pool_stats_returns_none_when_counter_methods_raise`
  - `test_pool_stats_reports_counters_from_queue_pool_like`
- [x] Verified real `sqlalchemy.pool.NullPool` does not have callable `size`/`checkedout`/`overflow` — defensive `getattr` is required, not paranoia.
- [ ] CI `Tests` and `Dev Tests` workflows green (was the failure mode on PR #435).

## Notes

- Closes the same issue as #435; #435 can be closed in favor of this branch, or this commit cherry-picked onto its head.
- No infra, middleware, or workflow edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)