### PR TITLE
feat(data-quality): surface gap and missing-repo sample on primary_category gate failure

### DIFF
--- a/.audit/2026-04-26/data-quality-recovery-note.md
+++ b/.audit/2026-04-26/data-quality-recovery-note.md
@@ -1,0 +1,77 @@
+# Data Quality Recovery Lane — Final Note
+
+**Date:** 2026-04-25 PDT (UTC date in repo paths)
+**Scope:** Recover from the only remaining `Data Quality Check` failure on `main`.
+**Workspace:** `C:\DEV\PERDITIO_PLATFORM\reporium-api`
+
+## Live failure shape (revalidated)
+
+- Workflow: `Data Quality Check` (`.github/workflows/data-quality.yml`)
+- Latest run on `main`: id `24944014155`, status `completed`, conclusion `failure`
+- Failing gate: `primary_category_coverage`
+  - Numerator: 1641 public repos with `primary_category`
+  - Denominator: 1856 public repos
+  - Coverage: 88.4%
+  - Threshold: 95%
+  - Shortfall: **123 repos** (need to reach 1764 / 1856 to pass)
+- All other gates pass: `embeddings_coverage`, `null_is_private`, `readme_summary_coverage`, `no_private_repos_in_api`
+- Auth/403 from the prior lane is fully gone — `X-Admin-Key` injection works.
+
+## Root cause
+
+The data deficit itself (215 public repos with `primary_category IS NULL`) lives outside this repo. It is fed by the `reporium-ingestion` enrichment Cloud Run Job. Memory entry `project_ask_sprint1_apr22.md` already assigns enrichment ownership to that lane.
+
+This repo's contribution to the failure is **insufficient diagnostics** — the gate today reports only `1641/1856 public repos have primary_category` and exits 1, giving the operator no way to know which repos to enrich, by how many, or where to act.
+
+## Repo-local fix (this lane)
+
+Branch: `claude/feature/KAN-DRAFT-data-quality-recovery`
+PR: see PR link captured in this lane handoff at the end of the file.
+
+Two small changes:
+
+1. **`app/routers/platform.py`** — `/metrics/data-quality` now returns an additional field, `missing_primary_category_sample`: a list (capped at 10) of the most-recently-ingested public repos that are still missing `primary_category`, each shaped `{name: "owner/name", ingested_at: "ISO-8601"}`. Cheap extra `SELECT ... ORDER BY ingested_at DESC LIMIT 10`. Private repos are still excluded.
+2. **`scripts/quality_gates.py`** — when `primary_category_coverage` fails, the script now prints:
+   - the absolute gap to the threshold ("need N more enriched repos to reach 95%")
+   - the sample list of missing repos with their `ingested_at` timestamps
+   - a one-line pointer to the fix location (`reporium-ingestion` enrichment Cloud Run Job)
+
+   Implementation detail: each gate result dict gained an `extra: list[str]` field; `main()` indents and prints those lines below `[FAIL]`. Pass-path output is unchanged.
+3. **`tests/test_platform_metrics.py`** — extended the existing `test_metrics_data_quality_reports_public_only_coverage` to assert the new sample field exists, includes the inserted `dq-pub-bare` (NULL primary_category, public), is capped at 10, and never leaks the private `dq-priv` row.
+
+## Proof of behavior
+
+A local end-to-end smoke test pointed `quality_gates.py` at a mock HTTP server returning a payload that mirrors the live failure (1641/1856 + 3 sample repos). Output:
+
+```
+[FAIL] primary_category_coverage: 1641/1856 public repos have primary_category
+        need 123 more enriched repos to reach 95% threshold
+        most-recent public repos missing primary_category (top 3):
+          - foo/recent-1  (ingested_at=2026-04-25T10:00:00+00:00)
+          - bar/recent-2  (ingested_at=2026-04-25T09:00:00+00:00)
+          - baz/recent-3  (ingested_at=2026-04-25T08:00:00+00:00)
+        fix in: reporium-ingestion enrichment Cloud Run Job — re-run the nightly enrichment workflow against the missing repo IDs.
+```
+
+`_shortfall(1641, 1856, 95.0) == 123` confirmed against the live numbers.
+
+The integration test against the real `/metrics/data-quality` endpoint requires Postgres on `localhost:5432`, which is not available on the workspace machine. CI on the PR will run it.
+
+## What this lane does NOT change
+
+- Threshold remains 95% (lowering it without fixing the underlying data would mask the problem).
+- The data fix itself stays with the **ingestion lane** — running enrichment against the 215 missing repos.
+- No `data-quality.yml` workflow change.
+- No deploy was triggered manually.
+
+## Exact next action (if the issue remains outside this repo after this PR merges)
+
+1. Wait for the PR to merge to `main` and Cloud Run auto-deploy to land (typically <15 min).
+2. Trigger one `Data Quality Check` workflow run via `workflow_dispatch`.
+3. Read the failing gate output — it will now include up to 10 specific `owner/name` repos to chase.
+4. In `reporium-ingestion`, run the enrichment Cloud Run Job restricted to those repo IDs (or the most recent N ingested-but-unenriched batch). Per memory `project_ask_sprint1_apr22.md`, the scheduler-triggered nightly job ran cleanly at 07:16 UTC on 2026-04-22 with 181 repos / 0 errors — the job itself is healthy.
+5. Re-run the data-quality workflow; expect the gate to clear once 123+ of the missing repos receive a category.
+
+## PR
+
+PR link: <to be filled in by the push step below>

--- a/.audit/2026-04-26/data-quality-recovery-note.md
+++ b/.audit/2026-04-26/data-quality-recovery-note.md
@@ -26,7 +26,7 @@ This repo's contribution to the failure is **insufficient diagnostics** — the 
 ## Repo-local fix (this lane)
 
 Branch: `claude/feature/KAN-DRAFT-data-quality-recovery`
-PR: see PR link captured in this lane handoff at the end of the file.
+PR: https://github.com/perditioinc/reporium-api/pull/442
 
 Two small changes:
 
@@ -74,4 +74,4 @@ The integration test against the real `/metrics/data-quality` endpoint requires 
 
 ## PR
 
-PR link: <to be filled in by the push step below>
+PR link: https://github.com/perditioinc/reporium-api/pull/442

--- a/app/routers/platform.py
+++ b/app/routers/platform.py
@@ -687,12 +687,42 @@ async def metrics_data_quality(
         )
     ).fetchone()
     total_public = int(row.total_public or 0) if row else 0
+
+    # Surface the most recently-ingested public repos that are still missing a
+    # primary_category. The data-quality gate is fed by the
+    # reporium-ingestion enrichment job; when this gate fails the operator
+    # needs to know *which* repos to chase, not just the percentage. Cap at
+    # 10 names so the response stays compact.
+    missing_sample_rows = (
+        await db.execute(
+            text(
+                """
+                SELECT owner || '/' || name AS full_name,
+                       ingested_at
+                FROM repos
+                WHERE is_private = false
+                  AND primary_category IS NULL
+                ORDER BY ingested_at DESC NULLS LAST
+                LIMIT 10
+                """
+            )
+        )
+    ).fetchall()
+    missing_primary_category_sample = [
+        {
+            "name": r.full_name,
+            "ingested_at": r.ingested_at.isoformat() if r.ingested_at else None,
+        }
+        for r in missing_sample_rows
+    ]
+
     return {
         "total_public_repos": total_public,
         "public_with_primary_category": int(row.public_with_primary_category or 0) if row else 0,
         "public_with_readme_summary": int(row.public_with_readme_summary or 0) if row else 0,
         "public_with_embeddings": int(row.public_with_embeddings or 0) if row else 0,
         "null_is_private_count": int(row.null_is_private_count or 0) if row else 0,
+        "missing_primary_category_sample": missing_primary_category_sample,
         "generated_at": datetime.now(timezone.utc).isoformat(),
     }
 

--- a/scripts/quality_gates.py
+++ b/scripts/quality_gates.py
@@ -54,6 +54,14 @@ def _pct(numerator: int, denominator: int) -> float:
     return (numerator / denominator * 100) if denominator > 0 else 0.0
 
 
+def _shortfall(numerator: int, denominator: int, threshold_pct: float) -> int:
+    """Count of additional rows needed for `numerator/denominator` to clear `threshold_pct`."""
+    if denominator <= 0:
+        return 0
+    needed = -(-int(threshold_pct * denominator) // 100)  # ceil(threshold * denom / 100)
+    return max(0, needed - numerator)
+
+
 def run_counts_checks(api_url: str) -> list[dict]:
     """Gates 1/2/4/5: read aggregate counts from /metrics/data-quality."""
     try:
@@ -66,6 +74,7 @@ def run_counts_checks(api_url: str) -> list[dict]:
             "unit": None,
             "pass": False,
             "detail": f"GET {api_url}/metrics/data-quality failed: {e}",
+            "extra": [],
         }]
 
     total_public = int(data.get("total_public_repos") or 0)
@@ -73,10 +82,31 @@ def run_counts_checks(api_url: str) -> list[dict]:
     with_readme = int(data.get("public_with_readme_summary") or 0)
     with_embeddings = int(data.get("public_with_embeddings") or 0)
     null_is_private = int(data.get("null_is_private_count") or 0)
+    missing_primary_sample = data.get("missing_primary_category_sample") or []
 
     category_pct = _pct(with_category, total_public)
     readme_pct = _pct(with_readme, total_public)
     emb_pct = _pct(with_embeddings, total_public)
+
+    category_gap = _shortfall(with_category, total_public, THRESHOLDS["primary_category_coverage_pct"])
+    primary_extra: list[str] = []
+    if category_gap > 0:
+        primary_extra.append(
+            f"need {category_gap} more enriched repos to reach "
+            f"{THRESHOLDS['primary_category_coverage_pct']:.0f}% threshold"
+        )
+        if missing_primary_sample:
+            primary_extra.append(
+                "most-recent public repos missing primary_category (top "
+                f"{len(missing_primary_sample)}):"
+            )
+            for entry in missing_primary_sample:
+                ingested = entry.get("ingested_at") or "unknown"
+                primary_extra.append(f"  - {entry.get('name', '?')}  (ingested_at={ingested})")
+        primary_extra.append(
+            "fix in: reporium-ingestion enrichment Cloud Run Job — re-run the nightly "
+            "enrichment workflow against the missing repo IDs."
+        )
 
     return [
         {
@@ -86,6 +116,7 @@ def run_counts_checks(api_url: str) -> list[dict]:
             "unit": "%",
             "pass": category_pct >= THRESHOLDS["primary_category_coverage_pct"],
             "detail": f"{with_category}/{total_public} public repos have primary_category",
+            "extra": primary_extra,
         },
         {
             "gate": "embeddings_coverage",
@@ -94,6 +125,7 @@ def run_counts_checks(api_url: str) -> list[dict]:
             "unit": "%",
             "pass": emb_pct >= THRESHOLDS["embeddings_coverage_pct"],
             "detail": f"{with_embeddings}/{total_public} public repos have embeddings",
+            "extra": [],
         },
         {
             "gate": "null_is_private",
@@ -102,6 +134,7 @@ def run_counts_checks(api_url: str) -> list[dict]:
             "unit": "rows",
             "pass": null_is_private <= THRESHOLDS["null_is_private_count"],
             "detail": f"{null_is_private} repos have NULL is_private",
+            "extra": [],
         },
         {
             "gate": "readme_summary_coverage",
@@ -110,6 +143,7 @@ def run_counts_checks(api_url: str) -> list[dict]:
             "unit": "%",
             "pass": readme_pct >= THRESHOLDS["readme_summary_coverage_pct"],
             "detail": f"{with_readme}/{total_public} public repos have readme_summary",
+            "extra": [],
         },
     ]
 
@@ -131,6 +165,7 @@ def run_library_full_check(api_url: str) -> list[dict]:
             "unit": "repos",
             "pass": len(private_exposed) == 0,
             "detail": f"API returned {len(repos)} repos, {len(private_exposed)} potentially private",
+            "extra": [],
         }]
     except Exception as e:  # noqa: BLE001 — surface full failure reason
         return [{
@@ -140,6 +175,7 @@ def run_library_full_check(api_url: str) -> list[dict]:
             "unit": "repos",
             "pass": False,
             "detail": f"API check failed: {e}",
+            "extra": [],
         }]
 
 
@@ -166,6 +202,8 @@ def main() -> None:
         print(f"[{status}] {r['gate']}: {r['detail']}")
         if not r["pass"]:
             failures.append(r["gate"])
+            for line in r.get("extra") or []:
+                print(f"        {line}")
 
     print()
     if failures:

--- a/tests/test_platform_metrics.py
+++ b/tests/test_platform_metrics.py
@@ -254,6 +254,16 @@ async def test_metrics_data_quality_reports_public_only_coverage(client):
     assert data["null_is_private_count"] == 0
     assert "generated_at" in data
 
+    # Operator-actionable sample of public repos still missing primary_category.
+    # `dq-pub-bare` (NULL primary_category, public) was inserted above and must
+    # appear so the data-quality gate workflow can name it on failure.
+    assert "missing_primary_category_sample" in data
+    sample_names = {entry["name"] for entry in data["missing_primary_category_sample"]}
+    assert "perditioinc/dq-pub-bare" in sample_names
+    assert len(data["missing_primary_category_sample"]) <= 10
+    # Private repos must never leak into the sample.
+    assert "perditioinc/dq-priv" not in sample_names
+
 
 @pytest.mark.asyncio
 async def test_metrics_prometheus_exposes_http_metrics(client):


### PR DESCRIPTION
## Summary

The `Data Quality Check` workflow's `primary_category_coverage` gate currently fails on `main` (run [24944014155](https://github.com/perditioinc/reporium-api/actions/runs/24944014155)) with output:

```
[FAIL] primary_category_coverage: 1641/1856 public repos have primary_category
```

The actual data fix lives in **reporium-ingestion** (the nightly enrichment Cloud Run Job). This repo can't backfill the 215 missing categories — but it can stop emitting an opaque failure that gives the operator no way to act.

This PR makes the failure output sharply more actionable, without changing the gate's pass/fail behavior.

- `/metrics/data-quality` now returns `missing_primary_category_sample`: the **10 most-recently-ingested public repos** still missing `primary_category`, each as `{name, ingested_at}`. Cheap extra `SELECT ... ORDER BY ingested_at DESC LIMIT 10`. Private rows still excluded.
- `scripts/quality_gates.py` now computes the absolute shortfall to the threshold and, on `[FAIL]`, prints the gap, the sample list, and a one-line pointer to the fix location.
- `tests/test_platform_metrics.py` extended to cover the new field, including the privacy assertion that the private `dq-priv` row never leaks into the sample.

## Sample new failure output (mock smoke test, payload mirroring live failure)

```
[FAIL] primary_category_coverage: 1641/1856 public repos have primary_category
        need 123 more enriched repos to reach 95% threshold
        most-recent public repos missing primary_category (top 3):
          - foo/recent-1  (ingested_at=2026-04-25T10:00:00+00:00)
          - bar/recent-2  (ingested_at=2026-04-25T09:00:00+00:00)
          - baz/recent-3  (ingested_at=2026-04-25T08:00:00+00:00)
        fix in: reporium-ingestion enrichment Cloud Run Job — re-run the nightly enrichment workflow against the missing repo IDs.
```

## Test plan

- [x] `_shortfall(1641, 1856, 95.0) == 123` matches the live failure shape
- [x] All 3 changed files parse cleanly (`ast.parse` smoke check)
- [x] End-to-end mock-server run of `quality_gates.py` produces the expected actionable output and still exits 1 on the failing path
- [ ] CI: `tests/test_platform_metrics.py::test_metrics_data_quality_reports_public_only_coverage` passes with the new sample-field assertions (cannot run locally — workspace machine has no Postgres)
- [ ] Post-merge: trigger one `Data Quality Check` workflow run via `workflow_dispatch` and confirm the gate now lists the 10 specific `owner/name` repos to chase

## Out of scope

- The 95% threshold itself — lowering it would mask the data deficit, not fix it.
- Backfilling the 215 missing categories — that work belongs to **reporium-ingestion**.
- The Security Scan and Nightly Graph Build failures — those belong to other lanes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)