### PR TITLE
KAN-DRAFT: tighten data-invariants to catch silent trends staleness

### DIFF
--- a/tests/test_data_invariants.py
+++ b/tests/test_data_invariants.py
@@ -1,17 +1,35 @@
 """
 Nightly data invariants for Reporium staging.
 
-These tests catch 3 classes of silent regression identified in
-.audit/api-regression-plan.md:
+These tests catch 6 classes of silent regression:
 
   1. Mass-delete regression — totalRepos floor (>= 1400)
   2. Taxonomy enrichment regression — at least 3 dimensions populated
-  3. Trend snapshots stall — weekly cron producing data
+  3. Trend snapshots stall — weekly cron producing any data at all
+     (test_trend_snapshots_exist)
+  4. Trend snapshots stale — most recent snapshot must be < 48h old
+     (test_trend_snapshots_recent)
+  5. Commit-stats stall — not every repo can have commits_last_7_days == 0
+     (test_commit_stats_not_universally_zero)
+  6. Fork-discovery stall — at least one repo must have been forked/added
+     in the last 30 days (test_repo_discovery_recent)
+
+Tests 4-6 + the strengthened #3 were added 2026-04-30 after a 10-day silent
+staleness incident: the existing nightly workflow stayed GREEN every day
+(see workflow runs 2026-04-21 through 2026-04-30) while production data
+was visibly stale — period.snapshots=0, every repo's commitStats.last7Days=0,
+no new repos in 15+ days. Root cause for the silent green: test #3 was
+marked @pytest.mark.xfail(strict=False), which masks a failing assertion
+as XFAIL (still green). It now asserts strictly.
+
+These tests will INTENTIONALLY FAIL in nightly runs until the sibling
+fixes for the trend-snapshot writer (T1), commit-stats refresh (T2), and
+fork-discovery sweep (T3) land and are redeployed. The failure is the
+alarm working as designed.
 
 Guards:
   - Only runs when STAGING_API_URL env var is set (skipped in CI unit-test
-    runs, nightly workflow populates it via secret).
-  - Xfail on snapshots until reporium-ingestion WEEKLY cron is unblocked.
+    runs and PR-time test workflow; nightly workflow populates it via secret).
 
 Run locally:
     STAGING_API_URL=https://reporium-api-573778300586.us-central1.run.app \\
@@ -35,6 +53,7 @@ Audit finding: the two taxonomy systems are distinct. This invariant guards
 from __future__ import annotations
 
 import os
+from datetime import datetime, timedelta, timezone
 
 import httpx
 import pytest
@@ -71,6 +90,17 @@ POTENTIALLY_EMPTY_DIMS = {"tags", "categories"}
 
 MIN_POPULATED_DIMS = 3  # at least this many must return non-empty values
 
+# Trend snapshots must be written daily; alarm if the latest is older than this.
+SNAPSHOT_FRESHNESS_HOURS = 48
+
+# Fork-discovery sweep should add new repos at least monthly.
+DISCOVERY_FRESHNESS_DAYS = 30
+
+# Pagination ceiling for /library/full sweeps. ~1900 repos / 500 = 4 pages,
+# 8 pages here is generous headroom in case totalRepos grows.
+MAX_PAGES = 8
+PAGE_SIZE = 500
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -85,6 +115,52 @@ def _get(path: str, params: dict | None = None, timeout: float = 60) -> httpx.Re
     url = f"{_base_url()}{path}"
     resp = httpx.get(url, params=params, timeout=timeout)
     return resp
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    """Tolerant ISO-8601 parser. Returns None for empty / unparseable strings."""
+    if not value:
+        return None
+    try:
+        # fromisoformat handles "+00:00" but not bare "Z" until Python 3.11+.
+        # Be defensive for older runners.
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+
+
+def _iter_library_full() -> list[dict]:
+    """Page through /library/full and return all repo dicts.
+
+    Stops at the lesser of:
+      - totalRepos (from page 1)
+      - MAX_PAGES (safety cap)
+    """
+    all_repos: list[dict] = []
+    page = 1
+    total: int | None = None
+
+    while page <= MAX_PAGES:
+        resp = _get(
+            "/library/full",
+            params={"page": page, "page_size": PAGE_SIZE},
+        )
+        assert resp.status_code == 200, (
+            f"GET /library/full page={page} returned {resp.status_code}: {resp.text[:300]}"
+        )
+        data = resp.json()
+        if total is None:
+            total = data.get("totalRepos") or 0
+        repos = data.get("repos", []) or []
+        all_repos.extend(repos)
+        if total is not None and len(all_repos) >= total:
+            break
+        if not repos:
+            # Empty page — protects against an off-by-one infinite loop.
+            break
+        page += 1
+
+    return all_repos
 
 
 # ---------------------------------------------------------------------------
@@ -149,7 +225,7 @@ def test_taxonomy_dimensions_populated():
                 populated.append(dim)
             else:
                 empty.append(dim)
-        except httpx.TimeoutException as exc:
+        except httpx.TimeoutException:
             # Timeout on a single slow dim is a performance issue, not a
             # correctness failure — count it as "unknown" not "error".
             empty.append(f"{dim}(timeout)")
@@ -165,18 +241,11 @@ def test_taxonomy_dimensions_populated():
 
 
 # ---------------------------------------------------------------------------
-# Invariant 3 — trend snapshots exist
+# Invariant 3 — trend snapshots exist (table not empty)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.invariants
-@pytest.mark.xfail(
-    strict=False,
-    reason=(
-        "reporium-ingestion WEEKLY cron stalled — trend_snapshots table may "
-        "be empty until KAN-ingestion cron is unblocked. Tracked in JIRA."
-    ),
-)
 def test_trend_snapshots_exist():
     """
     GET /trends/report → period.snapshots > 0.
@@ -184,17 +253,170 @@ def test_trend_snapshots_exist():
     Catches: ingestion weekly cron not running, trend_snapshots table never
     populated, snapshot pipeline silent failure.
 
-    Marked xfail: keeps CI green while ingestion cron is unblocked.
-    Once the cron is live and verified, remove the xfail marker.
+    History: this test was previously @pytest.mark.xfail(strict=False),
+    which silently masked the empty-table case as XFAIL (still GREEN).
+    Removed 2026-04-30 after the empty-snapshots state went undetected
+    for 10+ days. The strict assertion below now fails loudly so the
+    nightly workflow turns RED and notifies Workato → JIRA.
     """
     resp = _get("/trends/report")
     assert resp.status_code == 200, (
         f"GET /trends/report returned {resp.status_code}: {resp.text[:300]}"
     )
     data = resp.json()
-    period = data.get("period", {})
-    snapshots = period.get("snapshots", 0)
+    period = data.get("period", {}) or {}
+    snapshots = period.get("snapshots", 0) or 0
     assert snapshots > 0, (
         f"trends/report.period.snapshots={snapshots} — "
-        "no snapshot data; weekly ingestion cron may not be running"
+        "trend_snapshots table is empty; weekly ingestion writer is not running"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 4 — trend snapshots are recent (not just non-empty)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.invariants
+def test_trend_snapshots_recent():
+    """
+    GET /trends/report → period.to (latest snapshotted_at) must be within
+    the last SNAPSHOT_FRESHNESS_HOURS hours.
+
+    Catches: snapshot writer ran historically but has stopped recently —
+    e.g. a Cloud Run Job whose schedule was disabled, an auth/permission
+    regression that silently broke the daily insert, or any other case
+    where the table has rows but isn't being refreshed.
+
+    test_trend_snapshots_exist (#3) catches the empty-table case;
+    this test catches the stale-table case. Both must pass.
+    """
+    resp = _get("/trends/report")
+    assert resp.status_code == 200, (
+        f"GET /trends/report returned {resp.status_code}: {resp.text[:300]}"
+    )
+    data = resp.json()
+    period = data.get("period", {}) or {}
+    latest_iso = period.get("to")
+    assert latest_iso, (
+        f"trends/report.period.to is null (period={period!r}) — "
+        "no snapshots written; cannot evaluate freshness"
+    )
+    latest = _parse_iso(latest_iso)
+    assert latest is not None, (
+        f"trends/report.period.to={latest_iso!r} is unparseable"
+    )
+    now = datetime.now(timezone.utc)
+    age_hours = (now - latest).total_seconds() / 3600.0
+    assert age_hours <= SNAPSHOT_FRESHNESS_HOURS, (
+        f"latest trend_snapshot is {age_hours:.1f}h old "
+        f"(at {latest_iso}); freshness ceiling is {SNAPSHOT_FRESHNESS_HOURS}h. "
+        "Snapshot writer may be stalled."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 5 — commit_stats not universally zero
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.invariants
+def test_commit_stats_not_universally_zero():
+    """
+    Sweep all repos via /library/full and assert the sum of
+    commitStats.last7Days across the entire corpus is > 0.
+
+    Catches: the exact 2026-04 production state where every repo's
+    commits_last_7_days column was 0 because the commit-refresh job
+    silently stopped. A single active fork in the corpus is enough to
+    keep this green; only the universal-zero case fails.
+
+    Rationale for sum > 0 rather than per-row sampling: with ~1900 repos,
+    a few may legitimately have no commits in the last 7 days (archived,
+    truly idle). The smell we want to catch is "EVERY repo == 0" which
+    is what the commit-refresh stall produces.
+    """
+    repos = _iter_library_full()
+    assert repos, (
+        "GET /library/full returned 0 repos — corpus is empty; "
+        "this is also caught by test_total_repos_floor but worth flagging"
+    )
+
+    def _c7(r: dict) -> int:
+        # Be defensive: commitStats may be missing on a malformed row.
+        stats = r.get("commitStats") or {}
+        try:
+            return int(stats.get("last7Days") or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    total_c7 = sum(_c7(r) for r in repos)
+    nonzero_count = sum(1 for r in repos if _c7(r) > 0)
+
+    assert total_c7 > 0, (
+        f"commitStats.last7Days summed across {len(repos)} repos == 0 "
+        f"(0 repos with any 7-day commits). The commit-refresh job has "
+        "silently stalled — every row is zero. This is the 2026-04-XX "
+        "regression pattern."
+    )
+    # Soft observability — show the distribution in the failure log even on pass.
+    # Not an assertion; just useful in --tb=short output if a *later* test fails.
+    print(
+        f"[invariant] commits-7d sum={total_c7} nonzero_repos={nonzero_count}/{len(repos)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 6 — fork-discovery sweep is recent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.invariants
+def test_repo_discovery_recent():
+    """
+    Sweep all repos via /library/full and assert at least one repo was
+    forked or added (createdAt fallback for non-fork rows) within the
+    last DISCOVERY_FRESHNESS_DAYS days.
+
+    Catches: the fork-discovery sweep / nightly enrichment job has stopped
+    adding new repos to the corpus. This is the "no new repos in 15+ days"
+    half of the 2026-04 staleness incident.
+
+    Field semantics (from app/routers/library_full.py):
+      - forkedAt: when *we* forked the upstream (most reliable freshness signal)
+      - createdAt: for forks → upstream_created_at (NOT a freshness signal,
+        upstream may be years old); for non-forks → ingested_at OR
+        github_updated_at (which IS our DB row creation for non-forks)
+
+    We accept the latest of forkedAt OR (createdAt for non-forks). If
+    nothing has appeared in 30 days, the discovery job is stalled.
+    """
+    repos = _iter_library_full()
+    assert repos, "GET /library/full returned 0 repos — cannot evaluate"
+
+    cutoff = datetime.now(timezone.utc) - timedelta(days=DISCOVERY_FRESHNESS_DAYS)
+    most_recent: datetime | None = None
+    most_recent_name: str | None = None
+
+    for r in repos:
+        forked_at = _parse_iso(r.get("forkedAt"))
+        # createdAt is only a row-freshness signal for non-fork rows.
+        is_fork = bool(r.get("forkedFrom") or r.get("forked_from"))
+        created_at = None if is_fork else _parse_iso(r.get("createdAt"))
+
+        for ts in (forked_at, created_at):
+            if ts is None:
+                continue
+            if most_recent is None or ts > most_recent:
+                most_recent = ts
+                most_recent_name = r.get("name")
+
+    assert most_recent is not None, (
+        f"None of {len(repos)} repos had a parseable forkedAt or non-fork "
+        "createdAt timestamp — cannot determine discovery freshness"
+    )
+    assert most_recent >= cutoff, (
+        f"Most recent repo discovery was {most_recent.isoformat()} "
+        f"(repo={most_recent_name!r}), older than the {DISCOVERY_FRESHNESS_DAYS}-day "
+        "freshness ceiling. Fork-discovery sweep is stalled."
     )


### PR DESCRIPTION
## Gap analysis — why this PR exists

The `Nightly Data Invariants` workflow on `reporium-api` has reported **GREEN every day for 10+ consecutive days** (`gh run list --workflow=nightly-invariants.yml`: 2026-04-21 → 2026-04-30, all `success`) while production data is visibly stale:

```
$ curl https://reporium-api-573778300586.us-central1.run.app/trends/report
{"generatedAt":"2026-05-01T00:09:50Z",
 "period":{"from":null,"to":null,"snapshots":0},
 "trending":[], "emerging":[], ...}
```

**Root cause of the false green:** `test_trend_snapshots_exist` in `tests/test_data_invariants.py` was decorated with `@pytest.mark.xfail(strict=False, reason="reporium-ingestion WEEKLY cron stalled — ... until KAN-ingestion cron is unblocked")`. The cron was never unblocked, so the invariant silently went XFAIL on every run — green status, no JIRA notification.

The other "trends look stale" signals were not covered by any invariant:
- No assertion that `period.to` (latest `snapshotted_at`) is *recent* — only that the table is non-empty.
- No assertion on `commitStats.last7Days` — the universal-zero state the commit-refresh stall produces was invisible.
- No assertion that any new repos appear in the corpus over time.

## Changes

`tests/test_data_invariants.py` (single file, +241 / -19):

| # | Test | Status before | Status after |
|---|------|---------------|--------------|
| 3 | `test_trend_snapshots_exist` | xfail strict=False (silent green) | strict assert `period.snapshots > 0` |
| 4 | `test_trend_snapshots_recent` | did not exist | new — assert `period.to >= now - 48h` |
| 5 | `test_commit_stats_not_universally_zero` | did not exist | new — paginate `/library/full`, assert `Σ commitStats.last7Days > 0` |
| 6 | `test_repo_discovery_recent` | did not exist | new — paginate `/library/full`, assert any repo has `forkedAt` (or non-fork `createdAt`) within last 30d |

Module skipif guard (`STAGING_API_URL` unset → all tests skip) is unchanged. PR-time CI (`test.yml`) discovers these tests but they skip cleanly because the secret is only injected in `nightly-invariants.yml`.

## Intended failure pattern (this is the alarm working)

Run with the production staging URL today:

```
$ STAGING_API_URL=https://reporium-api-573778300586.us-central1.run.app     pytest -m invariants -v tests/test_data_invariants.py
test_total_repos_floor                  PASSED   (totalRepos=1861)
test_taxonomy_dimensions_populated      PASSED
test_trend_snapshots_exist              FAILED   (period.snapshots=0)
test_trend_snapshots_recent             FAILED   (period.to is null)
test_commit_stats_not_universally_zero  PASSED   (sum=136 across 15 repos)
test_repo_discovery_recent              PASSED   (most-recent forkedAt 2026-04-02)
2 failed, 4 passed
```

Tests #3 and #4 will **intentionally fail** in tonight's nightly run (08:00 UTC) until the sibling fix that re-enables the trend-snapshot writer (T1) lands and a fresh Cloud Run Job image deploys. That failure is the alarm working — Workato → JIRA notification will fire.

Tests #5 and #6 currently **pass** against production:
- 15/1861 repos have non-zero `commits_last_7_days` (top: `reporium-api`=20, `reporium-trust-score`=20, `Open-Generative-AI`=19); corpus-wide sum = 136. The "every repo == 0" smell described in the original ticket is no longer the live state — but the alarm now exists to catch a future recurrence.
- 25 repos discovered in the last 30 days; most recent fork = `awesome-design-md` on 2026-04-02; most recent non-fork ingest = 2026-04-15. Discovery is sluggish but inside the 30-day ceiling.

## How alarms get cleared

| Failing test | Cleared by |
|---|---|
| `test_trend_snapshots_exist` | T1 — re-enable trend-snapshot writer in reporium-ingestion + redeploy Cloud Run Job. First successful insert flips this green. |
| `test_trend_snapshots_recent` | Same as #3 — first insert's `snapshotted_at` will be < 48h fresh. |
| `test_commit_stats_not_universally_zero` | T2 — only fires if commit-refresh job stalls universally; currently passes. |
| `test_repo_discovery_recent` | T3 — only fires if fork-discovery sweep produces 0 new repos for 30+ days; currently passes. |

These are sibling tickets. This PR only adds the alarms — it does NOT fix the underlying writer.

## Verification

- Full local `pytest tests/`: **534 passed, 233 skipped**, 0 failed. Identical pass count to `origin/dev` baseline; the +3 skips = the 3 new invariants when `STAGING_API_URL` is unset.
- `pytest --collect-only -q tests/`: 767 tests collected (was 763 on dev). Clean import; no syntax errors.
- Workflow trigger surface confirmed: `nightly-invariants.yml` is `schedule:` + `workflow_dispatch:` only — does NOT run on PR. PR-time `test.yml` runs the module but the `pytestmark.skipif` guard skips all 6 invariants because `STAGING_API_URL` is not in the PR-time env.

## Test plan

- [x] Local pytest collection succeeds (767 tests)
- [x] Local full suite parity vs origin/dev (534 passed both)
- [x] Live run against production proves expected fail/pass split
- [x] Module-level skipif gates module on PR CI (no STAGING_API_URL)
- [ ] Tonight's nightly run goes RED on tests #3 + #4 (proves alarms fire)
- [ ] After T1 deploys: nightly run goes GREEN on all 6 (proves alarms clear)