### PR TITLE
fix(ingest): keep repos.primary_category in sync with junction is_primary

### DIFF
--- a/.audit/2026-04-26/dq-column-sync-note.md
+++ b/.audit/2026-04-26/dq-column-sync-note.md
@@ -1,0 +1,113 @@
+# DQ primary_category column-vs-junction sync fix
+
+**Date:** 2026-04-26
+**Branch:** `claude/feature/KAN-DRAFT-dq-primary-category-sync`
+**PR:** _to be filled in after `gh pr create`_
+
+## Exact root cause
+
+`/metrics/data-quality` (in [`app/routers/platform.py`](../../app/routers/platform.py))
+computes `primary_category_coverage` from `repos.primary_category IS NOT NULL`:
+
+```sql
+SELECT COUNT(*) FROM repos
+  WHERE is_private = false AND primary_category IS NOT NULL
+```
+
+But the canonical ingest path in [`app/routers/ingest.py`](../../app/routers/ingest.py)
+(`_upsert_repo`) only writes the `repo_categories` junction table — it never
+writes the `repos.primary_category` column. The schema has both:
+
+- `repos.primary_category : Text NULL` (model: [`app/models/repo.py:97`](../../app/models/repo.py))
+- `repo_categories(repo_id, category_id, category_name, is_primary)` (junction)
+
+The column was originally populated by a one-off migration
+(`backfill_primary_category.py`, KAN-41) and has been silently drifting since
+then because nothing in the live ingest pipeline keeps it in sync.
+
+This matches the observed live state on `main` (run `24947192489`):
+`primary_category_coverage` reads 1641/1856 = 88.4% even though the
+`/metrics/data-quality` `missing_primary_category_sample` (added in PR #442)
+contains repos that already have a correct `is_primary=true` row in the
+junction.
+
+## Exact files changed
+
+- `app/routers/ingest.py` — in `_upsert_repo`, after writing `RepoCategory`
+  rows, derive the primary category name from any `is_primary=true` entry in
+  the incoming payload and assign it to `repo.primary_category`. Lives inside
+  the existing `if item.categories:` block, so the skip-empty guard
+  (KAN-123) still applies — empty payloads do not clobber existing data.
+
+- `tests/test_ingest.py` — new
+  `test_ingest_keeps_primary_category_column_in_sync_with_junction` regression
+  test. Asserts the invariant:
+  > After ingest, `repos.primary_category` equals the `category_name` of the
+  > `repo_categories` row with `is_primary=true`.
+
+  Covers both the create path (first ingest) and the update path
+  (re-ingest swapping which category is primary).
+
+## Expected effect on the DQ gate
+
+- **Forward fix.** Going forward, every repo that flows through
+  `POST /ingest/repos` with a non-empty `categories` array will keep the
+  column and junction synchronized.
+- **Existing drift.** ~215 repos already have `is_primary=true` in the
+  junction but `NULL` in the column. Those rows do not self-heal until they
+  are re-ingested. There are two paths to flip the gate green sooner:
+
+  1. **Re-ingestion sweep** (zero new code): wait for the next nightly
+     enrichment / weekly full ingest to pass each repo through the patched
+     `_upsert_repo`. Slow but no extra moving part.
+
+  2. **One-off SQL backfill** against Cloud SQL (small, safe, idempotent):
+
+     ```sql
+     UPDATE repos r
+        SET primary_category = rc.category_name
+       FROM repo_categories rc
+      WHERE rc.repo_id = r.id
+        AND rc.is_primary = true
+        AND r.primary_category IS NULL;
+     ```
+
+     Read-only side-effect for rows where the column is already populated;
+     only writes when the column is currently `NULL` and a primary exists in
+     the junction. Recommended path to flip the gate green inside one
+     deployment cycle rather than waiting for full re-ingestion.
+
+## Existing drifted rows: backfill required?
+
+**Yes**, if the goal is to flip `Data Quality Check` green this week. The
+forward fix alone is necessary but not sufficient against the current
+denominator. The backfill SQL above is the cleanest one-off path. It does
+not need a migration script — a `gcloud sql connect` session or admin
+endpoint will do.
+
+The remaining gap after the backfill (rows with no `is_primary=true` in the
+junction at all) is the genuine empty-fork / enriched-no-primary population
+covered by `project_dq_gate_denominator_honesty.md` and
+`reporium-ingestion#67`.
+
+## Exact next action after merge
+
+1. **Merge this PR** to `reporium-api` `main`.
+2. **Re-run `Data Quality Check`** (`gh workflow run "Data Quality Check"`
+   or wait for the scheduled cron). On its own this should not yet flip the
+   gate green — see step 3.
+3. **Run the backfill SQL** above against Cloud SQL once. Expected outcome:
+   `public_with_primary_category` jumps from 1641 toward ~1856, putting
+   `primary_category_coverage` ≥ 95% and turning the gate green.
+4. **Re-run `Data Quality Check`** to confirm the gate is green.
+5. **Decide whether `reporium-ingestion#67` is still required** for any
+   residual empty-fork population. The denominator-honesty note still
+   applies for that secondary gap, but it is a smaller and qualitatively
+   different problem than the column-vs-junction sync bug.
+
+## Anti-duplication boundary
+
+This lane only touches `reporium-api` ingest sync. It does not change the
+DQ threshold, does not modify the gate query, does not work on
+`reporium-ingestion#67`, does not reopen frontend/security/graph/perf/ADR
+work.

--- a/.audit/2026-04-26/dq-column-sync-note.md
+++ b/.audit/2026-04-26/dq-column-sync-note.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-04-26
 **Branch:** `claude/feature/KAN-DRAFT-dq-primary-category-sync`
-**PR:** _to be filled in after `gh pr create`_
+**PR:** https://github.com/perditioinc/reporium-api/pull/444
 
 ## Exact root cause
 

--- a/app/routers/ingest.py
+++ b/app/routers/ingest.py
@@ -354,8 +354,17 @@ async def _upsert_repo(db: AsyncSession, item: RepoIngestItem) -> Repo:
             db.add(RepoTag(repo_id=repo.id, tag=tag))
     if item.categories:
         await db.execute(RepoCategory.__table__.delete().where(RepoCategory.repo_id == repo.id))
+        primary_category_name: str | None = None
         for cat in item.categories:
             db.add(RepoCategory(repo_id=repo.id, **cat.model_dump()))
+            if cat.is_primary and primary_category_name is None:
+                primary_category_name = cat.category_name
+        # Keep repos.primary_category in sync with the junction.
+        # /metrics/data-quality reads this column directly to compute the
+        # primary_category_coverage gate; without this assignment the column
+        # silently drifts out of sync because no other ingest path maintains it
+        # (the original backfill_primary_category.py was a one-off migration).
+        repo.primary_category = primary_category_name
     if item.builders:
         await db.execute(RepoBuilder.__table__.delete().where(RepoBuilder.repo_id == repo.id))
         for builder in item.builders:

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -344,3 +344,85 @@ async def test_ingest_flows_tags_and_categories_into_repo_taxonomy(client: Async
     assert ("tag", "vector-db") in rows
     assert ("category", "AI Agents") in rows
     assert ("category", "Developer Tools") in rows
+
+
+@pytest.mark.asyncio
+async def test_ingest_keeps_primary_category_column_in_sync_with_junction(client: AsyncClient):
+    """Regression: repos.primary_category must stay in sync with the
+    repo_categories junction (is_primary=true row).
+
+    The /metrics/data-quality gate reads repos.primary_category IS NOT NULL.
+    Before this fix, _upsert_repo wrote the junction but never the column,
+    so repos with a correct primary in the junction silently failed the gate.
+    """
+    from sqlalchemy import text as _text
+    import app.database as db_module
+
+    # Initial ingest with a primary category
+    fixture = {
+        **TEST_REPO_FIXTURE,
+        "name": "primary-cat-sync-repo",
+        "github_url": "https://github.com/testuser/primary-cat-sync-repo",
+        "categories": [
+            {"category_id": "ai-agents", "category_name": "AI Agents", "is_primary": True},
+            {"category_id": "dev-tools", "category_name": "Developer Tools", "is_primary": False},
+        ],
+    }
+    response = await client.post("/ingest/repos", json=[fixture], headers=AUTH_HEADERS)
+    assert response.status_code == 200
+
+    async with db_module.async_session_factory() as session:
+        column = (
+            await session.execute(
+                _text("SELECT primary_category FROM repos WHERE name = :name"),
+                {"name": "primary-cat-sync-repo"},
+            )
+        ).scalar_one()
+        junction = (
+            await session.execute(
+                _text(
+                    "SELECT category_name FROM repo_categories rc "
+                    "JOIN repos r ON r.id = rc.repo_id "
+                    "WHERE r.name = :name AND rc.is_primary = true"
+                ),
+                {"name": "primary-cat-sync-repo"},
+            )
+        ).scalar_one()
+
+    assert column == "AI Agents", (
+        f"repos.primary_category column out of sync with junction: "
+        f"column={column!r}, junction={junction!r}"
+    )
+    assert column == junction
+
+    # Re-ingest with a different primary — column must follow the junction
+    updated_fixture = {
+        **fixture,
+        "categories": [
+            {"category_id": "ai-agents", "category_name": "AI Agents", "is_primary": False},
+            {"category_id": "dev-tools", "category_name": "Developer Tools", "is_primary": True},
+        ],
+    }
+    response = await client.post("/ingest/repos", json=[updated_fixture], headers=AUTH_HEADERS)
+    assert response.status_code == 200
+
+    async with db_module.async_session_factory() as session:
+        column = (
+            await session.execute(
+                _text("SELECT primary_category FROM repos WHERE name = :name"),
+                {"name": "primary-cat-sync-repo"},
+            )
+        ).scalar_one()
+        junction = (
+            await session.execute(
+                _text(
+                    "SELECT category_name FROM repo_categories rc "
+                    "JOIN repos r ON r.id = rc.repo_id "
+                    "WHERE r.name = :name AND rc.is_primary = true"
+                ),
+                {"name": "primary-cat-sync-repo"},
+            )
+        ).scalar_one()
+
+    assert column == "Developer Tools"
+    assert column == junction


### PR DESCRIPTION
## Root cause

`/metrics/data-quality` (`app/routers/platform.py`) computes the
`primary_category_coverage` gate from `repos.primary_category IS NOT NULL`:

```sql
SELECT COUNT(*) FROM repos
  WHERE is_private = false AND primary_category IS NOT NULL
```

But the canonical ingest path in `app/routers/ingest.py` (`_upsert_repo`)
only writes the `repo_categories` junction (with `is_primary=true`) — it
never updates the `repos.primary_category` column. The column was populated
once by `backfill_primary_category.py` (KAN-41) and has silently drifted
since.

This is the live cause of the red `Data Quality Check` on `main`
(run `24947192489`, 1641/1856 = 88.4% < 95% threshold). Many of the 215
"missing" repos already have a correct `is_primary=true` row in the junction
— the gate just can't see them. PR #442's `missing_primary_category_sample`
diagnostic surfaces these same repos.

## Fix

In `_upsert_repo`, when `item.categories` is non-empty, derive the primary
category name from the incoming payload's `is_primary` entries and assign
it to `repo.primary_category`. Lives inside the existing
`if item.categories:` skip-empty guard, so empty payloads still don't
clobber existing data (KAN-123 invariant preserved).

## Test

Adds `test_ingest_keeps_primary_category_column_in_sync_with_junction`
covering both:

- **Create path** — first ingest writes `column == junction.category_name`.
- **Update path** — re-ingest swapping which category is primary updates
  the column to follow the new junction.

## Expected effect on the DQ gate

- **Forward fix.** Every repo flowing through `POST /ingest/repos` after
  this merges will keep the column and junction synchronized.
- **Existing drift.** ~215 repos still have `is_primary=true` in the
  junction but `NULL` in the column. They self-heal on next ingest. If we
  want the gate green sooner, run this one-off SQL backfill against
  Cloud SQL after merge:

  ```sql
  UPDATE repos r
     SET primary_category = rc.category_name
    FROM repo_categories rc
   WHERE rc.repo_id = r.id
     AND rc.is_primary = true
     AND r.primary_category IS NULL;
  ```

  Idempotent — only writes where the column is currently NULL and a
  primary exists in the junction.

## Out of scope

- DQ threshold changes
- Taxonomy redesign
- `reporium-ingestion#67` (genuine empty-fork population is a separate gap)
- Frontend, security, graph, perf, ADR work

See `.audit/2026-04-26/dq-column-sync-note.md` for full investigation
notes and post-merge steps.

## Test plan

- [ ] CI green on `Test` workflow (`test_ingest_keeps_primary_category_column_in_sync_with_junction` runs against test Postgres)
- [ ] Merge to `main` and confirm Vercel/Cloud Run deploy succeeds
- [ ] Run the backfill SQL above against Cloud SQL once
- [ ] Re-run `Data Quality Check` workflow — `primary_category_coverage` should flip green

🤖 Generated with [Claude Code](https://claude.com/claude-code)