### PR TITLE
feat(obs): observability for /admin/backfill/primary_category_column endpoint

### DIFF
--- a/app/prometheus_metrics.py
+++ b/app/prometheus_metrics.py
@@ -20,6 +20,20 @@ try:
         buckets=(0.01, 0.025, 0.05, 0.1, 0.2, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0),
     )
 
+    # Observability for the operator-runbook backfill endpoint
+    # (POST /admin/backfill/primary_category_column). See KAN-API-OBS-BACKFILL.
+    ADMIN_BACKFILL_RUNS_TOTAL = Counter(
+        "admin_backfill_runs_total",
+        "Total invocations of /admin/backfill/primary_category_column by terminal outcome.",
+        ("outcome",),
+    )
+
+    ADMIN_BACKFILL_DURATION_SECONDS = Histogram(
+        "admin_backfill_duration_seconds",
+        "End-to-end duration of /admin/backfill/primary_category_column in seconds.",
+        buckets=(0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0),
+    )
+
     def _render_latest() -> bytes:
         return generate_latest()
 
@@ -45,8 +59,17 @@ except ModuleNotFoundError:
         def labels(self, **labels: str) -> _MetricHandle:
             return _MetricHandle(self.values, labels)
 
+        def inc(self, amount: float = 1.0) -> None:
+            # Unlabeled increment falls back to a single bucket keyed by ().
+            self.values[tuple()] += amount
+
+        def observe(self, amount: float) -> None:
+            self.values[tuple()] += amount
+
     HTTP_REQUESTS_TOTAL = _FallbackMetric("reporium_http_requests_total")
     HTTP_REQUEST_DURATION_SECONDS = _FallbackMetric("reporium_http_request_duration_seconds")
+    ADMIN_BACKFILL_RUNS_TOTAL = _FallbackMetric("admin_backfill_runs_total")
+    ADMIN_BACKFILL_DURATION_SECONDS = _FallbackMetric("admin_backfill_duration_seconds")
 
     def _render_lines(metric: _FallbackMetric) -> list[str]:
         lines = [
@@ -61,6 +84,8 @@ except ModuleNotFoundError:
     def _render_latest() -> bytes:
         lines = _render_lines(HTTP_REQUESTS_TOTAL)
         lines.extend(_render_lines(HTTP_REQUEST_DURATION_SECONDS))
+        lines.extend(_render_lines(ADMIN_BACKFILL_RUNS_TOTAL))
+        lines.extend(_render_lines(ADMIN_BACKFILL_DURATION_SECONDS))
         lines.append("")
         return "\n".join(lines).encode("utf-8")
 

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -2,11 +2,14 @@ import asyncio
 import json
 import logging
 import os
+import time
+import uuid
 from dataclasses import dataclass, field as dc_field
 from datetime import date, datetime
 from typing import Optional
 
 import httpx
+import sentry_sdk
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel
 from slowapi import Limiter
@@ -19,6 +22,10 @@ from app.models.query_log import QueryLog
 from app.cache import cache
 from app.database import get_db
 from app.models.repo import IngestRun, Repo, RepoCategory, RepoEmbedding, RepoTag
+from app.prometheus_metrics import (
+    ADMIN_BACKFILL_DURATION_SECONDS,
+    ADMIN_BACKFILL_RUNS_TOTAL,
+)
 from app.rate_limit import rate_limit_storage
 from app.routers.library_full import invalidate_library_cache
 
@@ -1114,7 +1121,38 @@ async def backfill_primary_category_column(
     Returns before/after coverage stats and the row count updated.
 
     Pass `?dry_run=true` to compute counts without writing.
+
+    Observability (KAN-API-OBS-BACKFILL): emits structured `backfill.start`
+    and `backfill.end` log lines tagged with a correlation ID (taken from the
+    `X-Correlation-ID` header if present, else a freshly generated UUID4).
+    Increments the `admin_backfill_runs_total{outcome=...}` Prometheus
+    counter and observes the `admin_backfill_duration_seconds` histogram on
+    each terminal outcome. The correlation ID is also set as a Sentry tag so
+    transactions can be cross-linked to log lines.
     """
+    correlation_id = (
+        request.headers.get("X-Correlation-ID")
+        or request.headers.get("x-correlation-id")
+        or str(uuid.uuid4())
+    )
+    sentry_sdk.set_tag("correlation_id", correlation_id)
+    sentry_sdk.set_tag("admin_endpoint", "backfill_primary_category_column")
+
+    user_agent = request.headers.get("user-agent")
+
+    logger.info(
+        "backfill.start correlation_id=%s dry_run=%s user_agent=%s",
+        correlation_id,
+        dry_run,
+        user_agent,
+        extra={
+            "event": "backfill.start",
+            "correlation_id": correlation_id,
+            "dry_run": dry_run,
+            "request_user_agent": user_agent,
+        },
+    )
+
     coverage_sql = """
         SELECT
           COUNT(*) FILTER (WHERE is_private = false) AS public_total,
@@ -1126,62 +1164,112 @@ async def backfill_primary_category_column(
               AND r2.primary_category IS NULL) AS drift_to_heal
         FROM repos
     """
-    before = (await db.execute(text(coverage_sql))).one()
 
-    updated = 0
-    if not dry_run:
-        # RETURNING r.name lets us know exactly which repos had their
-        # primary_category rewritten so we can targeted-invalidate the
-        # per-repo detail cache (key shape: `repos:detail:{name}`). Without
-        # this, /repos/{name} could keep serving the stale (NULL or old)
-        # primary_category for up to CACHE_TTL_REPO_DETAIL after a backfill
-        # run. See KAN-API-CACHE-INVALIDATE / mem 4931.
-        result = await db.execute(text("""
-            UPDATE repos r
-               SET primary_category = sub.category_name
-              FROM (
-                SELECT DISTINCT ON (repo_id) repo_id, category_name
-                  FROM repo_categories
-                 WHERE is_primary = true
-                 ORDER BY repo_id, category_name
-              ) sub
-             WHERE sub.repo_id = r.id
-               AND r.primary_category IS NULL
-            RETURNING r.name
-        """))
-        updated_names = [row[0] for row in result.fetchall()]
-        updated = len(updated_names)
-        await db.commit()
-        await cache.invalidate("library:full*")
-        await cache.invalidate("repos:list:*")
-        # Per-row invalidation: bust each healed repo's detail cache so the
-        # next /repos/{name} read hits the DB and sees the new primary_category
-        # immediately, instead of waiting up to TTL for natural expiration.
-        for name in updated_names:
-            await cache.invalidate(f"repos:detail:{name}")
-        invalidate_library_cache()
+    started = time.perf_counter()
+    rows_scanned = 0
+    rows_updated = 0
+    outcome = "error"
+    try:
+        before = (await db.execute(text(coverage_sql))).one()
+        rows_scanned = int(before.public_total or 0)
 
-    after = (await db.execute(text(coverage_sql))).one()
+        if not dry_run:
+            # RETURNING r.name lets us know exactly which repos had their
+            # primary_category rewritten so we can targeted-invalidate the
+            # per-repo detail cache (key shape: `repos:detail:{name}`). Without
+            # this, /repos/{name} could keep serving the stale (NULL or old)
+            # primary_category for up to CACHE_TTL_REPO_DETAIL after a backfill
+            # run. See KAN-API-CACHE-INVALIDATE / mem 4931.
+            result = await db.execute(text("""
+                UPDATE repos r
+                   SET primary_category = sub.category_name
+                  FROM (
+                    SELECT DISTINCT ON (repo_id) repo_id, category_name
+                      FROM repo_categories
+                     WHERE is_primary = true
+                     ORDER BY repo_id, category_name
+                  ) sub
+                 WHERE sub.repo_id = r.id
+                   AND r.primary_category IS NULL
+                RETURNING r.name
+            """))
+            updated_names = [row[0] for row in result.fetchall()]
+            rows_updated = len(updated_names)
+            await db.commit()
+            await cache.invalidate("library:full*")
+            await cache.invalidate("repos:list:*")
+            # Per-row invalidation: bust each healed repo's detail cache so the
+            # next /repos/{name} read hits the DB and sees the new primary_category
+            # immediately, instead of waiting up to TTL for natural expiration.
+            for name in updated_names:
+                await cache.invalidate(f"repos:detail:{name}")
+            invalidate_library_cache()
 
-    def _coverage_pct(with_col: int, total: int) -> float:
-        return round((with_col / total) * 100, 4) if total else 0.0
+        after = (await db.execute(text(coverage_sql))).one()
 
-    return {
-        "dry_run": dry_run,
-        "updated": updated,
-        "before": {
-            "public_total": int(before.public_total),
-            "public_with_primary_category": int(before.public_with_col),
-            "drift_rows": int(before.drift_to_heal),
-            "coverage_pct": _coverage_pct(before.public_with_col, before.public_total),
-        },
-        "after": {
-            "public_total": int(after.public_total),
-            "public_with_primary_category": int(after.public_with_col),
-            "drift_rows": int(after.drift_to_heal),
-            "coverage_pct": _coverage_pct(after.public_with_col, after.public_total),
-        },
-    }
+        def _coverage_pct(with_col: int, total: int) -> float:
+            return round((with_col / total) * 100, 4) if total else 0.0
+
+        outcome = "success"
+        duration_ms = round((time.perf_counter() - started) * 1000, 3)
+        logger.info(
+            "backfill.end correlation_id=%s outcome=%s rows_scanned=%d rows_updated=%d duration_ms=%.3f",
+            correlation_id,
+            outcome,
+            rows_scanned,
+            rows_updated,
+            duration_ms,
+            extra={
+                "event": "backfill.end",
+                "correlation_id": correlation_id,
+                "outcome": outcome,
+                "rows_scanned": rows_scanned,
+                "rows_updated": rows_updated,
+                "duration_ms": duration_ms,
+            },
+        )
+        return {
+            "correlation_id": correlation_id,
+            "dry_run": dry_run,
+            "updated": rows_updated,
+            "duration_ms": duration_ms,
+            "before": {
+                "public_total": int(before.public_total),
+                "public_with_primary_category": int(before.public_with_col),
+                "drift_rows": int(before.drift_to_heal),
+                "coverage_pct": _coverage_pct(before.public_with_col, before.public_total),
+            },
+            "after": {
+                "public_total": int(after.public_total),
+                "public_with_primary_category": int(after.public_with_col),
+                "drift_rows": int(after.drift_to_heal),
+                "coverage_pct": _coverage_pct(after.public_with_col, after.public_total),
+            },
+        }
+    except Exception as exc:
+        duration_ms = round((time.perf_counter() - started) * 1000, 3)
+        logger.error(
+            "backfill.end correlation_id=%s outcome=error rows_scanned=%d rows_updated=%d duration_ms=%.3f error=%r",
+            correlation_id,
+            rows_scanned,
+            rows_updated,
+            duration_ms,
+            exc,
+            extra={
+                "event": "backfill.end",
+                "correlation_id": correlation_id,
+                "outcome": "error",
+                "rows_scanned": rows_scanned,
+                "rows_updated": rows_updated,
+                "duration_ms": duration_ms,
+                "error_type": type(exc).__name__,
+            },
+            exc_info=True,
+        )
+        raise
+    finally:
+        ADMIN_BACKFILL_RUNS_TOTAL.labels(outcome=outcome).inc()
+        ADMIN_BACKFILL_DURATION_SECONDS.observe(time.perf_counter() - started)
 
 
 # ── Security signal models ──────────────────────────────────────────────────

--- a/tests/test_backfill_primary_category_column.py
+++ b/tests/test_backfill_primary_category_column.py
@@ -44,6 +44,29 @@ class _UpdateReturningResult:
         return [(name,) for name in self._names]
 
 
+class _FakeHeaders(dict):
+    """Minimal Headers stand-in: case-insensitive `.get()` like Starlette's."""
+
+    def get(self, key, default=None):
+        # Starlette's Headers.get is case-insensitive.
+        for k, v in self.items():
+            if k.lower() == key.lower():
+                return v
+        return default
+
+
+class _FakeRequest:
+    """Minimal Request stand-in for direct unit calls of the handler.
+
+    The handler reads `request.headers.get("X-Correlation-ID")` and
+    `request.headers.get("user-agent")` for KAN-API-OBS-BACKFILL
+    observability. A bare object with a `headers` mapping is enough.
+    """
+
+    def __init__(self, headers: dict | None = None):
+        self.headers = _FakeHeaders(headers or {})
+
+
 async def _delete_repos(ids: list[str]) -> None:
     """Tear down inserted repos and their junction rows."""
     async with db_module.async_session_factory() as session:
@@ -228,7 +251,11 @@ async def test_backfill_invalidates_repos_detail_cache_for_each_healed_row():
     with patch("app.routers.admin.cache.invalidate", new=AsyncMock()) as invalidate, \
          patch("app.routers.admin.invalidate_library_cache") as invalidate_memory:
         result = await backfill_primary_category_column(
-            request=None,  # @_limiter.limit decorator wraps but isn't exercised in unit call
+            # @_limiter.limit decorator wraps but isn't exercised in the unit call.
+            # The handler reads `request.headers` for the correlation-id and
+            # user-agent observability fields (KAN-API-OBS-BACKFILL), so we
+            # supply a minimal Request stand-in instead of None.
+            request=_FakeRequest(),
             dry_run=False,
             db=db,
             _api_key="test",
@@ -272,7 +299,7 @@ async def test_backfill_dry_run_does_not_invalidate_cache():
     with patch("app.routers.admin.cache.invalidate", new=AsyncMock()) as invalidate, \
          patch("app.routers.admin.invalidate_library_cache") as invalidate_memory:
         result = await backfill_primary_category_column(
-            request=None,
+            request=_FakeRequest(),
             dry_run=True,
             db=db,
             _api_key="test",

--- a/tests/test_backfill_primary_category_column_observability.py
+++ b/tests/test_backfill_primary_category_column_observability.py
@@ -1,0 +1,155 @@
+"""Observability tests for POST /admin/backfill/primary_category_column.
+
+Covers KAN-API-OBS-BACKFILL: correlation ID propagation (header-supplied or
+generated), structured `backfill.end` log line, Prometheus counter increment
+with the right outcome label.
+"""
+
+import logging
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+
+import app.database as db_module
+from app.prometheus_metrics import ADMIN_BACKFILL_RUNS_TOTAL
+from tests.conftest import AUTH_HEADERS
+
+
+def _success_count() -> float:
+    """Read the current `admin_backfill_runs_total{outcome="success"}` value.
+
+    Works for both the real prometheus_client Counter and the in-process
+    `_FallbackMetric` shim so tests stay green whether or not
+    prometheus_client is installed.
+    """
+    counter = ADMIN_BACKFILL_RUNS_TOTAL
+    if hasattr(counter, "_metrics"):  # prometheus_client.Counter
+        for labels, child in counter._metrics.items():
+            if labels == ("success",):
+                return child._value.get()
+        return 0.0
+    # Fallback shim: values is a defaultdict keyed by sorted-tuple-of-pairs.
+    return float(counter.values.get((("outcome", "success"),), 0.0))
+
+
+async def _delete_repos(ids: list[str]) -> None:
+    async with db_module.async_session_factory() as session:
+        await session.execute(
+            text("DELETE FROM repo_categories WHERE repo_id = ANY(:ids)"),
+            {"ids": ids},
+        )
+        await session.execute(
+            text("DELETE FROM repos WHERE id = ANY(:ids)"),
+            {"ids": ids},
+        )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_backfill_logs_end_with_nonzero_duration_and_counter_bumps(
+    client: AsyncClient, caplog: pytest.LogCaptureFixture
+):
+    """Smoke-test the observability surface end-to-end:
+
+    1. The handler logs `backfill.end` with a populated `duration_ms`.
+    2. Each call increments `admin_backfill_runs_total{outcome="success"}`
+       by exactly 1.
+    3. The response body carries `correlation_id` and `duration_ms`.
+    """
+    drift_id = str(uuid.uuid4())
+    inserted_ids = [drift_id]
+
+    try:
+        async with db_module.async_session_factory() as session:
+            await session.execute(text(
+                "INSERT INTO repos (id, name, owner, github_url, is_fork, is_private, primary_category) "
+                "VALUES (:id, 'pcc-obs-drift-repo', 'testuser', :url, false, false, NULL) "
+                "ON CONFLICT (name) DO UPDATE SET primary_category = NULL"
+            ), {"id": drift_id, "url": "https://github.com/testuser/pcc-obs-drift-repo"})
+            await session.execute(text(
+                "INSERT INTO repo_categories (repo_id, category_id, category_name, is_primary) "
+                "VALUES (:id, 'rag-retrieval', 'RAG & Retrieval', true) "
+                "ON CONFLICT (repo_id, category_id) DO UPDATE SET is_primary = true"
+            ), {"id": drift_id})
+            await session.commit()
+
+        before_count = _success_count()
+
+        with caplog.at_level(logging.INFO, logger="app.routers.admin"):
+            resp = await client.post(
+                "/admin/backfill/primary_category_column",
+                headers=AUTH_HEADERS,
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert "correlation_id" in body
+        assert isinstance(body["duration_ms"], (int, float))
+        assert body["duration_ms"] >= 0
+
+        end_records = [
+            r for r in caplog.records
+            if getattr(r, "event", None) == "backfill.end"
+        ]
+        assert end_records, "expected a backfill.end log record"
+        end_rec = end_records[-1]
+        assert getattr(end_rec, "outcome", None) == "success"
+        assert getattr(end_rec, "duration_ms", 0) > 0
+        assert getattr(end_rec, "rows_updated", -1) >= 1
+
+        after_count = _success_count()
+        assert after_count - before_count == pytest.approx(1.0, abs=1e-9), (
+            f"counter should bump by exactly 1; before={before_count} after={after_count}"
+        )
+    finally:
+        await _delete_repos(inserted_ids)
+
+
+@pytest.mark.asyncio
+async def test_backfill_propagates_caller_supplied_correlation_id(
+    client: AsyncClient, caplog: pytest.LogCaptureFixture
+):
+    """When the caller provides `X-Correlation-ID`, it is preserved verbatim
+    in both the structured log lines and the response body."""
+    supplied_cid = "obs-test-" + uuid.uuid4().hex[:12]
+
+    headers = dict(AUTH_HEADERS)
+    headers["X-Correlation-ID"] = supplied_cid
+
+    with caplog.at_level(logging.INFO, logger="app.routers.admin"):
+        resp = await client.post(
+            "/admin/backfill/primary_category_column?dry_run=true",
+            headers=headers,
+        )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["correlation_id"] == supplied_cid
+
+    matching = [
+        r for r in caplog.records
+        if getattr(r, "correlation_id", None) == supplied_cid
+    ]
+    assert any(getattr(r, "event", None) == "backfill.start" for r in matching), (
+        "expected backfill.start log with caller correlation_id"
+    )
+    assert any(getattr(r, "event", None) == "backfill.end" for r in matching), (
+        "expected backfill.end log with caller correlation_id"
+    )
+
+
+@pytest.mark.asyncio
+async def test_backfill_generates_correlation_id_when_header_absent(
+    client: AsyncClient,
+):
+    """When no `X-Correlation-ID` is supplied, the handler mints a UUID4 and
+    surfaces it in the response so the caller can correlate after-the-fact."""
+    resp = await client.post(
+        "/admin/backfill/primary_category_column?dry_run=true",
+        headers=AUTH_HEADERS,
+    )
+    assert resp.status_code == 200, resp.text
+    cid = resp.json()["correlation_id"]
+    # Should parse as a UUID (raises ValueError otherwise).
+    parsed = uuid.UUID(cid)
+    assert parsed.version == 4


### PR DESCRIPTION
## Summary

Adds structured observability to the operator-runbook backfill endpoint
(`POST /admin/backfill/primary_category_column`, landed in #445) so future
runs are auditable, dashboard-able, and correlate-able with Sentry traces.

## What changed

**`app/routers/admin.py` — `backfill_primary_category_column`:**
- Correlation ID per call: takes from `X-Correlation-ID` request header if
  present, else mints a fresh UUID4. Propagated to all log lines, the
  response body, and set as a Sentry tag.
- Structured `backfill.start` log line at INFO with: `correlation_id`,
  `dry_run`, `request_user_agent`.
- Structured `backfill.end` log line at INFO on success / ERROR on failure,
  with: `correlation_id`, `outcome`, `rows_scanned`, `rows_updated`,
  `duration_ms`. Carries `event` field so Cloud Logging filters cleanly on
  `event="backfill.end"`.
- `try`/`except`/`finally` wrapping so the metrics increment even when the
  handler crashes; failures re-raise for the FastAPI error layer.
- Response body picks up two new fields: `correlation_id` and `duration_ms`.
  Existing keys (`dry_run`, `updated`, `before`, `after`) are preserved
  verbatim — fully backward-compatible.

**`app/prometheus_metrics.py`:**
- New Counter: `admin_backfill_runs_total{outcome="success|error"}`.
- New Histogram: `admin_backfill_duration_seconds` (buckets 50ms..120s, sized
  for a backfill that scans the whole `repos` table).
- Fallback shim metrics added for the `prometheus_client`-not-installed
  branch, so behavior matches whether or not the dependency is present.
- `_render_latest()` in the fallback path now emits the two new metrics.

**`tests/test_backfill_primary_category_column_observability.py`** (new):
- `backfill.end` log line is emitted with `outcome="success"`, non-zero
  `duration_ms`, and `rows_updated >= 1` after a real drift heal.
- `admin_backfill_runs_total{outcome="success"}` increments by exactly 1
  per call.
- Caller-supplied `X-Correlation-ID` is preserved verbatim in the response
  body and in both `backfill.start` + `backfill.end` log records.
- When the header is absent, the handler mints a UUID4 (parses cleanly via
  `uuid.UUID()`, version=4) and surfaces it in the response.

## Why

- Backfill is now part of the operator runbook (kicked off from `/admin`
  on suspected DQ drift). Each run needs to be attributable: who triggered
  it, when, how long it took, how many rows it touched, did it succeed.
- Sentry is already wired in this repo (`app/main.py:73`); this PR plugs
  the handler into it via `set_tag("correlation_id", ...)` so the next
  exception has a thread back to the operator's run.
- Counter + histogram surface in `/metrics/prometheus` — the existing
  Grafana scrape will pick them up automatically (no dashboard change
  required for raw collection; alert/panel work is a separate ticket).

## Refs

- KAN-API-OBS-BACKFILL (parallel-tasks board, Round 2).
- Memory entry 4931 (backfill cache-staleness — PR #447's surface).
- PR #445 — the endpoint this PR enriches.

## Collision note

This PR touches `app/routers/admin.py` at the same handler as **PR #447**
(`fix(admin): invalidate repos:detail cache on primary_category backfill`,
branch `claude/feature/KAN-CACHE-INVALIDATE-on-backfill`). Whichever PR
merges second will need a small mechanical rebase. **The conflict is
mechanical (different lines for different concerns) — no semantic
conflict**: PR #447 modifies the UPDATE statement (adds `RETURNING r.name`)
and the post-commit cache-invalidation block; this PR wraps the entire
handler body in a try/except/finally and adds correlation-ID + log + metric
plumbing around it. Both diffs can coexist; the rebase is a 5-minute job.

## Test plan

- [x] `python -m pytest tests/test_backfill_primary_category_column.py
      tests/test_backfill_primary_category_column_observability.py
      tests/test_admin.py -v --collect-only` — 16 tests collect cleanly,
      no import errors.
- [x] `python -c "from app.main import app"` — app loads, route is
      registered.
- [x] `python -c "from app.prometheus_metrics import
      ADMIN_BACKFILL_RUNS_TOTAL, ADMIN_BACKFILL_DURATION_SECONDS;
      render_latest_metrics()"` — both metrics render in the Prometheus
      exposition payload.
- [ ] CI runs the DB-dependent tests (local Postgres not available in this
      worktree).
- [ ] Operator review.

DO NOT MERGE until operator approves and the PR #447 collision is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)