### PR TITLE
KAN-145: scope notify-on-failure to push events on protected branches

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
 
   notify-on-failure:
     needs: test
-    if: failure()
+    if: ${{ failure() && github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') }}
     uses: perditioinc/perditio-devkit/.github/workflows/on-test-failure.yml@aa588479da71164c0bd2ee493a76ee46830d10dc # main @ 2026-04-26
     with:
       branch: ${{ github.ref_name }}


### PR DESCRIPTION
## Problem

The `notify-on-failure` job in `.github/workflows/test.yml` currently fires whenever the Tests workflow ends red, including on the synthetic `pull/N/merge` ref produced by `pull_request` events. Because each red run files an `automated,bug` issue and the bot does not auto-close on the next green run, in-flight PR transients leave lingering issues that read like a regression chain.

Today (2026-04-30) we closed three such issues as PR-cycle transients, not real regressions:

- #437 — synthetic ref of #435 (closed unmerged)
- #446 — synthetic ref of #445 (fixed before merge at `9067c3c4`)
- #451 — synthetic ref of #450 (fixed before merge at `7b0ce4be`)

`main` was green throughout.

## Fix

Scope `notify-on-failure` to fire only on `push` events to protected branches (`main`, `dev`):

```diff
   notify-on-failure:
     needs: test
-    if: failure()
+    if: ${{ failure() && github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') }}
```

PR-cycle failures still surface in the PR's own checks; authors fix them as part of the PR before merge. Only failures that land on a protected branch (i.e., a real regression) open a bug issue.

## Validation

- `python -c "import yaml; yaml.safe_load(open('.github/workflows/test.yml'))"` — YAML parse OK
- `actionlint` not available in this env (npm package not on registry; intentionally not installed globally)
- Workflow change only; no application code touched

## Out of scope

- Auto-closing the existing closed issues (already closed manually)
- Changes to the called reusable workflow `perditioinc/perditio-devkit/.github/workflows/on-test-failure.yml`
- Other workflow tweaks