### PR TITLE
ci(security): pin floating action refs (nightly-invariants + test)

### DIFF
--- a/.audit/2026-04-26/security-scan-jira.md
+++ b/.audit/2026-04-26/security-scan-jira.md
@@ -1,0 +1,186 @@
+# JIRA fallback — Security Scan red on `main` (2026-04-26)
+
+> JIRA was not reachable from this lane session. This file is the
+> structured backup; copy fields verbatim into JIRA when available.
+
+## Issue 1 — Pin floating action refs in `nightly-invariants.yml` and `test.yml`
+
+- **Project**: KAN (Reporium API)
+- **Type**: Task / Security
+- **Component**: CI / GitHub Actions
+- **Priority**: Medium
+- **Status**: In review (PR opened from this lane)
+
+**Summary**
+
+Two workflow files referenced GitHub Actions by floating tag/branch
+instead of by SHA. SHA pinning is required by the platform's own
+`reporium-security` scanner and by GitHub's hardening guidance:
+
+| File | Line | Was | Pin |
+|---|---|---|---|
+| `.github/workflows/nightly-invariants.yml` | 22 | `actions/checkout@v4` | `@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2` |
+| `.github/workflows/nightly-invariants.yml` | 25 | `actions/setup-python@v5` | `@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0` |
+| `.github/workflows/nightly-invariants.yml` | 46 | `actions/upload-artifact@v4` | `@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2` |
+| `.github/workflows/test.yml` | 94 | `perditioinc/perditio-devkit/.github/workflows/on-test-failure.yml@main` | `@aa588479da71164c0bd2ee493a76ee46830d10dc # main @ 2026-04-26` |
+
+SHAs verified against `gh api repos/<owner>/<repo>/git/refs/tags`. The
+`actions/checkout` and `actions/setup-python` SHAs match the values
+already in use elsewhere in this repo, so this is not introducing a new
+version surface.
+
+**Acceptance**
+
+- [x] Workflow YAML parses cleanly (verified: `yaml.safe_load`).
+- [x] PR opened from `claude/feature/KAN-DRAFT-security-scan-fix`.
+- [ ] After merge, the next `Tests` and `Nightly Data Invariants` runs
+  on `main` succeed without floating-ref drift risk.
+
+## Issue 2 — `reporium-security` scanner false-positive on inline version comments
+
+- **Project**: KAN (or wherever `reporium-security` is owned)
+- **Type**: Bug
+- **Component**: reporium-security / scanner
+- **Priority**: High (blocks `Security Scan` going green across every repo
+  that follows the standard "SHA + `# vX.Y.Z`" pinning pattern)
+- **Status**: Open — fix is upstream, NOT in `reporium-api` lane scope
+
+**Summary**
+
+`reporium-security/reporium_security/checks/workflows.py` rejects every
+correctly-SHA-pinned action that has an inline version comment. After
+this lane's fix is merged, **all 18 remaining workflow warnings** in
+`reporium-api` are false positives of this single regex bug.
+
+**Root cause**
+
+```python
+# reporium-security/reporium_security/checks/workflows.py
+SHA_PATTERN = re.compile(r"@[0-9a-f]{40}$")
+
+def _check_uses_sha(workflow_content, filename):
+    for line_num, line in enumerate(workflow_content.splitlines(), start=1):
+        stripped = line.strip()
+        if "uses:" in stripped:
+            action_ref = stripped.split("uses:")[-1].strip()
+            ...
+            if "@" in action_ref and not SHA_PATTERN.search(action_ref):
+                findings.append(... "uses tag instead of SHA" ...)
+```
+
+For a line like:
+
+```yaml
+uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+```
+
+`action_ref` becomes
+`actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0`.
+The regex anchors with `$`, so the trailing ` # v5.6.0` defeats the
+match — the action is reported as "uses tag instead of SHA" even though
+it is correctly pinned.
+
+**Proposed fix (one line)**
+
+Strip an inline comment from `action_ref` before the regex check:
+
+```python
+action_ref = stripped.split("uses:")[-1].split("#", 1)[0].strip()
+```
+
+Equivalent loosenings of the regex (e.g. drop `$`, or allow trailing
+whitespace + `#`) are also acceptable. This is a one-line change in
+`reporium-security`; this lane did not apply it because
+`reporium-security` is outside the `reporium-api` lane scope.
+
+**Repro**
+
+Already reproducing on every push to `main` since 2026-04-26 00:14 UTC.
+Most recent failing runs at prompt time:
+- 24944058954
+- 24944029033
+- 24944026326
+
+Local repro:
+```
+cd reporium-api && python -m reporium_security scan .
+# → Workflows: Found 18 warning(s) in GitHub Actions workflows.
+```
+
+**Acceptance**
+
+- [ ] After upstream patch + redeploy of `reporium-security`, scanning
+  `reporium-api` (post this lane's PR) reports `0 warning(s)` from the
+  Workflows check.
+- [ ] Same scan re-run against `reporium`, `reporium-db`,
+  `reporium-ingestion` etc. confirms the regex fix did not regress
+  their already-green scans.
+
+## Issue 3 — `History: Found 1 potential secret(s) in git history` is a placeholder false-positive
+
+- **Project**: KAN (or `reporium-security`)
+- **Type**: Bug — scanner false-positive
+- **Component**: reporium-security / scanner / history check
+- **Priority**: Medium
+
+**Summary**
+
+`reporium_security/checks/history.py` flagged commit
+`0d295b75ae2af5360e2d6699a0534094da727711` (PR #440 — "fix(data-quality):
+pass X-Admin-Key to /metrics/data-quality") as containing a "Hardcoded
+API key".
+
+Investigated: the matched line is from
+`.audit/2026-04-24/kan-data-quality-verification-jira.md`, inside a
+fenced shell-snippet showing how to dry-run the gate script:
+
+```
+ADMIN_API_KEY="<value>" \
+```
+
+`<value>` is a literal placeholder, not a leaked secret.  The
+`Hardcoded API key` regex
+(`(?i)api_key\s*=\s*["\'][^"\']{4,}["\']`) requires only 4+ chars
+inside the quotes, and `<value>` is 7 chars.
+
+**Why the existing skip list missed it**
+
+`history.py` already filters lines containing `"placeholder"`,
+`"example"`, `"changeme"`, `"xxx"`, etc., but does not skip the
+`<...>` shell/man-page placeholder convention.
+
+**Proposed fix (one of two)**
+
+(a) In `history.py` skip-keyword list, add the angle-bracket
+placeholder:
+```python
+if any(p in lower_line for p in (
+    ..., 'placeholder', 'changeme', 'xxx',
+    '<value>', '<your_', '<sha>', '<token>',  # NEW
+)):
+```
+
+OR (preferred) (b) detect the placeholder shape with a tiny regex on
+the matched substring rather than a fixed keyword list:
+```python
+if re.search(r'<[a-z_][a-z0-9_]*>', lower_line):
+    continue
+```
+
+This is again a `reporium-security` change — out of `reporium-api` lane
+scope.
+
+**Acceptance**
+
+- [ ] After upstream patch, the scan against `reporium-api` reports
+  `History: No secrets detected in recent git history.`
+- [ ] No real secrets get accidentally suppressed (regex requires a
+  word inside angle brackets, not a 32+ char hex blob).
+
+## Out of scope for this lane
+
+- Rewriting git history. The "history" finding is a placeholder, not a
+  real leak, so no `git filter-repo` is needed even if the lane
+  permitted it.
+- Touching `scripts/quality_gates.py`, `app/routers/platform.py`, or
+  any data-quality file. Those are owned by the data-quality lane.

--- a/.audit/2026-04-26/security-scan-note.md
+++ b/.audit/2026-04-26/security-scan-note.md
@@ -65,6 +65,7 @@ is also out of lane scope.
 
 Branch: `claude/feature/KAN-DRAFT-security-scan-fix`
 Base: `origin/main` @ `502af14` (post PR #440 merge).
+PR: https://github.com/perditioinc/reporium-api/pull/443
 
 Changes:
 

--- a/.audit/2026-04-26/security-scan-note.md
+++ b/.audit/2026-04-26/security-scan-note.md
@@ -1,0 +1,149 @@
+# API Security Scan Lane — execution note (2026-04-26)
+
+## Exact current failure shape (verified live, then locally)
+
+`Security Scan` workflow on `main` exited 1 with:
+
+```
+Security Grade: F
+  Secrets:      No secrets detected in source files.
+  Dependencies: Dependency check skipped: pip-audit not installed.
+                (No known CVEs found in dependencies. when run locally
+                 with pip-audit installed.)
+  Workflows:    Found 18 warning(s) in GitHub Actions workflows.
+  Files:        No sensitive files detected in the repository.
+  History:      Found 1 potential secret(s) in git history.
+```
+
+Most recent failing runs at lane start: 24944058954, 24944029033,
+24944026326. First failure landed with PR #440 (commit `0d295b7`,
+2026-04-26 00:14 UTC). The previous run on PR #436 (`24943938837`) was
+green.
+
+## Workflow-local vs history-local breakdown
+
+### Workflow check — 18 warnings, all "uses tag instead of SHA"
+
+After classification, **0 are real "tag instead of SHA" violations and
+18 are scanner false-positives** caused by a single regex bug in
+`reporium-security`. Every action in `reporium-api` is already pinned to
+a 40-char SHA; the scanner only fails to recognize it because the line
+also has the standard inline `# vX.Y.Z` documentation comment.
+
+The four lines that **were** real violations at lane start:
+
+| File | Line | Reference |
+|---|---|---|
+| `nightly-invariants.yml` | 22 | `actions/checkout@v4` |
+| `nightly-invariants.yml` | 25 | `actions/setup-python@v5` |
+| `nightly-invariants.yml` | 46 | `actions/upload-artifact@v4` |
+| `test.yml` | 94 | `perditioinc/perditio-devkit/.../on-test-failure.yml@main` |
+
+These are real (tag/branch refs, not SHAs) and are fixed by this
+lane's PR.
+
+### History check — 1 finding, placeholder false-positive
+
+Matched line:
+
+```
++   ADMIN_API_KEY="<value>" \
+```
+
+Origin: an audit doc fenced shell snippet
+(`.audit/2026-04-24/kan-data-quality-verification-jira.md`) showing
+how to dry-run the data-quality gate script. `<value>` is a literal
+angle-bracket placeholder — not a leaked secret. The regex
+`(?i)api_key\s*=\s*["\'][^"\']{4,}["\']` matches because `<value>` is
+7 characters; the existing skip list (`placeholder`, `example`,
+`changeme`, `xxx`, etc.) does not include `<...>`-style placeholders.
+
+**No real secret is leaked.** Git history rewrite is NOT warranted and
+is also out of lane scope.
+
+## Repo-local fix made (this lane)
+
+Branch: `claude/feature/KAN-DRAFT-security-scan-fix`
+Base: `origin/main` @ `502af14` (post PR #440 merge).
+
+Changes:
+
+```
+.github/workflows/nightly-invariants.yml | 6 +++---
+.github/workflows/test.yml               | 2 +-
+2 files changed, 4 insertions(+), 4 deletions(-)
+```
+
+Replacements (SHAs verified against `gh api .../git/refs/tags`):
+
+- `actions/checkout@v4` → `@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2`
+  (matches the SHA already used by 8 other workflows in this repo)
+- `actions/setup-python@v5` → `@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0`
+  (matches the SHA used by every other setup-python step in this repo)
+- `actions/upload-artifact@v4` → `@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2`
+  (current `v4` tag target as of 2026-04-26)
+- `perditioinc/perditio-devkit/.../on-test-failure.yml@main` →
+  `@aa588479da71164c0bd2ee493a76ee46830d10dc # main @ 2026-04-26`
+  (current `main` HEAD; reusable workflows accept SHAs)
+
+YAML parsed clean with `yaml.safe_load` for both files.
+
+## Why CI stays red after the PR merges
+
+The 4 real violations are eliminated, but the scanner still reports 18
+warnings because pinning the previously-floating refs introduces 4 new
+inline `# vX.Y.Z` comments — each of which trips the same regex
+false-positive that the original 14 already trip. **Net workflow
+warning count: 18 → 18.**
+
+Going green requires a one-line fix in `reporium-security` (out of
+this lane's scope). See
+[security-scan-jira.md](security-scan-jira.md) Issue 2 for the precise
+patch:
+
+```python
+# reporium-security/reporium_security/checks/workflows.py
+action_ref = stripped.split("uses:")[-1].split("#", 1)[0].strip()
+```
+
+After that lands, scanning `reporium-api` post-PR will report
+`0 warning(s)` for workflows. The history-check false positive needs
+a separate one-line skip-list update in
+`reporium-security/reporium_security/checks/history.py` (Issue 3 in
+the JIRA fallback file).
+
+## Validation performed
+
+- `python -m reporium_security scan .` — full report captured before
+  and after pinning. Count stayed at 18 warnings; the *content* of
+  the warnings shifted from "real floating refs" to "false-positive
+  on the new inline comments", confirming the underlying state is
+  better even though the reported number is the same.
+- `python -c "import yaml; yaml.safe_load(open(<file>).read())"` for
+  both edited workflow files — clean parse.
+- No `git filter-repo`, no force-push, no history rewrite of any kind.
+
+## Exact next step if the upstream regex bug remains
+
+Either:
+
+1. **Preferred**: open a PR in `reporium-security` with the two
+   one-line fixes in `checks/workflows.py` and `checks/history.py`
+   described in the JIRA fallback. After that ships, this repo's
+   `Security Scan` will go green on the very next push to `main`
+   without any further reporium-api change.
+
+2. **Alternative if upstream is blocked**: as a workaround, strip
+   inline `# vX.Y.Z` comments from every `uses:` line in this repo's
+   workflows. Sacrifices version readability for a green badge.
+   Not recommended; the upstream regex fix is one line.
+
+## Lane scope adherence
+
+- Touched only `.github/workflows/*.yml` and lane-local audit notes.
+- Did NOT touch `scripts/quality_gates.py`, `app/routers/platform.py`,
+  or `tests/test_platform_metrics.py` (owned by the active
+  data-quality recovery lane on a sibling branch).
+- Did NOT modify `reporium-security` despite the regex bug being the
+  load-bearing blocker — that repo is sibling to `reporium-api` and
+  outside this lane's stated workspace.

--- a/.github/workflows/nightly-invariants.yml
+++ b/.github/workflows/nightly-invariants.yml
@@ -19,10 +19,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.11"
           cache: pip
@@ -43,7 +43,7 @@ jobs:
 
       - name: Upload pytest output
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: invariants-pytest-output
           path: pytest-output.txt

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -91,7 +91,7 @@ jobs:
   notify-on-failure:
     needs: test
     if: failure()
-    uses: perditioinc/perditio-devkit/.github/workflows/on-test-failure.yml@main
+    uses: perditioinc/perditio-devkit/.github/workflows/on-test-failure.yml@aa588479da71164c0bd2ee493a76ee46830d10dc # main @ 2026-04-26
     with:
       branch: ${{ github.ref_name }}
       sha: ${{ github.sha }}


### PR DESCRIPTION
## Summary
- Pins the four remaining floating action refs in `reporium-api` to SHAs:
  `actions/checkout@v4`, `actions/setup-python@v5`,
  `actions/upload-artifact@v4`, and the reusable
  `perditioinc/perditio-devkit/.../on-test-failure.yml@main`.
- Reused the SHAs already standardized in this repo for `checkout` and
  `setup-python`; verified all SHAs against `gh api .../git/refs/tags`.
- No code paths change — purely supply-chain hardening.

## Why this PR does NOT (yet) make Security Scan green
After this merges, **all 18 remaining `Security Scan` workflow warnings
are false positives of a single regex bug** in
`reporium-security/reporium_security/checks/workflows.py`:

```python
SHA_PATTERN = re.compile(r"@[0-9a-f]{40}$")
```

The `$` anchor defeats the match whenever a `uses:` line has the
standard inline `# vX.Y.Z` documentation comment. Every action in this
repo is in fact SHA-pinned; the scanner just doesn't recognize that
when a comment follows. One-line upstream fix:

```python
action_ref = stripped.split("uses:")[-1].split("#", 1)[0].strip()
```

That belongs in `reporium-security`, which is outside this lane's
scope. Same `reporium-security` repo also owns the second false
positive (history check flagged a `<value>` placeholder in an audit
markdown — not a real leak; no history rewrite needed).

Full classification + proposed upstream patch:
- [`.audit/2026-04-26/security-scan-jira.md`](https://github.com/perditioinc/reporium-api/blob/claude/feature/KAN-DRAFT-security-scan-fix/.audit/2026-04-26/security-scan-jira.md)
- [`.audit/2026-04-26/security-scan-note.md`](https://github.com/perditioinc/reporium-api/blob/claude/feature/KAN-DRAFT-security-scan-fix/.audit/2026-04-26/security-scan-note.md)

Failing runs that motivated the lane: 24944058954, 24944029033,
24944026326 (all post PR #440).

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open(<file>).read())"` —
  both edited workflow files parse cleanly.
- [x] `python -m reporium_security scan .` re-run locally — same 18-count,
  but now classifies as 18 inline-comment false-positives and
  0 actual floating refs (vs. 14 / 4 split before).
- [ ] After merge: confirm `Tests` and `Nightly Data Invariants`
  workflows still execute (SHAs are identical commits to the v4/v5
  tags, so this should be a no-op behaviorally).
- [ ] Follow-on `reporium-security` PR with the regex fix will return
  Security Scan to grade A on `main` without any further reporium-api
  change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)