### PR TITLE
fix(admin): invalidate repos:detail cache on primary_category backfill (mem 4931)

### DIFF
--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -1130,6 +1130,12 @@ async def backfill_primary_category_column(
 
     updated = 0
     if not dry_run:
+        # RETURNING r.name lets us know exactly which repos had their
+        # primary_category rewritten so we can targeted-invalidate the
+        # per-repo detail cache (key shape: `repos:detail:{name}`). Without
+        # this, /repos/{name} could keep serving the stale (NULL or old)
+        # primary_category for up to CACHE_TTL_REPO_DETAIL after a backfill
+        # run. See KAN-API-CACHE-INVALIDATE / mem 4931.
         result = await db.execute(text("""
             UPDATE repos r
                SET primary_category = sub.category_name
@@ -1141,11 +1147,18 @@ async def backfill_primary_category_column(
               ) sub
              WHERE sub.repo_id = r.id
                AND r.primary_category IS NULL
+            RETURNING r.name
         """))
-        updated = result.rowcount or 0
+        updated_names = [row[0] for row in result.fetchall()]
+        updated = len(updated_names)
         await db.commit()
         await cache.invalidate("library:full*")
         await cache.invalidate("repos:list:*")
+        # Per-row invalidation: bust each healed repo's detail cache so the
+        # next /repos/{name} read hits the DB and sees the new primary_category
+        # immediately, instead of waiting up to TTL for natural expiration.
+        for name in updated_names:
+            await cache.invalidate(f"repos:detail:{name}")
         invalidate_library_cache()
 
     after = (await db.execute(text(coverage_sql))).one()

--- a/tests/test_backfill_primary_category_column.py
+++ b/tests/test_backfill_primary_category_column.py
@@ -1,13 +1,47 @@
 """Tests for POST /admin/backfill/primary_category_column endpoint."""
 
 import uuid
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from httpx import AsyncClient
 from sqlalchemy import text
 
 import app.database as db_module
+from app.routers.admin import backfill_primary_category_column
 from tests.conftest import AUTH_HEADERS, TEST_API_KEY
+
+
+class _CoverageRow:
+    """Tuple-shaped row stand-in for the coverage_sql `.one()` call."""
+
+    def __init__(self, public_total: int, public_with_col: int, drift_to_heal: int):
+        self.public_total = public_total
+        self.public_with_col = public_with_col
+        self.drift_to_heal = drift_to_heal
+
+
+class _CoverageResult:
+    def __init__(self, row: _CoverageRow):
+        self._row = row
+
+    def one(self):
+        return self._row
+
+
+class _UpdateReturningResult:
+    """Stand-in for the UPDATE ... RETURNING name result.
+
+    The handler iterates `result.fetchall()` and reads `row[0]`, so each
+    row needs to be subscriptable. A 1-tuple matches both that shape and
+    the actual SQLAlchemy `Row` protocol used at runtime.
+    """
+
+    def __init__(self, names: list[str]):
+        self._names = names
+
+    def fetchall(self):
+        return [(name,) for name in self._names]
 
 
 async def _delete_repos(ids: list[str]) -> None:
@@ -160,3 +194,93 @@ async def test_backfill_dry_run_does_not_write(client: AsyncClient):
         assert col is None
     finally:
         await _delete_repos(inserted_ids)
+
+
+# ---------------------------------------------------------------------------
+# Unit test (no DB) — verifies cache invalidation contract per KAN-API-CACHE-INVALIDATE
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backfill_invalidates_repos_detail_cache_for_each_healed_row():
+    """Every row whose primary_category was healed should have its
+    `repos:detail:<name>` cache key invalidated.
+
+    Memory entry 4931 caught that the post-#445 backfill committed UPDATEs but
+    did not bust the per-repo detail cache, so /repos/{name} could keep
+    returning the stale (NULL or pre-rewrite) primary_category for up to
+    CACHE_TTL_REPO_DETAIL (1h) after a backfill. This unit test pins the
+    invalidation contract so a future refactor can't silently regress it.
+    """
+    healed_names = ["repo-alpha", "repo-beta", "repo-gamma"]
+
+    db = AsyncMock()
+    # The handler issues exactly 3 db.execute calls in the non-dry-run path:
+    #   1) coverage_sql BEFORE
+    #   2) UPDATE ... RETURNING name
+    #   3) coverage_sql AFTER
+    db.execute = AsyncMock(side_effect=[
+        _CoverageResult(_CoverageRow(public_total=100, public_with_col=80, drift_to_heal=3)),
+        _UpdateReturningResult(healed_names),
+        _CoverageResult(_CoverageRow(public_total=100, public_with_col=83, drift_to_heal=0)),
+    ])
+
+    with patch("app.routers.admin.cache.invalidate", new=AsyncMock()) as invalidate, \
+         patch("app.routers.admin.invalidate_library_cache") as invalidate_memory:
+        result = await backfill_primary_category_column(
+            request=None,  # @_limiter.limit decorator wraps but isn't exercised in unit call
+            dry_run=False,
+            db=db,
+            _api_key="test",
+            _admin_key=None,
+        )
+
+    # Sanity: handler reported the rows we said we healed.
+    assert result["dry_run"] is False
+    assert result["updated"] == 3
+    assert result["after"]["drift_rows"] == 0
+
+    # Commit happened.
+    db.commit.assert_awaited_once()
+
+    # The library/list bulk invalidations are still expected (existing contract).
+    bulk_calls = {call.args[0] for call in invalidate.await_args_list}
+    assert "library:full*" in bulk_calls
+    assert "repos:list:*" in bulk_calls
+
+    # Per-row invalidation: each healed repo's detail cache must be busted.
+    for name in healed_names:
+        assert f"repos:detail:{name}" in bulk_calls, (
+            f"expected `repos:detail:{name}` to be invalidated after backfill "
+            f"(KAN-API-CACHE-INVALIDATE / mem 4931). saw: {sorted(bulk_calls)}"
+        )
+
+    # In-memory library cache invalidation also still fires.
+    invalidate_memory.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_backfill_dry_run_does_not_invalidate_cache():
+    """Dry-run path must not touch the cache (no rows changed)."""
+    db = AsyncMock()
+    # In dry-run the handler issues 2 execute calls: BEFORE coverage + AFTER coverage.
+    db.execute = AsyncMock(side_effect=[
+        _CoverageResult(_CoverageRow(public_total=100, public_with_col=80, drift_to_heal=3)),
+        _CoverageResult(_CoverageRow(public_total=100, public_with_col=80, drift_to_heal=3)),
+    ])
+
+    with patch("app.routers.admin.cache.invalidate", new=AsyncMock()) as invalidate, \
+         patch("app.routers.admin.invalidate_library_cache") as invalidate_memory:
+        result = await backfill_primary_category_column(
+            request=None,
+            dry_run=True,
+            db=db,
+            _api_key="test",
+            _admin_key=None,
+        )
+
+    assert result["dry_run"] is True
+    assert result["updated"] == 0
+    db.commit.assert_not_awaited()
+    invalidate.assert_not_awaited()
+    invalidate_memory.assert_not_called()


### PR DESCRIPTION
## Summary
- KAN-API-CACHE-INVALIDATE: PR #445's `/admin/backfill/primary_category_column` updates rows in `repos.primary_category` but never invalidated the per-repo `repos:detail:{name}` cache.
- Result: after a backfill commit, `/repos/{name}` could keep serving the stale (NULL or pre-rewrite) `primary_category` for up to `CACHE_TTL_REPO_DETAIL` (1h) before natural TTL expiry.
- Memory entry 4931 (2026-04-26) flagged this; the backfill ran live at ~01:53 UTC 2026-04-27 and healed 4 rows whose detail cache was potentially stale until expiration.

## Fix shape
- **Per-row invalidation** (preferred over bulk wipe to avoid affecting unrelated cached entities).
- Switched the `UPDATE repos ... SET primary_category = ...` to `RETURNING r.name`.
- Iterate the returned names after `db.commit()` and call `cache.invalidate(f\"repos:detail:{name}\")` for each. The existing `library:full*` / `repos:list:*` / in-memory invalidations are unchanged.
- Dry-run path is untouched — no rows changed, no cache busted.

## Files changed
- `app/routers/admin.py` — handler now captures healed names and invalidates per-row detail cache.
- `tests/test_backfill_primary_category_column.py` — adds two unit tests:
  - `test_backfill_invalidates_repos_detail_cache_for_each_healed_row` (mocked DB; pins the contract that every healed name produces a `repos:detail:<name>` invalidate call).
  - `test_backfill_dry_run_does_not_invalidate_cache` (negative case).

## Test plan
- [x] `python -m pytest tests/test_backfill_primary_category_column.py -v` — 2 new tests pass; existing 4 DB-dependent tests skip cleanly without a live Postgres.
- [x] `python -m pytest tests/test_admin.py -v` — no regressions on the broader admin test surface.
- [ ] Operator: verify against live deploy after merge by hitting `/admin/backfill/primary_category_column?dry_run=true` (expect `updated == 0` since 2026-04-27 01:53 UTC run already healed the drift), then any `/repos/{name}` of an originally-healed repo to confirm the column-backed value is served.

## Links
- Memory: entry 4931 (`repos:detail` cache not invalidated by backfill).
- Predecessor: PR #445 ([commit `9067c3c`](https://github.com/perditioinc/reporium-api/commit/9067c3c)) — added the backfill endpoint without cache invalidation.
- Sibling: `project_dq_gate_column_vs_junction_bug.md` (the broader DQ closeout cycle this is the cache hygiene patch for).
- Constraint: this PR does NOT touch the backfill SQL semantics (only adds `RETURNING name`); the bug is invalidation-only.

## Out of scope (deferred)
- KAN-AUDIT-INVARIANT-CACHE — adds a cache-vs-DB consistency invariant to `reporium-audit` to catch future regressions of this shape at CI time.
- KAN-API-OBS-BACKFILL — observability for the backfill endpoint (correlation ID, duration, counters); will rebase against this PR.

**Do NOT merge** without operator review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)