### PR TITLE
feat(admin): backfill primary_category column from junction (DQ gate followup)

### DIFF
--- a/.audit/2026-04-26/dq-primary-category-backfill-endpoint.md
+++ b/.audit/2026-04-26/dq-primary-category-backfill-endpoint.md
@@ -1,0 +1,119 @@
+# DQ primary_category column backfill — admin endpoint
+
+**Date:** 2026-04-26 (PDT evening / 2026-04-27 UTC)
+**Branch:** `claude/feature/KAN-DRAFT-dq-primary-category-backfill-endpoint`
+**Predecessor:** PR #444 (forward-fix in `_upsert_repo`, merged 2026-04-27T01:19:48Z, commit `619325e`)
+
+## Why this lane exists
+
+PR #444 keeps `repos.primary_category` in sync with the `repo_categories`
+junction **going forward** — every new ingest now writes both. But ~220
+public repos already have `is_primary=true` in the junction with `NULL` in
+the column (drift accumulated before the forward-fix). The forward-fix
+won't heal them until they are re-ingested, which the nightly enrichment
+will only do organically over time.
+
+The DQ Check rerun on `main` after #444 (run `24972119928`) confirmed the
+gate is still red:
+
+- `primary_category_coverage`: **1641 / 1861 = 88.18 %** (threshold 95 %)
+- Need **127 more rows with non-NULL column** to flip green.
+
+A live sample of the most-recent named-10 missing-primary repos showed a
+mixed gap shape:
+
+| Bucket | Count (of 10) | Examples |
+| --- | --- | --- |
+| Drift (junction has primary, column NULL) | 4 | hackingtool, Pixelle-Video, claude-context, skills___ |
+| Genuine empty (no junction entries at all) | 6 | build-your-own-x, DeepEP, ml-intern, osv-scanner, Open-Generative-AI, design.md |
+
+Backfill alone won't flip the gate green if the named-10 ratio holds —
+projected post-backfill coverage from sampled ratios is roughly 92–94 %
+depending on whether older drift is denser than recent. But it heals the
+**drift portion** of the gap idempotently, leaving only the genuine-empty
+population for `reporium-ingestion#67` to address.
+
+## Why an admin endpoint, not direct SQL
+
+The audit note in PR #444 said `gcloud sql connect` would do — but the
+Cloud SQL instance is **PRIVATE-IP only** (10.14.0.3) on the
+`projects/perditio-platform/global/networks/default` VPC. `gcloud sql
+connect` and `cloud-sql-proxy` from a developer machine cannot reach it
+without VPN or VPC peering, neither of which is configured for this
+environment.
+
+The cleanest in-VPC path is an admin endpoint on `reporium-api` itself,
+which already runs in the VPC with Cloud SQL Auth Proxy sidecar and a
+configured admin-key gate. Pattern matches the existing
+`/admin/backfill/categories` endpoint.
+
+## What this PR adds
+
+1. **`POST /admin/backfill/primary_category_column`**
+   in `app/routers/admin.py`
+   - Auth: `verify_api_key` + `require_admin_key` (same pattern as
+     `/admin/backfill/categories`).
+   - Rate limit: `5/minute` (one-shot operation, doesn't need higher).
+   - `?dry_run=true` returns the same before/after stats without writing.
+   - Idempotent UPDATE: writes only where `primary_category IS NULL` and a
+     `repo_categories` row with `is_primary=true` exists. Re-running is a
+     no-op once the drift is healed.
+   - Uses `DISTINCT ON (repo_id) ... ORDER BY repo_id, category_name` so
+     the chosen primary is deterministic when a junction has duplicate
+     `is_primary=true` rows (a separate latent bug — see "Side-finding"
+     below).
+   - Invalidates `library:full*` and `repos:list:*` caches after a write.
+   - Returns `{dry_run, updated, before: {...}, after: {...}}` with
+     `public_total / public_with_primary_category / drift_rows / coverage_pct`
+     in each before/after block so the caller can verify the effect on the
+     gate denominator without a follow-up workflow run.
+
+2. **`tests/test_backfill_primary_category_column.py`** — three tests:
+   - Auth gating (no API key → 403; API key without admin key → 401/403).
+   - Happy path: drift row gets healed, genuine-empty row stays NULL,
+     already-set row is unchanged. Second call is a no-op (idempotency).
+   - Dry-run: count returned, no writes performed.
+
+## Anti-duplication boundary
+
+This lane only adds a one-shot remediation endpoint. It does **not**:
+
+- modify the DQ gate query or threshold
+- change the gate denominator semantics (separately tracked in
+  `project_dq_gate_denominator_honesty.md`)
+- touch ingestion (`reporium-ingestion#67` covers genuine-empty forks)
+- reopen frontend / security / graph / perf / rendering ADR work
+- fix the duplicate `is_primary=true` junction bug (see below)
+
+## Side-finding: duplicate is_primary entries
+
+During the named-10 sampling, `perditioinc/hackingtool` was found to have
+**two** `repo_categories` rows with `is_primary=true`
+(`MLOps & Infrastructure` and `Edge & Mobile AI`). The junction lacks a
+uniqueness constraint enforcing a single primary per repo, and at least
+one ingest path is producing duplicate flags. This is independent of the
+column-vs-junction sync bug and is **out of scope** for this PR.
+
+The backfill UPDATE handles this safely (DISTINCT ON picks one
+deterministically) but the underlying junction integrity issue should be
+filed as a separate follow-up bug.
+
+## Operational plan after merge
+
+1. Wait for Deploy to Cloud Run to publish the new revision.
+2. Hit the endpoint with `?dry_run=true` first to verify the projected
+   numbers match expectations (drift_to_heal count, projected coverage).
+3. Hit it without `dry_run` to execute the backfill.
+4. Re-run `Data Quality Check` workflow against `main`.
+5. Decide based on residual gap:
+   - If gate green → DQ lane closes; `#67` drops priority.
+   - If gate still red but residual is mostly genuine-empty (no junction
+     entries) → promote `reporium-ingestion#67`.
+   - If gate still red from a different shape → open the smallest
+     ingestion follow-up for that residual.
+
+## Exact files changed
+
+- `app/routers/admin.py` — new endpoint after `backfill_categories`
+- `tests/test_backfill_primary_category_column.py` — new
+- `.audit/2026-04-26/dq-primary-category-backfill-endpoint.md` — this file

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -1093,6 +1093,84 @@ async def backfill_categories(
     return {"processed": processed, "assigned": assigned, "skipped": skipped}
 
 
+@router.post("/admin/backfill/primary_category_column", response_model=dict)
+@_limiter.limit("5/minute")
+async def backfill_primary_category_column(
+    request: Request,
+    dry_run: bool = Query(default=False),
+    db: AsyncSession = Depends(get_db),
+    _api_key: str = Depends(verify_api_key),
+    _admin_key: None = Depends(require_admin_key),
+):
+    """
+    Sync `repos.primary_category` from the `repo_categories` junction.
+
+    Only writes rows where `repos.primary_category IS NULL` AND a matching
+    `repo_categories` row with `is_primary = true` exists. Idempotent: rerun
+    is a no-op once drift is healed. Pairs with the forward-fix in PR #444
+    (`_upsert_repo` now keeps the column in sync going forward); this
+    endpoint heals the existing drift accumulated before that fix.
+
+    Returns before/after coverage stats and the row count updated.
+
+    Pass `?dry_run=true` to compute counts without writing.
+    """
+    coverage_sql = """
+        SELECT
+          COUNT(*) FILTER (WHERE is_private = false) AS public_total,
+          COUNT(*) FILTER (WHERE is_private = false AND primary_category IS NOT NULL) AS public_with_col,
+          (SELECT COUNT(DISTINCT r2.id) FROM repos r2
+             JOIN repo_categories rc2 ON rc2.repo_id = r2.id
+            WHERE r2.is_private = false
+              AND rc2.is_primary = true
+              AND r2.primary_category IS NULL) AS drift_to_heal
+        FROM repos
+    """
+    before = (await db.execute(text(coverage_sql))).one()
+
+    updated = 0
+    if not dry_run:
+        result = await db.execute(text("""
+            UPDATE repos r
+               SET primary_category = sub.category_name
+              FROM (
+                SELECT DISTINCT ON (repo_id) repo_id, category_name
+                  FROM repo_categories
+                 WHERE is_primary = true
+                 ORDER BY repo_id, category_name
+              ) sub
+             WHERE sub.repo_id = r.id
+               AND r.primary_category IS NULL
+        """))
+        updated = result.rowcount or 0
+        await db.commit()
+        await cache.invalidate("library:full*")
+        await cache.invalidate("repos:list:*")
+        invalidate_library_cache()
+
+    after = (await db.execute(text(coverage_sql))).one()
+
+    def _coverage_pct(with_col: int, total: int) -> float:
+        return round((with_col / total) * 100, 4) if total else 0.0
+
+    return {
+        "dry_run": dry_run,
+        "updated": updated,
+        "before": {
+            "public_total": int(before.public_total),
+            "public_with_primary_category": int(before.public_with_col),
+            "drift_rows": int(before.drift_to_heal),
+            "coverage_pct": _coverage_pct(before.public_with_col, before.public_total),
+        },
+        "after": {
+            "public_total": int(after.public_total),
+            "public_with_primary_category": int(after.public_with_col),
+            "drift_rows": int(after.drift_to_heal),
+            "coverage_pct": _coverage_pct(after.public_with_col, after.public_total),
+        },
+    }
+
+
 # ── Security signal models ──────────────────────────────────────────────────
 
 class SecuritySignalsPatch(BaseModel):

--- a/tests/test_backfill_primary_category_column.py
+++ b/tests/test_backfill_primary_category_column.py
@@ -1,0 +1,145 @@
+"""Tests for POST /admin/backfill/primary_category_column endpoint."""
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+
+import app.database as db_module
+from tests.conftest import AUTH_HEADERS, TEST_API_KEY
+
+
+@pytest.mark.asyncio
+async def test_backfill_primary_category_column_requires_api_key(client: AsyncClient):
+    resp = await client.post("/admin/backfill/primary_category_column")
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_backfill_primary_category_column_requires_admin_key(
+    client: AsyncClient, monkeypatch
+):
+    monkeypatch.setenv("ADMIN_API_KEY", "test-admin-key")
+    resp = await client.post(
+        "/admin/backfill/primary_category_column",
+        headers={"Authorization": f"Bearer {TEST_API_KEY}"},
+    )
+    assert resp.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_backfill_heals_drift_and_is_idempotent(client: AsyncClient):
+    """Repos with is_primary=true in junction but NULL column get healed.
+
+    Repos with no primary in the junction are left NULL.
+    A second call is a no-op (idempotency).
+    """
+    drift_id = str(uuid.uuid4())
+    empty_id = str(uuid.uuid4())
+    already_set_id = str(uuid.uuid4())
+
+    async with db_module.async_session_factory() as session:
+        for repo_id, name, primary in [
+            (drift_id, "drift-repo", None),
+            (empty_id, "empty-repo", None),
+            (already_set_id, "already-set-repo", "Foundation Models"),
+        ]:
+            await session.execute(text(
+                "INSERT INTO repos (id, name, owner, github_url, is_fork, is_private, primary_category) "
+                "VALUES (:id, :name, 'testuser', :url, false, false, :primary) "
+                "ON CONFLICT (name) DO UPDATE SET primary_category = EXCLUDED.primary_category"
+            ), {"id": repo_id, "name": name,
+                "url": f"https://github.com/testuser/{name}",
+                "primary": primary})
+        # drift_id has a junction primary; empty_id has nothing; already_set_id
+        # has a junction primary that matches its column.
+        await session.execute(text(
+            "DELETE FROM repo_categories WHERE repo_id = ANY(:ids)"
+        ), {"ids": [drift_id, already_set_id]})
+        for repo_id, cat_name in [
+            (drift_id, "AI Agents"),
+            (already_set_id, "Foundation Models"),
+        ]:
+            await session.execute(text(
+                "INSERT INTO repo_categories (repo_id, category_id, category_name, is_primary) "
+                "VALUES (:repo_id, :cat_id, :cat_name, true)"
+            ), {"repo_id": repo_id,
+                "cat_id": cat_name.lower().replace(" ", "-"),
+                "cat_name": cat_name})
+        await session.commit()
+
+    resp = await client.post(
+        "/admin/backfill/primary_category_column",
+        headers=AUTH_HEADERS,
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["dry_run"] is False
+    assert data["updated"] >= 1
+    assert data["before"]["drift_rows"] >= 1
+    assert data["after"]["drift_rows"] == 0
+    assert data["after"]["public_with_primary_category"] >= data["before"]["public_with_primary_category"]
+
+    async with db_module.async_session_factory() as session:
+        drift_col = (await session.execute(
+            text("SELECT primary_category FROM repos WHERE id = :id"),
+            {"id": drift_id},
+        )).scalar_one()
+        empty_col = (await session.execute(
+            text("SELECT primary_category FROM repos WHERE id = :id"),
+            {"id": empty_id},
+        )).scalar_one()
+        already_col = (await session.execute(
+            text("SELECT primary_category FROM repos WHERE id = :id"),
+            {"id": already_set_id},
+        )).scalar_one()
+
+    assert drift_col == "AI Agents"
+    assert empty_col is None
+    assert already_col == "Foundation Models"
+
+    resp2 = await client.post(
+        "/admin/backfill/primary_category_column",
+        headers=AUTH_HEADERS,
+    )
+    assert resp2.status_code == 200
+    assert resp2.json()["updated"] == 0
+    assert resp2.json()["after"]["drift_rows"] == 0
+
+
+@pytest.mark.asyncio
+async def test_backfill_dry_run_does_not_write(client: AsyncClient):
+    drift_id = str(uuid.uuid4())
+    async with db_module.async_session_factory() as session:
+        await session.execute(text(
+            "INSERT INTO repos (id, name, owner, github_url, is_fork, is_private, primary_category) "
+            "VALUES (:id, 'dry-run-drift-repo', 'testuser', :url, false, false, NULL) "
+            "ON CONFLICT (name) DO UPDATE SET primary_category = NULL"
+        ), {"id": drift_id, "url": "https://github.com/testuser/dry-run-drift-repo"})
+        await session.execute(text(
+            "DELETE FROM repo_categories WHERE repo_id = :id"
+        ), {"id": drift_id})
+        await session.execute(text(
+            "INSERT INTO repo_categories (repo_id, category_id, category_name, is_primary) "
+            "VALUES (:id, 'rag-retrieval', 'RAG & Retrieval', true)"
+        ), {"id": drift_id})
+        await session.commit()
+
+    resp = await client.post(
+        "/admin/backfill/primary_category_column?dry_run=true",
+        headers=AUTH_HEADERS,
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["dry_run"] is True
+    assert data["updated"] == 0
+    assert data["before"]["drift_rows"] >= 1
+    assert data["after"]["drift_rows"] == data["before"]["drift_rows"]
+
+    async with db_module.async_session_factory() as session:
+        col = (await session.execute(
+            text("SELECT primary_category FROM repos WHERE id = :id"),
+            {"id": drift_id},
+        )).scalar_one()
+    assert col is None

--- a/tests/test_backfill_primary_category_column.py
+++ b/tests/test_backfill_primary_category_column.py
@@ -10,6 +10,20 @@ import app.database as db_module
 from tests.conftest import AUTH_HEADERS, TEST_API_KEY
 
 
+async def _delete_repos(ids: list[str]) -> None:
+    """Tear down inserted repos and their junction rows."""
+    async with db_module.async_session_factory() as session:
+        await session.execute(
+            text("DELETE FROM repo_categories WHERE repo_id = ANY(:ids)"),
+            {"ids": ids},
+        )
+        await session.execute(
+            text("DELETE FROM repos WHERE id = ANY(:ids)"),
+            {"ids": ids},
+        )
+        await session.commit()
+
+
 @pytest.mark.asyncio
 async def test_backfill_primary_category_column_requires_api_key(client: AsyncClient):
     resp = await client.post("/admin/backfill/primary_category_column")
@@ -38,108 +52,111 @@ async def test_backfill_heals_drift_and_is_idempotent(client: AsyncClient):
     drift_id = str(uuid.uuid4())
     empty_id = str(uuid.uuid4())
     already_set_id = str(uuid.uuid4())
+    inserted_ids = [drift_id, empty_id, already_set_id]
 
-    async with db_module.async_session_factory() as session:
-        for repo_id, name, primary in [
-            (drift_id, "drift-repo", None),
-            (empty_id, "empty-repo", None),
-            (already_set_id, "already-set-repo", "Foundation Models"),
-        ]:
-            await session.execute(text(
-                "INSERT INTO repos (id, name, owner, github_url, is_fork, is_private, primary_category) "
-                "VALUES (:id, :name, 'testuser', :url, false, false, :primary) "
-                "ON CONFLICT (name) DO UPDATE SET primary_category = EXCLUDED.primary_category"
-            ), {"id": repo_id, "name": name,
-                "url": f"https://github.com/testuser/{name}",
-                "primary": primary})
-        # drift_id has a junction primary; empty_id has nothing; already_set_id
-        # has a junction primary that matches its column.
-        await session.execute(text(
-            "DELETE FROM repo_categories WHERE repo_id = ANY(:ids)"
-        ), {"ids": [drift_id, already_set_id]})
-        for repo_id, cat_name in [
-            (drift_id, "AI Agents"),
-            (already_set_id, "Foundation Models"),
-        ]:
-            await session.execute(text(
-                "INSERT INTO repo_categories (repo_id, category_id, category_name, is_primary) "
-                "VALUES (:repo_id, :cat_id, :cat_name, true)"
-            ), {"repo_id": repo_id,
-                "cat_id": cat_name.lower().replace(" ", "-"),
-                "cat_name": cat_name})
-        await session.commit()
+    try:
+        async with db_module.async_session_factory() as session:
+            for repo_id, name, primary in [
+                (drift_id, "pcc-drift-repo", None),
+                (empty_id, "pcc-empty-repo", None),
+                (already_set_id, "pcc-already-set-repo", "Foundation Models"),
+            ]:
+                await session.execute(text(
+                    "INSERT INTO repos (id, name, owner, github_url, is_fork, is_private, primary_category) "
+                    "VALUES (:id, :name, 'testuser', :url, false, false, :primary) "
+                    "ON CONFLICT (name) DO UPDATE SET primary_category = EXCLUDED.primary_category"
+                ), {"id": repo_id, "name": name,
+                    "url": f"https://github.com/testuser/{name}",
+                    "primary": primary})
+            for repo_id, cat_name in [
+                (drift_id, "AI Agents"),
+                (already_set_id, "Foundation Models"),
+            ]:
+                await session.execute(text(
+                    "INSERT INTO repo_categories (repo_id, category_id, category_name, is_primary) "
+                    "VALUES (:repo_id, :cat_id, :cat_name, true) "
+                    "ON CONFLICT (repo_id, category_id) DO UPDATE SET is_primary = true"
+                ), {"repo_id": repo_id,
+                    "cat_id": cat_name.lower().replace(" ", "-").replace("&", "and"),
+                    "cat_name": cat_name})
+            await session.commit()
 
-    resp = await client.post(
-        "/admin/backfill/primary_category_column",
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 200, resp.text
-    data = resp.json()
-    assert data["dry_run"] is False
-    assert data["updated"] >= 1
-    assert data["before"]["drift_rows"] >= 1
-    assert data["after"]["drift_rows"] == 0
-    assert data["after"]["public_with_primary_category"] >= data["before"]["public_with_primary_category"]
+        resp = await client.post(
+            "/admin/backfill/primary_category_column",
+            headers=AUTH_HEADERS,
+        )
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data["dry_run"] is False
+        assert data["updated"] >= 1
+        assert data["before"]["drift_rows"] >= 1
+        assert data["after"]["drift_rows"] == 0
+        assert data["after"]["public_with_primary_category"] >= data["before"]["public_with_primary_category"]
 
-    async with db_module.async_session_factory() as session:
-        drift_col = (await session.execute(
-            text("SELECT primary_category FROM repos WHERE id = :id"),
-            {"id": drift_id},
-        )).scalar_one()
-        empty_col = (await session.execute(
-            text("SELECT primary_category FROM repos WHERE id = :id"),
-            {"id": empty_id},
-        )).scalar_one()
-        already_col = (await session.execute(
-            text("SELECT primary_category FROM repos WHERE id = :id"),
-            {"id": already_set_id},
-        )).scalar_one()
+        async with db_module.async_session_factory() as session:
+            drift_col = (await session.execute(
+                text("SELECT primary_category FROM repos WHERE id = :id"),
+                {"id": drift_id},
+            )).scalar_one()
+            empty_col = (await session.execute(
+                text("SELECT primary_category FROM repos WHERE id = :id"),
+                {"id": empty_id},
+            )).scalar_one()
+            already_col = (await session.execute(
+                text("SELECT primary_category FROM repos WHERE id = :id"),
+                {"id": already_set_id},
+            )).scalar_one()
 
-    assert drift_col == "AI Agents"
-    assert empty_col is None
-    assert already_col == "Foundation Models"
+        assert drift_col == "AI Agents"
+        assert empty_col is None
+        assert already_col == "Foundation Models"
 
-    resp2 = await client.post(
-        "/admin/backfill/primary_category_column",
-        headers=AUTH_HEADERS,
-    )
-    assert resp2.status_code == 200
-    assert resp2.json()["updated"] == 0
-    assert resp2.json()["after"]["drift_rows"] == 0
+        resp2 = await client.post(
+            "/admin/backfill/primary_category_column",
+            headers=AUTH_HEADERS,
+        )
+        assert resp2.status_code == 200
+        assert resp2.json()["updated"] == 0
+        assert resp2.json()["after"]["drift_rows"] == 0
+    finally:
+        await _delete_repos(inserted_ids)
 
 
 @pytest.mark.asyncio
 async def test_backfill_dry_run_does_not_write(client: AsyncClient):
     drift_id = str(uuid.uuid4())
-    async with db_module.async_session_factory() as session:
-        await session.execute(text(
-            "INSERT INTO repos (id, name, owner, github_url, is_fork, is_private, primary_category) "
-            "VALUES (:id, 'dry-run-drift-repo', 'testuser', :url, false, false, NULL) "
-            "ON CONFLICT (name) DO UPDATE SET primary_category = NULL"
-        ), {"id": drift_id, "url": "https://github.com/testuser/dry-run-drift-repo"})
-        await session.execute(text(
-            "DELETE FROM repo_categories WHERE repo_id = :id"
-        ), {"id": drift_id})
-        await session.execute(text(
-            "INSERT INTO repo_categories (repo_id, category_id, category_name, is_primary) "
-            "VALUES (:id, 'rag-retrieval', 'RAG & Retrieval', true)"
-        ), {"id": drift_id})
-        await session.commit()
+    inserted_ids = [drift_id]
 
-    resp = await client.post(
-        "/admin/backfill/primary_category_column?dry_run=true",
-        headers=AUTH_HEADERS,
-    )
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["dry_run"] is True
-    assert data["updated"] == 0
-    assert data["before"]["drift_rows"] >= 1
-    assert data["after"]["drift_rows"] == data["before"]["drift_rows"]
+    try:
+        async with db_module.async_session_factory() as session:
+            await session.execute(text(
+                "INSERT INTO repos (id, name, owner, github_url, is_fork, is_private, primary_category) "
+                "VALUES (:id, 'pcc-dry-run-drift-repo', 'testuser', :url, false, false, NULL) "
+                "ON CONFLICT (name) DO UPDATE SET primary_category = NULL"
+            ), {"id": drift_id, "url": "https://github.com/testuser/pcc-dry-run-drift-repo"})
+            await session.execute(text(
+                "INSERT INTO repo_categories (repo_id, category_id, category_name, is_primary) "
+                "VALUES (:id, 'rag-retrieval', 'RAG & Retrieval', true) "
+                "ON CONFLICT (repo_id, category_id) DO UPDATE SET is_primary = true"
+            ), {"id": drift_id})
+            await session.commit()
 
-    async with db_module.async_session_factory() as session:
-        col = (await session.execute(
-            text("SELECT primary_category FROM repos WHERE id = :id"),
-            {"id": drift_id},
-        )).scalar_one()
-    assert col is None
+        resp = await client.post(
+            "/admin/backfill/primary_category_column?dry_run=true",
+            headers=AUTH_HEADERS,
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["dry_run"] is True
+        assert data["updated"] == 0
+        assert data["before"]["drift_rows"] >= 1
+        assert data["after"]["drift_rows"] == data["before"]["drift_rows"]
+
+        async with db_module.async_session_factory() as session:
+            col = (await session.execute(
+                text("SELECT primary_category FROM repos WHERE id = :id"),
+                {"id": drift_id},
+            )).scalar_one()
+        assert col is None
+    finally:
+        await _delete_repos(inserted_ids)


### PR DESCRIPTION
## Summary

- One-shot admin endpoint `POST /admin/backfill/primary_category_column` to heal the ~220 rows of `is_primary=true (junction) / NULL (column)` drift that PR #444's forward-fix doesn't self-heal.
- Idempotent UPDATE; supports `?dry_run=true`. Returns before/after `public_total / public_with_primary_category / drift_rows / coverage_pct`.
- `DISTINCT ON` makes the write deterministic against the duplicate-`is_primary` junction rows discovered in `perditioinc/hackingtool` during the named-10 sample (separate latent bug, flagged for a follow-up).
- Tests cover auth gating, healing + idempotency, dry-run no-write.

## Why an endpoint, not direct SQL

Cloud SQL `reporium-db` is **private-IP only** (`10.14.0.3` on the perditio-platform VPC). Direct `gcloud sql connect` / cloud-sql-proxy from a developer host cannot reach it without VPN/VPC peering — neither is configured. The in-VPC `reporium-api` runs with the Cloud SQL Auth Proxy sidecar and an admin-key gate, mirroring the existing `/admin/backfill/categories` pattern.

## Operational plan after merge

1. Wait for Deploy to Cloud Run.
2. Hit endpoint with `?dry_run=true` → verify projected drift_rows count.
3. Hit endpoint without dry_run → execute backfill.
4. Re-run **Data Quality Check** workflow.
5. Branch on residual: green ⇒ DQ lane closes / `#67` drops priority. Red with mostly genuine-empty repos ⇒ promote `reporium-ingestion#67`.

## Anti-duplication boundary

Does NOT modify the gate query, threshold, denominator semantics, ingestion path, frontend, security, graph, perf, or rendering ADR. Out of scope: duplicate-`is_primary` junction integrity bug.

## Test plan

- [x] Auth gating (403 without API key; 401/403 without admin key)
- [x] Drift row healed; genuine-empty stays NULL; already-set unchanged
- [x] Second call is no-op (idempotency)
- [x] `dry_run=true` reports counts without writing
- [ ] Post-deploy: dry-run reports drift_rows ≈ 220, coverage_pct ≈ 88.18
- [ ] Post-deploy: live run flips `public_with_primary_category` upward
- [ ] DQ Check rerun shows new coverage; decision on `#67` taken

🤖 Generated with [Claude Code](https://claude.com/claude-code)