### PR TITLE
docs(api): document X-App-Token auth contract in OpenAPI + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 Backend API for Reporium — the AI-native GitHub knowledge graph. Handles all data reads and writes, semantic search, 8-dimension dynamic taxonomy, portfolio intelligence, and a queryable MCP interface for Claude.
 
-Public reads. Protected writes (X-Ingest-Key). Admin operations (X-Admin-Key).
+Public reads. Protected writes (X-Ingest-Key). Admin operations (X-Admin-Key). LLM endpoints (X-App-Token).
 
 ---
 
@@ -48,6 +48,7 @@ uvicorn app.main:app --reload
 | `DATABASE_URL` | Yes | `postgresql+asyncpg://...` |
 | `ADMIN_API_KEY` | No | X-Admin-Key header for admin endpoints. Unset = open in dev. |
 | `INGEST_API_KEY` | No | X-Ingest-Key header for ingest endpoints. Unset = open in dev. |
+| `APP_API_TOKEN` | No | X-App-Token header for LLM endpoints. Unset = open in dev; logged at CRITICAL on prod startup if missing. |
 | `REDIS_URL` | No | Redis connection string — API works without it |
 | `GRAPH_SNAPSHOT_BUCKET` | No | GCS bucket for the published graph snapshot artifact |
 | `GRAPH_SNAPSHOT_OBJECT` | No | Object path for the graph snapshot artifact |
@@ -69,9 +70,45 @@ uvicorn app.main:app --reload
 | Header | Env Var | Applies To |
 |--------|---------|-----------|
 | `X-Ingest-Key` | `INGEST_API_KEY` | All `/ingest/*` routes |
-| `X-Admin-Key` | `ADMIN_API_KEY` | All `/admin/*` routes |
+| `X-Admin-Key` | `ADMIN_API_KEY` | All `/admin/*` routes (also `/metrics/*` when `METRICS_REQUIRE_AUTH=1`) |
+| `X-App-Token` | `APP_API_TOKEN` | LLM-backed endpoints: `/intelligence/ask`, `/intelligence/ask/stream`, `/intelligence/nl-filter`, `/intelligence/compare` |
 
-Both headers are optional when the env var is unset (dev-safe passthrough). In production, set both in Cloud Run environment variables or GCP Secret Manager.
+All three headers are optional when their env var is unset (dev-safe passthrough). In production, set them in Cloud Run environment variables or GCP Secret Manager.
+
+### `X-App-Token` (LLM endpoints)
+
+The `/api/intelligence/ask` family and other LLM-backed endpoints require the `X-App-Token` header — a shared secret protecting expensive Anthropic calls. Send it on every request:
+
+```bash
+curl https://api.reporium.com/intelligence/ask \
+  -H 'Content-Type: application/json' \
+  -H 'X-App-Token: <your-app-token>' \
+  -d '{"question": "What are the top RAG repos?"}'
+```
+
+**Note:** the token goes in the `X-App-Token` header — **not** `Authorization: Bearer`. Sending a Bearer token to `/intelligence/ask` will return HTTP 403.
+
+A request without the header (or with the wrong token) returns:
+
+```http
+HTTP/1.1 403 Forbidden
+Content-Type: application/json
+
+{"detail": "Missing X-App-Token header"}
+```
+
+Or, if a token was sent but doesn't match the configured `APP_API_TOKEN`:
+
+```http
+HTTP/1.1 403 Forbidden
+Content-Type: application/json
+
+{"detail": "Invalid X-App-Token header"}
+```
+
+The 403 response detail names the header explicitly so integrators can self-diagnose without reading the source. To obtain an app token in production, request one via the platform admin (it's stored in GCP Secret Manager under `APP_API_TOKEN`). For local development, leave `APP_API_TOKEN` unset — the auth dependency is a no-op outside production.
+
+The same scheme is registered in `/openapi.json` as `AppToken` so it's self-documenting in the Scalar docs at `/docs`.
 
 ---
 
@@ -92,7 +129,6 @@ Both headers are optional when the env var is unset (dev-safe passthrough). In p
 | `GET /trends` | Latest trend signals |
 | `GET /gaps` | Gap analysis — underrepresented taxonomy areas |
 | `GET /stats` | Library statistics |
-| `GET /intelligence/portfolio-insights` | Proactive signals: gaps, velocity leaders, stale repos, near-duplicates |
 | `GET /docs` | Scalar API docs (dark theme) |
 
 ### Ingest (X-Ingest-Key required)
@@ -104,6 +140,15 @@ Both headers are optional when the env var is unset (dev-safe passthrough). In p
 | `POST /ingest/gaps` | Update gap analysis |
 | `POST /ingest/log` | Update ingestion run log |
 | `POST /ingest/events/repo-ingested` | GCP Pub/Sub push handler — triggers taxonomy + intelligence refresh |
+
+### LLM endpoints (X-App-Token required)
+| Endpoint | Description |
+|----------|-------------|
+| `POST /intelligence/ask` | Natural-language Q&A over the knowledge graph (Anthropic-backed) |
+| `POST /intelligence/ask/stream` | Streaming variant of `/intelligence/ask` |
+| `POST /intelligence/nl-filter` | Translate natural-language queries into structured filter params |
+| `GET /intelligence/compare` | Side-by-side compare 2-5 repos with metrics + tags + HN mentions |
+| `GET /intelligence/portfolio-insights` | Curated portfolio dashboard feed |
 
 ### Admin (X-Admin-Key required)
 | Endpoint | Description |

--- a/app/auth.py
+++ b/app/auth.py
@@ -64,9 +64,29 @@ async def verify_api_key(
 
 # ---------------------------------------------------------------------------
 # Admin key - protects admin-only endpoints (POST /admin/*, /admin/taxonomy/*)
+#
+# NOTE on scheme_name (KAN-API-AUTH-DOC, 2026-04-27):
+# Each APIKeyHeader below sets `scheme_name` explicitly. Without it, FastAPI
+# uses the class name "APIKeyHeader" for every instance, so /openapi.json
+# collapses X-Admin-Key, X-Ingest-Key, and X-App-Token into a single
+# indistinguishable scheme. Integrators reading the spec then can't tell
+# which header to send for which endpoint — the reporium-evals Sprint 0/1
+# runner spent ~3 days silently failing because of exactly this ambiguity.
+# Distinct scheme_names + a `description` field give each header a unique,
+# self-documenting entry in /openapi.json and /docs (Scalar).
 # ---------------------------------------------------------------------------
 
-_ADMIN_KEY_HEADER = APIKeyHeader(name="X-Admin-Key", auto_error=False)
+_ADMIN_KEY_HEADER = APIKeyHeader(
+    name="X-Admin-Key",
+    auto_error=False,
+    scheme_name="AdminKey",
+    description=(
+        "Admin shared secret. Required on `/admin/*` and (when "
+        "`METRICS_REQUIRE_AUTH=1`) `/metrics/*` endpoints. Configure via the "
+        "`ADMIN_API_KEY` env var. Requests without a valid header are "
+        "rejected with HTTP 403."
+    ),
+)
 
 
 async def require_admin_key(
@@ -115,8 +135,28 @@ async def require_metrics_access(
 # Accept both X-Ingest-Key and the legacy X-Admin-Key for backward compatibility.
 # ---------------------------------------------------------------------------
 
-_INGEST_KEY_HEADER = APIKeyHeader(name="X-Ingest-Key", auto_error=False)
-_LEGACY_INGEST_KEY_HEADER = APIKeyHeader(name="X-Admin-Key", auto_error=False)
+_INGEST_KEY_HEADER = APIKeyHeader(
+    name="X-Ingest-Key",
+    auto_error=False,
+    scheme_name="IngestKey",
+    description=(
+        "Ingest pipeline shared secret. Required on `POST /ingest/*` "
+        "endpoints. Configure via the `INGEST_API_KEY` env var. The legacy "
+        "`X-Admin-Key` header is also accepted for backward compatibility "
+        "(see AdminKey scheme). Requests without a valid header are "
+        "rejected with HTTP 403."
+    ),
+)
+_LEGACY_INGEST_KEY_HEADER = APIKeyHeader(
+    name="X-Admin-Key",
+    auto_error=False,
+    scheme_name="LegacyIngestKey",
+    description=(
+        "Legacy admin-key header accepted on `POST /ingest/*` for backward "
+        "compatibility with pre-IngestKey clients. New integrations should "
+        "use `X-Ingest-Key` (IngestKey scheme) instead."
+    ),
+)
 
 
 async def require_ingest_key(
@@ -143,7 +183,21 @@ async def require_ingest_key(
 # App token - lightweight guard on expensive LLM endpoints
 # ---------------------------------------------------------------------------
 
-_APP_TOKEN_HEADER = APIKeyHeader(name="X-App-Token", auto_error=False)
+_APP_TOKEN_HEADER = APIKeyHeader(
+    name="X-App-Token",
+    auto_error=False,
+    scheme_name="AppToken",
+    description=(
+        "App-level shared secret protecting expensive LLM endpoints "
+        "(`/intelligence/ask`, `/intelligence/ask/stream`, "
+        "`/intelligence/nl-filter`, `/intelligence/compare`). Send the "
+        "token configured under the `APP_API_TOKEN` env var (or "
+        "`ASK_EVAL_APP_TOKEN` in eval contexts). Example: "
+        "`curl -H 'X-App-Token: <token>' ...`. Requests without a valid "
+        "header are rejected with HTTP 403 and the response detail names "
+        "the missing header explicitly so integrators can self-diagnose."
+    ),
+)
 
 
 async def require_app_token(
@@ -153,6 +207,13 @@ async def require_app_token(
     Lightweight app verification for expensive endpoints.
     The token is a simple shared secret set via APP_API_TOKEN env var.
     Not full auth - just prevents random scripts from hitting LLM endpoints.
+
+    On reject, the 403 detail names the X-App-Token header explicitly so
+    integrators reading the response immediately know which header is
+    missing. KAN-API-AUTH-DOC (2026-04-27): the previous "App token
+    required" wording was the smoking gun in the reporium-evals Sprint 0/1
+    runner outage where the integrator spent ~3 days unable to figure out
+    which header to send.
     """
     expected = os.getenv("APP_API_TOKEN", "")
     if not expected:
@@ -162,7 +223,15 @@ async def require_app_token(
         return  # Dev mode
     # Issue #237: timing-safe comparison.
     if not _secrets_equal(x_app_token, expected):
-        raise HTTPException(status_code=403, detail="App token required")
+        # Distinguish missing-header from wrong-token in the message so
+        # callers can self-diagnose without reading source. Status code
+        # remains 403 (unchanged behavior); only the human-readable detail
+        # is more diagnostic.
+        if not x_app_token:
+            detail = "Missing X-App-Token header"
+        else:
+            detail = "Invalid X-App-Token header"
+        raise HTTPException(status_code=403, detail=detail)
 
 
 def hash_app_token(token: str | None) -> str | None:

--- a/tests/test_app_token_auth.py
+++ b/tests/test_app_token_auth.py
@@ -1,0 +1,270 @@
+"""
+Tests for the X-App-Token contract on LLM endpoints (KAN-API-AUTH-DOC).
+
+Background: the reporium-evals Sprint 0/1 runner spent ~3 days silently
+failing because the X-App-Token contract was undocumented and the 403
+detail ("App token required") didn't name the missing header. These tests
+lock in the diagnostic message so future integrators can self-diagnose
+straight from the response body.
+
+Covers:
+  * `app.auth.require_app_token` dependency unit-level (missing header,
+    wrong token, dev-mode passthrough, correct token).
+  * The diagnostic 403 detail names "X-App-Token" verbatim — locking in
+    the contract so a future "clean up" rewrite can't silently regress
+    the message.
+  * End-to-end via /intelligence/nl-filter (the simplest X-App-Token
+    endpoint, no DB coupling).
+  * /openapi.json registers a distinct `AppToken` security scheme
+    referencing the `X-App-Token` header so the contract is visible to
+    any spec-driven client.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi import HTTPException
+
+from app.auth import require_app_token
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — require_app_token dependency
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_require_app_token_dev_passthrough_when_unset(monkeypatch):
+    """When APP_API_TOKEN is unset and ENVIRONMENT != production, accept any
+    request (dev-safe passthrough). This matches pre-existing behavior so
+    the local dev story stays unchanged."""
+    monkeypatch.delenv("APP_API_TOKEN", raising=False)
+    monkeypatch.setenv("ENVIRONMENT", "test")
+    # No header — must be a no-op (no exception).
+    assert await require_app_token(x_app_token=None) is None
+
+
+@pytest.mark.asyncio
+async def test_require_app_token_403_when_header_missing(monkeypatch):
+    """Missing header (None) returns 403 with a message that NAMES the
+    X-App-Token header verbatim. This is the single most useful
+    diagnostic for an integrator hitting /ask for the first time."""
+    monkeypatch.setenv("APP_API_TOKEN", "secret-token-value")
+    with pytest.raises(HTTPException) as exc_info:
+        await require_app_token(x_app_token=None)
+    assert exc_info.value.status_code == 403
+    # Lock in the exact message — this is the contract the README + the
+    # OpenAPI scheme description promise to integrators.
+    assert exc_info.value.detail == "Missing X-App-Token header"
+
+
+@pytest.mark.asyncio
+async def test_require_app_token_403_when_header_empty_string(monkeypatch):
+    """Empty-string header (header sent but no value) is treated the same
+    as a missing header — the message must still name the header."""
+    monkeypatch.setenv("APP_API_TOKEN", "secret-token-value")
+    with pytest.raises(HTTPException) as exc_info:
+        await require_app_token(x_app_token="")
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "Missing X-App-Token header"
+
+
+@pytest.mark.asyncio
+async def test_require_app_token_403_with_invalid_token(monkeypatch):
+    """A non-empty but wrong token returns a different 403 detail so
+    integrators can distinguish 'forgot the header' from 'header sent
+    but wrong value'."""
+    monkeypatch.setenv("APP_API_TOKEN", "secret-token-value")
+    with pytest.raises(HTTPException) as exc_info:
+        await require_app_token(x_app_token="not-the-right-token")
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == "Invalid X-App-Token header"
+
+
+@pytest.mark.asyncio
+async def test_require_app_token_passes_with_correct_token(monkeypatch):
+    """The correct token is accepted (timing-safe compare under the hood,
+    covered separately in test_security_hardening_2026_04.py)."""
+    monkeypatch.setenv("APP_API_TOKEN", "secret-token-value")
+    # Must not raise and must return None.
+    assert await require_app_token(x_app_token="secret-token-value") is None
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — /intelligence/nl-filter end-to-end
+#
+# nl-filter is the cleanest X-App-Token route: no DB coupling, no
+# Anthropic call when the body fails validation. We use a query that
+# passes validation (3-300 chars) and assert on the auth layer alone by
+# patching the LLM call so we don't actually hit Anthropic in CI.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_nl_filter_403_without_header(client, monkeypatch):
+    """End-to-end: a request without X-App-Token gets a 403 with the
+    diagnostic detail. This is the response shape an integrator sees on
+    their first failed call, and the message must name the header."""
+    monkeypatch.setenv("APP_API_TOKEN", "secret-token-value")
+    resp = await client.post(
+        "/intelligence/nl-filter",
+        json={"query": "Python RAG repos with 1000+ stars"},
+    )
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body == {"detail": "Missing X-App-Token header"}
+
+
+@pytest.mark.asyncio
+async def test_nl_filter_403_with_wrong_header(client, monkeypatch):
+    """End-to-end: a wrong token returns the 'Invalid' variant of the
+    detail so callers can distinguish missing vs. wrong."""
+    monkeypatch.setenv("APP_API_TOKEN", "secret-token-value")
+    resp = await client.post(
+        "/intelligence/nl-filter",
+        json={"query": "Python RAG repos with 1000+ stars"},
+        headers={"X-App-Token": "wrong-token"},
+    )
+    assert resp.status_code == 403
+    body = resp.json()
+    assert body == {"detail": "Invalid X-App-Token header"}
+
+
+@pytest.mark.asyncio
+async def test_nl_filter_passes_auth_with_correct_header(client, monkeypatch):
+    """End-to-end: a request with the correct X-App-Token clears the auth
+    layer. We don't assert on the body (the route does its own LLM call)
+    — only that we didn't get the 403 the other tests assert on. A 200
+    or any other downstream status proves auth passed."""
+    import json
+    from unittest.mock import MagicMock, patch
+
+    monkeypatch.setenv("APP_API_TOKEN", "secret-token-value")
+
+    # Mock Haiku so we don't hit Anthropic in CI; auth runs before this.
+    parsed = {
+        "language": "python",
+        "category": "rag-retrieval",
+        "min_stars": 1000,
+        "max_stars": None,
+        "sort": "stars",
+        "tags": ["rag"],
+        "quality": None,
+        "maturity": None,
+        "exclude_archived": False,
+        "interpretation": "Python · RAG · 1,000+ stars",
+    }
+    fake_msg = MagicMock()
+    fake_msg.content = [MagicMock(text=json.dumps(parsed))]
+    fake_msg.usage = MagicMock(input_tokens=100, output_tokens=50)
+    breaker_mock = MagicMock(call=lambda fn: fn())
+
+    with (
+        patch("app.routers.nl_filter._get_client") as MockClient,
+        patch("app.routers.nl_filter.anthropic_breaker", breaker_mock),
+        patch("app.routers.nl_filter.cache.get", return_value=None),
+        patch("app.routers.nl_filter.cache.set"),
+    ):
+        MockClient.return_value.messages.create.return_value = fake_msg
+        resp = await client.post(
+            "/intelligence/nl-filter",
+            json={"query": "Python RAG repos with 1000+ stars"},
+            headers={"X-App-Token": "secret-token-value"},
+        )
+
+    # The contract this test enforces: with the correct header, we get
+    # past auth — i.e. NOT a 403. The downstream behavior is covered in
+    # test_nl_filter.py.
+    assert resp.status_code != 403, (
+        f"Expected auth to pass with correct X-App-Token; got 403: {resp.text}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# OpenAPI contract — /openapi.json self-documents the X-App-Token header
+#
+# This is the surface a spec-driven integrator (or codegen tool) reads
+# first. If FastAPI ever stops generating a distinct security scheme for
+# X-App-Token, this test fails loudly so the regression doesn't ship.
+# ---------------------------------------------------------------------------
+
+
+def test_openapi_registers_app_token_scheme():
+    """OpenAPI introspection — does NOT use the `client` fixture so this
+    runs without a test database. Reads `app.openapi()` directly."""
+    from app.main import app as _app
+
+    spec = _app.openapi()
+    schemes = spec.get("components", {}).get("securitySchemes", {})
+
+    # AppToken scheme is registered with a distinct name (not the FastAPI
+    # default class-name "APIKeyHeader") AND points at the X-App-Token
+    # header explicitly. Without a distinct scheme_name, AppToken would
+    # collapse into AdminKey/IngestKey under a single 'APIKeyHeader' key
+    # — exactly the OpenAPI ambiguity the reporium-evals runner hit.
+    assert "AppToken" in schemes, (
+        f"AppToken security scheme missing; only got: {list(schemes.keys())}"
+    )
+    app_token_scheme = schemes["AppToken"]
+    assert app_token_scheme["type"] == "apiKey"
+    assert app_token_scheme["in"] == "header"
+    assert app_token_scheme["name"] == "X-App-Token"
+    # The description must mention the header name so anyone reading the
+    # OpenAPI spec (Scalar UI, codegen, swagger viewer) sees it.
+    assert "X-App-Token" in app_token_scheme.get("description", "")
+
+
+def test_openapi_protected_routes_reference_app_token():
+    """The four LLM endpoints documented in the README all reference the
+    AppToken scheme in their `security` block. Asserting this catches a
+    decorator-removal regression (e.g. someone deleting Depends(require_app_token))."""
+    from app.main import app as _app
+
+    spec = _app.openapi()
+    paths = spec["paths"]
+
+    expected = {
+        "/intelligence/ask": "post",
+        "/intelligence/ask/stream": "post",
+        "/intelligence/nl-filter": "post",
+        "/intelligence/compare": "get",
+    }
+    for path, method in expected.items():
+        op = paths.get(path, {}).get(method)
+        assert op is not None, f"Route {method.upper()} {path} missing from OpenAPI"
+        security = op.get("security", [])
+        scheme_names = [list(s.keys())[0] for s in security if s]
+        assert "AppToken" in scheme_names, (
+            f"Route {method.upper()} {path} does not require AppToken; "
+            f"security block: {security}"
+        )
+
+
+def test_openapi_admin_routes_use_distinct_scheme_from_app_token():
+    """Regression guard against the ambiguity that motivated this ticket:
+    /admin/* and /ingest/* must not be tagged AppToken (and vice versa).
+    Distinct scheme_names per APIKeyHeader keep the spec self-documenting."""
+    from app.main import app as _app
+
+    spec = _app.openapi()
+    paths = spec["paths"]
+
+    # Sample admin/ingest routes — these should require AdminKey or
+    # IngestKey, NOT AppToken.
+    cases = [
+        ("/admin/data-quality", "get", "AdminKey"),
+        ("/ingest/repos", "post", "IngestKey"),
+    ]
+    for path, method, expected_scheme in cases:
+        op = paths.get(path, {}).get(method)
+        if op is None:
+            continue  # tolerate route renames; the AppToken assertions above are the real lock
+        security = op.get("security", [])
+        scheme_names = [list(s.keys())[0] for s in security if s]
+        assert expected_scheme in scheme_names, (
+            f"Route {method.upper()} {path} expected {expected_scheme}; "
+            f"got: {scheme_names}"
+        )
+        assert "AppToken" not in scheme_names, (
+            f"Route {method.upper()} {path} unexpectedly tagged AppToken; "
+            f"security block: {security}"
+        )


### PR DESCRIPTION
## Summary

- The `X-App-Token` auth contract on `/intelligence/ask` (and the rest of the LLM family) was undocumented anywhere consumable. The reporium-evals Sprint 0/1 runner spent ~3 days silently failing because of this — see KAN-EVAL-VERIFY F1 finding (reporium-evals#2). Anyone else integrating with the API would hit the same wall.
- This PR makes the contract visible in **three** surfaces: OpenAPI metadata, README, and the 403 response message itself. Behavior is unchanged — only docs, OpenAPI scheme metadata, and the human-readable 403 detail.

## What changed

**`app/auth.py`** — each `APIKeyHeader` now sets a distinct `scheme_name` + `description`:

- Without explicit `scheme_name`, FastAPI uses the class name `APIKeyHeader` for every instance, so `/openapi.json` collapses `X-Admin-Key`, `X-Ingest-Key`, and `X-App-Token` into one indistinguishable scheme. That's the exact ambiguity the eval runner hit.
- After this change, the four LLM routes (`/intelligence/ask`, `/intelligence/ask/stream`, `/intelligence/nl-filter`, `/intelligence/compare`) reference a dedicated `AppToken` scheme that documents the header name, env var, and includes a curl example.
- `require_app_token` now returns `{"detail": "Missing X-App-Token header"}` (header absent) or `{"detail": "Invalid X-App-Token header"}` (header sent but wrong value) instead of the previous "App token required". Status code remains 403 — diagnostic-message fix only, no behavior change.

**`README.md`**:

- Adds an `APP_API_TOKEN` row to the env vars table.
- Adds an X-App-Token row to the Auth table.
- Adds a "X-App-Token (LLM endpoints)" subsection with a curl example, explicit "not `Authorization: Bearer`" warning, and the exact 403 response shapes integrators will see.
- Adds a new "LLM endpoints (X-App-Token required)" table to the Endpoints listing.

**`tests/test_app_token_auth.py`** (new, 11 tests):

- 5 unit tests on `require_app_token` lock in the diagnostic message + dev-mode passthrough.
- 3 OpenAPI introspection tests assert AppToken scheme is registered, the four LLM routes reference it, and admin/ingest routes do NOT conflate with it (regression guard against future `scheme_name` removal).
- 3 integration tests against `/intelligence/nl-filter` exercise end-to-end 403 + happy path (skipped without a test DB; run in CI).

## OpenAPI before/after

Before — `/openapi.json` collapses all three header schemes into one and `/intelligence/ask` shows the same `APIKeyHeader` reference as admin endpoints:

```json
"securitySchemes": {
  "APIKeyHeader": {"type":"apiKey","in":"header","name":"X-Admin-Key"},
  "HTTPBearer":   {"type":"http","scheme":"bearer"}
}
"/intelligence/ask": { "post": { "security": [{"APIKeyHeader": []}] } }
```

After:

```json
"securitySchemes": {
  "AdminKey":        {"type":"apiKey","in":"header","name":"X-Admin-Key", "description":"..."},
  "IngestKey":       {"type":"apiKey","in":"header","name":"X-Ingest-Key","description":"..."},
  "LegacyIngestKey": {"type":"apiKey","in":"header","name":"X-Admin-Key", "description":"..."},
  "AppToken":        {"type":"apiKey","in":"header","name":"X-App-Token","description":"App-level shared secret protecting expensive LLM endpoints (`/intelligence/ask`, ...). Send the token configured under the `APP_API_TOKEN` env var. Example: `curl -H 'X-App-Token: <token>' ...`. Requests without a valid header are rejected with HTTP 403 and the response detail names the missing header explicitly so integrators can self-diagnose."},
  "HTTPBearer":      {"type":"http","scheme":"bearer"}
}
"/intelligence/ask": { "post": { "security": [{"AppToken": []}] } }
```

## Test plan

- [x] `pytest tests/test_app_token_auth.py -v` — 8 passed locally (5 unit + 3 OpenAPI introspection); 3 DB-dependent integration tests skipped locally, will run in CI.
- [x] `pytest tests/` (full suite, no DB locally) — 583 passed, 249 skipped, 0 failed. No regressions.
- [ ] CI: full suite passes including the 3 DB-dependent integration tests on `/intelligence/nl-filter`.
- [ ] Manual: `curl http://localhost:8000/openapi.json | jq '.components.securitySchemes'` shows distinct AppToken / AdminKey / IngestKey entries with descriptions.
- [ ] Manual: hit `/intelligence/nl-filter` without `X-App-Token` against a server with `APP_API_TOKEN` set → expect `403 {"detail": "Missing X-App-Token header"}`.

## References

- KAN-API-AUTH-DOC (parallel-tasks board, 2026-04-27, section D)
- KAN-EVAL-VERIFY F1 finding (`reporium-evals#2`) — root cause: undocumented `X-App-Token` contract
- Memory entry: `.audit/2026-04-27/parallel-tasks-board.md` (orchestrator dispatch board)

🤖 Generated with [Claude Code](https://claude.com/claude-code)