### PR TITLE
feat(admin): mark-private endpoint with dry-run + cache invalidation

### DIFF
--- a/.audit/2026-04-28/private-row-correction.md
+++ b/.audit/2026-04-28/private-row-correction.md
@@ -1,0 +1,196 @@
+# Private-row correction — bleed-stop runbook
+
+**Incident:** 2026-04-27 ~07:15 UTC. `perditioinc/hippo-harvest-assignment` (a
+GitHub-private repo) was ingested with `is_private = false` and surfaced on
+every public read endpoint of reporium-api (and was baked into the static
+`reporium.com/data/library.json` artifact).
+
+**Lane:** This document covers Lane 1 only — corrective DB write to flip the
+single bad row to `is_private = true` and invalidate caches. Static-artifact
+regeneration (Lane 2), ingestion RCA (Lane 3), and audit-contract fix (Lane 4)
+are tracked separately.
+
+## What this PR ships
+
+A single new admin endpoint:
+
+```
+POST /admin/repos/mark-private
+Headers: X-Admin-Key: <ADMIN_API_KEY>
+Body:    {"owner": "perditioinc", "name": "hippo-harvest-assignment",
+          "dry_run": true}
+```
+
+- **Dry-run** (default) returns match info — id, owner, name,
+  `current_is_private`, `ingested_at`, and the cache prefixes that *would* be
+  invalidated. Read-only.
+- **Apply** (`dry_run: false`) sets `is_private = true`, invalidates 11 cache
+  prefixes via `redis_cache.clear_prefix()`, writes an `AuditLog` row, and
+  returns `applied: true`.
+- **Idempotent** — applying to an already-private row is a no-op success.
+- **Defensive** — refuses to mutate if more than one row matches
+  (`repos.name` is `UNIQUE`, so this is impossible-but-guarded).
+
+## Why a new endpoint and not the existing /ingest/repos
+
+`/ingest/repos` *can* mark a row private via the sticky logic introduced in
+PR #414, but only when called with the *full* repo payload — re-fetching that
+from production for incident response is awkward and slow. The new endpoint
+takes only `owner+name`, supports dry-run preview, and bundles the cache
+invalidation that `/ingest/repos` does not. Pattern is reusable for future
+incidents (Cloud SQL is private-IP only, so direct `UPDATE` from the
+operator host is not possible — see `reference_cloud_sql_private_ip.md`).
+
+## Cache prefixes invalidated on apply
+
+Every prefix is matched via `redis_cache.clear_prefix()` (Redis SCAN — bounded
+I/O even on production-sized key spaces). Defined in
+`app/routers/admin_visibility.py::INVALIDATION_PREFIXES`:
+
+| Prefix             | Surfaces it covers |
+|--------------------|----|
+| `library:`         | `/library`, `/library/full` paginated pages |
+| `repos:`           | `/repos` list + `/repos/{name}` detail |
+| `graph_`           | `/graph/edges`, `/graph/subgraph`, `/graph/clusters`, `/graph/search` |
+| `trending:`        | `/intelligence/trending` |
+| `ecosystem:`       | `/intelligence/ecosystem/{name}` |
+| `intelligence:`    | portfolio insights, category momentum, similar |
+| `signals:`         | taxonomy gaps, stale repos, velocity leaders |
+| `compare:`         | `/compare` results |
+| `similar:`         | `/intelligence/similar/{name}` |
+| `smart_route:`     | LLM router cache (may cite the repo) |
+| `llm_response:`    | LLM answer cache (same) |
+
+Per-repo `graph_edges:{rid}` keys (set in `intelligence.py` via the in-memory
+`cache`) are cleared via the `graph_` prefix sweep when both layers point
+to the same Redis instance, which is the production configuration.
+
+## Bleed-stop runbook
+
+Run from any host that can hit production (`reporium-api-573778300586.us-central1.run.app`).
+
+**Step 1 — Wait for deploy.** This PR must be merged and Cloud Run must roll
+out before the endpoint exists. Verify with:
+
+```bash
+curl -I -X POST https://reporium-api-573778300586.us-central1.run.app/admin/repos/mark-private
+# expect 422 (validation error — no body), NOT 404
+```
+
+**Step 2 — Dry-run preview.**
+
+```bash
+curl -sS -X POST \
+  -H "X-Admin-Key: $REPORIUM_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"owner": "perditioinc", "name": "hippo-harvest-assignment", "dry_run": true}' \
+  https://reporium-api-573778300586.us-central1.run.app/admin/repos/mark-private | jq .
+```
+
+Expected response shape:
+
+```json
+{
+  "match": {
+    "id": "a01e40b2-0997-4a27-8b82-9f52c6a0fd81",
+    "owner": "perditioinc",
+    "name": "hippo-harvest-assignment",
+    "current_is_private": false,
+    "ingested_at": "2026-04-27T07:15:14+00:00"
+  },
+  "match_count": 1,
+  "applied": false,
+  "would_invalidate_prefixes": [...]
+}
+```
+
+**Confirm before proceeding:**
+- `match_count == 1` — exactly one row, no broad delete possible
+- `match.id == "a01e40b2-0997-4a27-8b82-9f52c6a0fd81"` (cross-check against
+  the production probe captured during the prior reconnaissance session)
+- `match.current_is_private == false` (confirms this is the bad row)
+
+If any check fails, **stop**. Do not run apply.
+
+**Step 3 — Apply.**
+
+```bash
+curl -sS -X POST \
+  -H "X-Admin-Key: $REPORIUM_ADMIN_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"owner": "perditioinc", "name": "hippo-harvest-assignment", "dry_run": false}' \
+  https://reporium-api-573778300586.us-central1.run.app/admin/repos/mark-private | jq .
+```
+
+Expected response: `applied: true`, `match.current_is_private: true`,
+`invalidated_prefixes` listing the 11 prefixes from the table above.
+
+**Step 4 — Verify production no longer leaks.**
+
+```bash
+# Detail endpoint — must 404
+curl -sS -o /dev/null -w "%{http_code}\n" \
+  https://reporium-api-573778300586.us-central1.run.app/repos/hippo-harvest-assignment
+# expect: 404
+
+curl -sS -o /dev/null -w "%{http_code}\n" \
+  https://reporium-api-573778300586.us-central1.run.app/repos/perditioinc/hippo-harvest-assignment
+# expect: 404
+
+# Search must not return it
+curl -sS "https://reporium-api-573778300586.us-central1.run.app/search?q=hippo" | jq '. | length'
+# expect: prior count minus 1
+
+# /library/full must not list it
+curl -sS "https://reporium-api-573778300586.us-central1.run.app/library/full?page=1&page_size=2000" | \
+  jq '.repos[] | select(.name == "hippo-harvest-assignment")'
+# expect: empty (no output)
+```
+
+**Step 5 — Confirm in DB via existing audit endpoint.**
+
+```bash
+curl -sS -H "X-Admin-Key: $REPORIUM_ADMIN_KEY" \
+  "https://reporium-api-573778300586.us-central1.run.app/admin/audit?endpoint=admin.mark_private&limit=5" | jq .
+```
+
+Look for the row with `request_summary` containing
+`name=hippo-harvest-assignment dry_run=False prior_is_private=true`.
+
+## Out of scope (Lane 2+)
+
+- **Static artifact** at `reporium.com/data/library.json` is **frozen** until
+  the next frontend rebuild + deploy. The API fix does not touch the baked
+  JSON. Lane 2 (reporium repo) blocks the artifact from emitting private
+  rows in the first place.
+- **Ingestion RCA** — why was the row inserted with `is_private=false` for a
+  private GitHub repo? Lane 3 (reporium-ingestion repo).
+- **Audit contract** — why didn't `reporium-audit/checks/contract.py`
+  detect this in 22 hours? Lane 4 (reporium-audit repo).
+
+## Files in this PR
+
+- `app/routers/admin_visibility.py` — new admin router (110 lines)
+- `app/main.py` — `+1` import, `+1` `include_router`
+- `tests/test_admin_mark_private.py` — 9 tests (1 route registration, 8 DB-
+  dependent: dry-run preview, apply mutation, cache invalidation calls,
+  idempotency, audit-log row, dry-run-does-not-invalidate, missing
+  X-Admin-Key returns 403, 404 on unknown owner+name)
+
+## Verification status (this PR, pre-deploy)
+
+- [x] Tests written first; route-registration test went red, then green.
+- [x] Lint clean (`ruff check`) on changed files.
+- [x] Full test suite passes: 576 passed, 254 skipped (DB-dependent), 0 failed.
+- [ ] DB-dependent tests run in CI (will fire on PR open).
+- [ ] Endpoint exercised against production after deploy (Step 2-5 above).
+
+## After Lane 1
+
+Lane 1 alone does NOT close the visible leak. Even with the row corrected:
+- The static artifact at reporium.com still serves the old JSON.
+- The next ingestion run could re-introduce the row if the source bug
+  persists (it cannot flip is_private back to false because of PR #414's
+  sticky logic, but it can still surface the row in other ways).
+
+Lane 2 + Lane 3 must land before declaring the incident closed.

--- a/app/main.py
+++ b/app/main.py
@@ -22,7 +22,7 @@ from app.rate_limit import rate_limit_storage
 from app.prometheus_metrics import record_http_request
 from app.slo_observer import slo_observer
 from app.database import async_session_factory, check_db_connection, engine
-from app.routers import admin, analytics, compare, dependencies, graph, ingest, intelligence, library, library_full, mentions, nl_filter, platform, recommendations, repos, search, taxonomy, trends, webhooks, wiki
+from app.routers import admin, admin_visibility, analytics, compare, dependencies, graph, ingest, intelligence, library, library_full, mentions, nl_filter, platform, recommendations, repos, search, taxonomy, trends, webhooks, wiki
 from app.telemetry import init_telemetry
 
 
@@ -328,6 +328,7 @@ app.include_router(library_full.router)
 app.include_router(taxonomy.router, prefix="/taxonomy")
 app.include_router(compare.router)
 app.include_router(admin.router)
+app.include_router(admin_visibility.router)
 app.include_router(webhooks.router)
 app.include_router(dependencies.router)
 

--- a/app/routers/admin_visibility.py
+++ b/app/routers/admin_visibility.py
@@ -1,0 +1,166 @@
+"""Admin endpoint to mark a single repo as ``is_private = true``, with a
+dry-run preview and post-mutation cache invalidation.
+
+Built for incident response (2026-04-27 hippo-harvest-assignment leak).
+Cloud SQL is private-IP only, so direct ``UPDATE`` from an operator host
+isn't possible — this endpoint is the in-VPC corrective path.
+
+Contract — see ``tests/test_admin_mark_private.py``:
+  - X-Admin-Key required.
+  - 404 when no row matches owner+name.
+  - dry_run=true: returns the match info, does not mutate or invalidate.
+  - dry_run=false: sets ``is_private = true``, invalidates documented cache
+    prefixes, writes an AuditLog row, and returns ``applied=true``.
+  - Idempotent: applying to an already-private row is a no-op success.
+"""
+from __future__ import annotations
+
+import logging
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import require_admin_key
+from app.cache_redis import redis_cache
+from app.database import get_db
+from app.models.audit_log import AuditLog
+from app.models.repo import Repo
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Admin"])
+
+
+# Cache key prefixes that may include the affected repo. Conservative — the
+# bleed-stop value of clearing too much beats serving a private repo from a
+# stale list. Each prefix is matched via Redis SCAN (``clear_prefix``), so
+# this is bounded I/O even on production-sized key spaces.
+INVALIDATION_PREFIXES: tuple[str, ...] = (
+    "library:",       # /library and /library/full pages
+    "repos:",         # /repos list + /repos/{name} detail
+    "graph_",         # graph_edges, graph_subgraph, graph_clusters, graph_search
+    "trending:",      # /intelligence/trending leaderboards
+    "ecosystem:",     # /intelligence/ecosystem/{name}
+    "intelligence:",  # portfolio insights, category momentum, similar
+    "signals:",       # taxonomy gaps, stale repos, velocity leaders
+    "compare:",       # /compare results
+    "similar:",       # /intelligence/similar/{name}
+    "smart_route:",   # LLM router cache (may cite the repo)
+    "llm_response:",  # LLM answer cache (same)
+)
+
+
+class MarkPrivateRequest(BaseModel):
+    owner: str = Field(..., min_length=1, max_length=200)
+    name: str = Field(..., min_length=1, max_length=200)
+    dry_run: bool = Field(
+        default=True,
+        description=(
+            "If true (default), returns match info without mutating. "
+            "Operators MUST run dry_run=true first and confirm match_count=1 "
+            "before submitting dry_run=false."
+        ),
+    )
+
+
+class MarkPrivateMatch(BaseModel):
+    id: str
+    owner: str
+    name: str
+    current_is_private: bool
+    ingested_at: str | None
+
+
+class MarkPrivateResponse(BaseModel):
+    match: MarkPrivateMatch
+    match_count: int
+    applied: bool
+    would_invalidate_prefixes: list[str]
+    invalidated_prefixes: list[str] | None = None
+
+
+@router.post(
+    "/admin/repos/mark-private",
+    response_model=MarkPrivateResponse,
+    dependencies=[Depends(require_admin_key)],
+)
+async def mark_private(
+    body: MarkPrivateRequest,
+    db: AsyncSession = Depends(get_db),
+) -> MarkPrivateResponse:
+    """Flip a single repo to ``is_private = true``. Dry-run first by default."""
+
+    stmt = select(Repo).where(Repo.owner == body.owner, Repo.name == body.name)
+    matches = (await db.execute(stmt)).scalars().all()
+
+    if len(matches) == 0:
+        raise HTTPException(status_code=404, detail="Repo not found")
+    if len(matches) > 1:
+        # `repos.name` is UNIQUE in the schema; this is a defensive guard for
+        # an impossible state that, if it ever happens, must NOT mutate.
+        raise HTTPException(
+            status_code=409,
+            detail=f"Expected exactly 1 match, found {len(matches)} — refusing to mutate",
+        )
+
+    repo = matches[0]
+    match_payload = MarkPrivateMatch(
+        id=str(repo.id),
+        owner=repo.owner,
+        name=repo.name,
+        current_is_private=bool(repo.is_private),
+        ingested_at=repo.ingested_at.isoformat() if repo.ingested_at else None,
+    )
+
+    if body.dry_run:
+        return MarkPrivateResponse(
+            match=match_payload,
+            match_count=1,
+            applied=False,
+            would_invalidate_prefixes=list(INVALIDATION_PREFIXES),
+        )
+
+    # Apply path — mutate first, then invalidate caches, then audit-log.
+    if not repo.is_private:
+        repo.is_private = True
+        await db.flush()
+
+    invalidated: list[str] = []
+    for prefix in INVALIDATION_PREFIXES:
+        try:
+            await redis_cache.clear_prefix(prefix)
+            invalidated.append(prefix)
+        except Exception:  # noqa: BLE001 — invalidation is best-effort
+            logger.warning(
+                "mark_private: clear_prefix(%s) failed — continuing", prefix,
+                exc_info=True,
+            )
+
+    audit = AuditLog(
+        endpoint="admin.mark_private",
+        method="POST",
+        request_summary=(
+            f"owner={body.owner} name={body.name} dry_run=False "
+            f"prior_is_private={match_payload.current_is_private}"
+        ),
+        response_status=200,
+    )
+    db.add(audit)
+    await db.commit()
+    await db.refresh(repo)
+
+    return MarkPrivateResponse(
+        match=MarkPrivateMatch(
+            id=str(repo.id),
+            owner=repo.owner,
+            name=repo.name,
+            current_is_private=bool(repo.is_private),
+            ingested_at=repo.ingested_at.isoformat() if repo.ingested_at else None,
+        ),
+        match_count=1,
+        applied=True,
+        would_invalidate_prefixes=list(INVALIDATION_PREFIXES),
+        invalidated_prefixes=invalidated,
+    )

--- a/tests/test_admin_mark_private.py
+++ b/tests/test_admin_mark_private.py
@@ -1,0 +1,360 @@
+"""POST /admin/repos/mark-private — bleed-stop endpoint for marking a single
+repo as ``is_private = true`` and invalidating affected caches.
+
+Designed for incident response (2026-04-27 hippo-harvest-assignment leak):
+operator must be able to flip a wrongly-public row to private through a
+deployed admin path, with a dry-run preview AND post-mutation cache
+invalidation, since direct SQL access is gated by Cloud SQL private-IP
+networking.
+
+The endpoint must:
+  1. Require X-Admin-Key (re-uses ``require_admin_key``).
+  2. 404 when no row matches owner+name.
+  3. ``dry_run=true`` returns match info without mutating.
+  4. ``dry_run=false`` sets ``is_private = true`` and invalidates caches.
+  5. Idempotent — applying to an already-private row is a no-op success.
+  6. Write an AuditLog entry for the mutation.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import text
+
+import app.database as db_module
+
+
+_OWNER = "perditioinc"
+_NAME = "mark-private-fixture"
+
+
+async def _seed_repo(*, is_private: bool = False) -> str:
+    """Insert a public repo for the test. Returns the new id (str)."""
+    repo_id = str(uuid.uuid4())
+    async with db_module.async_session_factory() as session:
+        await session.execute(
+            text(
+                """
+                INSERT INTO repos
+                    (id, name, owner, github_url, description,
+                     is_fork, is_private, primary_language)
+                VALUES
+                    (:id, :name, :owner, :github_url, :description,
+                     false, :is_private, 'Python')
+                ON CONFLICT (name) DO UPDATE
+                    SET is_private = EXCLUDED.is_private,
+                        owner = EXCLUDED.owner
+                RETURNING id::text
+                """
+            ),
+            {
+                "id": repo_id,
+                "name": _NAME,
+                "owner": _OWNER,
+                "github_url": f"https://github.com/{_OWNER}/{_NAME}",
+                "description": "fixture for mark-private",
+                "is_private": is_private,
+            },
+        )
+        row = (
+            await session.execute(
+                text("SELECT id::text FROM repos WHERE name = :name"),
+                {"name": _NAME},
+            )
+        ).first()
+        await session.commit()
+    return row[0]
+
+
+@pytest_asyncio.fixture
+async def public_repo(_setup_db) -> str:
+    """Seed a public repo, yield its id, clean up after."""
+    rid = await _seed_repo(is_private=False)
+    yield rid
+    async with db_module.async_session_factory() as session:
+        await session.execute(
+            text("DELETE FROM repos WHERE name = :name"),
+            {"name": _NAME},
+        )
+        await session.commit()
+
+
+@pytest_asyncio.fixture
+async def private_repo(_setup_db) -> str:
+    """Seed an already-private repo (idempotency test)."""
+    rid = await _seed_repo(is_private=True)
+    yield rid
+    async with db_module.async_session_factory() as session:
+        await session.execute(
+            text("DELETE FROM repos WHERE name = :name"),
+            {"name": _NAME},
+        )
+        await session.commit()
+
+
+_ADMIN_HEADER = {"X-Admin-Key": "test-admin-key"}
+
+
+# ---------------------------------------------------------------------------
+# Route registration (runs without a DB — first canary)
+# ---------------------------------------------------------------------------
+
+
+def test_mark_private_route_is_registered():
+    """The endpoint must be wired into the app router. Catches forgetting
+    ``include_router`` regardless of test DB availability."""
+    from app.main import app
+
+    routes = set()
+    for r in app.routes:
+        methods = getattr(r, "methods", set()) or set()
+        path = getattr(r, "path", "")
+        for m in methods:
+            routes.add(f"{m} {path}")
+    assert "POST /admin/repos/mark-private" in routes, (
+        "POST /admin/repos/mark-private must be registered on the app — "
+        "the bleed-stop endpoint is missing"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Authn / 404 / shape
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mark_private_requires_admin_key(client: AsyncClient, monkeypatch):
+    """Without the X-Admin-Key header (when ADMIN_API_KEY is set), 403."""
+    monkeypatch.setenv("ADMIN_API_KEY", "test-admin-key")
+    resp = await client.post(
+        "/admin/repos/mark-private",
+        json={"owner": _OWNER, "name": _NAME, "dry_run": True},
+    )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_mark_private_404_for_unknown_repo(
+    client: AsyncClient, _setup_db, monkeypatch
+):
+    monkeypatch.setenv("ADMIN_API_KEY", "test-admin-key")
+    resp = await client.post(
+        "/admin/repos/mark-private",
+        json={"owner": "nobody", "name": "does-not-exist", "dry_run": True},
+        headers=_ADMIN_HEADER,
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Dry-run mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mark_private_dry_run_returns_match_without_mutation(
+    client: AsyncClient, public_repo: str, monkeypatch
+):
+    monkeypatch.setenv("ADMIN_API_KEY", "test-admin-key")
+    resp = await client.post(
+        "/admin/repos/mark-private",
+        json={"owner": _OWNER, "name": _NAME, "dry_run": True},
+        headers=_ADMIN_HEADER,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["applied"] is False
+    assert body["match_count"] == 1
+
+    match = body["match"]
+    assert match["id"] == public_repo
+    assert match["owner"] == _OWNER
+    assert match["name"] == _NAME
+    assert match["current_is_private"] is False
+    # ingested_at may be None for raw inserts that didn't set it; just check key.
+    assert "ingested_at" in match
+
+    # Cache prefixes are listed so the operator can review what would be touched.
+    assert isinstance(body["would_invalidate_prefixes"], list)
+    assert len(body["would_invalidate_prefixes"]) >= 5
+
+    # Confirm DB unchanged.
+    async with db_module.async_session_factory() as session:
+        is_private = (
+            await session.execute(
+                text("SELECT is_private FROM repos WHERE name = :name"),
+                {"name": _NAME},
+            )
+        ).scalar_one()
+        assert is_private is False, "dry-run must not mutate"
+
+
+# ---------------------------------------------------------------------------
+# Apply mode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mark_private_apply_flips_is_private(
+    client: AsyncClient, public_repo: str, monkeypatch
+):
+    monkeypatch.setenv("ADMIN_API_KEY", "test-admin-key")
+    resp = await client.post(
+        "/admin/repos/mark-private",
+        json={"owner": _OWNER, "name": _NAME, "dry_run": False},
+        headers=_ADMIN_HEADER,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["applied"] is True
+    assert body["match"]["current_is_private"] is True
+    assert "invalidated_prefixes" in body
+    assert isinstance(body["invalidated_prefixes"], list)
+
+    # Confirm DB row flipped.
+    async with db_module.async_session_factory() as session:
+        is_private = (
+            await session.execute(
+                text("SELECT is_private FROM repos WHERE name = :name"),
+                {"name": _NAME},
+            )
+        ).scalar_one()
+        assert is_private is True
+
+
+@pytest.mark.asyncio
+async def test_mark_private_apply_invalidates_caches(
+    client: AsyncClient, public_repo: str, monkeypatch
+):
+    """The endpoint must call redis_cache.clear_prefix for every documented
+    prefix. We patch the clear_prefix method to record invocations rather
+    than depending on a real Redis instance — both production and the test
+    DB use redis_cache, so capturing the calls proves the invalidation
+    logic ran."""
+    monkeypatch.setenv("ADMIN_API_KEY", "test-admin-key")
+
+    captured_prefixes: list[str] = []
+
+    from app import cache_redis
+
+    async def _capture(prefix: str) -> None:
+        captured_prefixes.append(prefix)
+
+    monkeypatch.setattr(cache_redis.redis_cache, "clear_prefix", _capture)
+
+    resp = await client.post(
+        "/admin/repos/mark-private",
+        json={"owner": _OWNER, "name": _NAME, "dry_run": False},
+        headers=_ADMIN_HEADER,
+    )
+    assert resp.status_code == 200
+
+    # Sanity: every documented prefix was actually invalidated.
+    assert "library:" in captured_prefixes
+    assert "repos:" in captured_prefixes
+    assert "graph_" in captured_prefixes
+    assert "intelligence:" in captured_prefixes
+    assert "similar:" in captured_prefixes
+
+
+@pytest.mark.asyncio
+async def test_mark_private_idempotent_on_already_private(
+    client: AsyncClient, private_repo: str, monkeypatch
+):
+    """Applying mark-private to an already-private repo is a no-op success.
+    Critical for re-running the same incident-response command without
+    surprises."""
+    monkeypatch.setenv("ADMIN_API_KEY", "test-admin-key")
+    resp = await client.post(
+        "/admin/repos/mark-private",
+        json={"owner": _OWNER, "name": _NAME, "dry_run": False},
+        headers=_ADMIN_HEADER,
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["applied"] is True
+    assert body["match"]["current_is_private"] is True
+
+
+@pytest.mark.asyncio
+async def test_mark_private_writes_audit_log(
+    client: AsyncClient, public_repo: str, monkeypatch
+):
+    """Every mutation writes an AuditLog row capturing endpoint+payload+200."""
+    monkeypatch.setenv("ADMIN_API_KEY", "test-admin-key")
+
+    async with db_module.async_session_factory() as session:
+        before = (
+            await session.execute(
+                text(
+                    "SELECT COUNT(*) FROM audit_logs "
+                    "WHERE endpoint = 'admin.mark_private'"
+                )
+            )
+        ).scalar_one()
+
+    resp = await client.post(
+        "/admin/repos/mark-private",
+        json={"owner": _OWNER, "name": _NAME, "dry_run": False},
+        headers=_ADMIN_HEADER,
+    )
+    assert resp.status_code == 200
+
+    async with db_module.async_session_factory() as session:
+        after = (
+            await session.execute(
+                text(
+                    "SELECT COUNT(*) FROM audit_logs "
+                    "WHERE endpoint = 'admin.mark_private'"
+                )
+            )
+        ).scalar_one()
+        latest = (
+            await session.execute(
+                text(
+                    "SELECT response_status, request_summary FROM audit_logs "
+                    "WHERE endpoint = 'admin.mark_private' "
+                    "ORDER BY id DESC LIMIT 1"
+                )
+            )
+        ).first()
+
+    assert after == before + 1
+    assert latest.response_status == 200
+    # Request summary should contain owner & name so an auditor can verify the
+    # exact target of the mutation without reading the full payload.
+    assert _OWNER in (latest.request_summary or "")
+    assert _NAME in (latest.request_summary or "")
+
+
+@pytest.mark.asyncio
+async def test_mark_private_dry_run_does_not_invalidate_cache(
+    client: AsyncClient, public_repo: str, monkeypatch
+):
+    """Dry-run must not touch the cache — operators rely on dry-run being
+    truly read-only."""
+    monkeypatch.setenv("ADMIN_API_KEY", "test-admin-key")
+
+    captured_prefixes: list[str] = []
+    from app import cache_redis
+
+    async def _capture(prefix: str) -> None:
+        captured_prefixes.append(prefix)
+
+    monkeypatch.setattr(cache_redis.redis_cache, "clear_prefix", _capture)
+
+    resp = await client.post(
+        "/admin/repos/mark-private",
+        json={"owner": _OWNER, "name": _NAME, "dry_run": True},
+        headers=_ADMIN_HEADER,
+    )
+    assert resp.status_code == 200
+    assert captured_prefixes == [], (
+        "dry-run must not call clear_prefix — invalidation is reserved for "
+        "the apply path"
+    )


### PR DESCRIPTION
## Bleed-stop endpoint for incident response

The 2026-04-27 hippo-harvest-assignment leak needs a corrective DB write. Cloud SQL is private-IP only (operator can't \`gcloud sql connect\`). \`/ingest/repos\` could mark private via PR #414's sticky logic but requires the full repo payload and has no dry-run / no cache invalidation. This endpoint solves both.

## What ships

\`POST /admin/repos/mark-private\` (admin-key-gated)
- \`{owner, name, dry_run}\` body
- Refuses to mutate when \`match_count != 1\`
- Dry-run returns match info + cache prefixes that *would* be invalidated
- Apply: sets \`is_private=true\`, invalidates **11 documented cache prefixes** via \`redis_cache.clear_prefix()\`, writes an \`audit_logs\` row
- Idempotent: applying to already-private row is a no-op success

## Operator runbook

\`.audit/2026-04-28/private-row-correction.md\` — 5-step runbook (deploy gate → dry-run preview → apply → verify endpoints → confirm via \`/admin/audit\`).

## Verification

- 576 passed, 254 skipped (DB-dependent: route registration + 8 behavioural tests).
- \`ruff check\` clean.

## After merge

1. Deploy reporium-api.
2. Run dry-run: \`curl -X POST .../admin/repos/mark-private -d '{\"owner\":\"perditioinc\",\"name\":\"hippo-harvest-assignment\",\"dry_run\":true}' -H \"X-Admin-Key: $REPORIUM_ADMIN_KEY\"\`.
3. Confirm \`match_count == 1\` and \`match.id == a01e40b2-0997-4a27-8b82-9f52c6a0fd81\`.
4. Run apply (\`dry_run: false\`).
5. Verify \`/repos/hippo-harvest-assignment\` returns 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)