### PR TITLE
KAN-DRAFT: loud-fail Ask Quality Gate on protected-branch ANTHROPIC_API_KEY absence

### DIFF
--- a/.github/workflows/ask-quality-gate.yml
+++ b/.github/workflows/ask-quality-gate.yml
@@ -42,6 +42,15 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Verify ANTHROPIC_API_KEY is set on protected branches
+        if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') }}
+        run: |
+          if [ -z "${ANTHROPIC_API_KEY:-}" ]; then
+            echo "::error::ANTHROPIC_API_KEY is empty on protected branch '${GITHUB_REF}'. The Ask Quality Gate cannot validate without it. Provision via 'gh secret set ANTHROPIC_API_KEY --repo perditioinc/reporium-api' (canonical source: GCP Secret Manager 'anthropic-api-key')."
+            exit 1
+          fi
+          echo "ANTHROPIC_API_KEY present (${#ANTHROPIC_API_KEY} chars)"
+
       - name: Run numeric golden-set gate for /intelligence/ask
         if: ${{ env.ANTHROPIC_API_KEY != '' }}
         run: |

--- a/tests/test_ask_golden_numeric.py
+++ b/tests/test_ask_golden_numeric.py
@@ -65,10 +65,13 @@ import pytest_asyncio
 import yaml
 from httpx import ASGITransport, AsyncClient
 
-pytestmark = pytest.mark.skipif(
-    not os.getenv("ANTHROPIC_API_KEY"),
-    reason="ANTHROPIC_API_KEY not set — golden-set numeric gate requires live Claude access",
-)
+pytestmark = [
+    pytest.mark.skipif(
+        not os.getenv("ANTHROPIC_API_KEY"),
+        reason="ANTHROPIC_API_KEY not set — golden-set numeric gate requires live Claude access",
+    ),
+    pytest.mark.timeout(600),  # 50+ real Anthropic calls; global 30s budget is insufficient
+]
 
 
 GOLDEN_SET_PATH = Path(__file__).parent / "golden_set_ask.yaml"


### PR DESCRIPTION
## Summary

Defense-in-depth patch to `.github/workflows/ask-quality-gate.yml`: adds an upstream step that fails loudly (with a GitHub Actions `::error::` annotation) when `ANTHROPIC_API_KEY` is empty on a protected-branch push (`main` or `dev`).

## Why now

The Ask Quality Gate (added 2026-04-05) had a defensive `if: ${{ env.ANTHROPIC_API_KEY != '' }}` guard on the test step. Intent: skip-gracefully on fork PRs where GitHub does not propagate org secrets. **Bug: it also silent-skipped on `main`/`dev` because the secret was never provisioned in repo secrets.** The gate appeared green for ~25 days while running zero validation. Issue #367 was filed when four KG-precision P1s (#362-#365) slipped past a "passing" gate.

The secret `ANTHROPIC_API_KEY` was provisioned in repo secrets at **2026-05-02T07:20 UTC** (verified via `gh secret list`). The next protected-branch run executes the test step for real. This PR ensures the silent-skip pattern cannot recur if the secret ever rotates / gets deleted / fails to propagate.

## What changed

A new step is inserted **before** the existing `Run numeric golden-set gate` step:

- Runs only when `github.event_name == 'push'` AND `github.ref` is `refs/heads/main` or `refs/heads/dev`
- If `ANTHROPIC_API_KEY` is empty: emits `::error::` annotation and `exit 1`
- If set: echoes presence-only confirmation (`length`, never the value)

The existing `if: ${{ env.ANTHROPIC_API_KEY != '' }}` guard on the test step is **preserved** — it remains useful for fork PRs where the secret legitimately doesn't propagate.

## Test plan

- [x] YAML validates (`python -c "import yaml; yaml.safe_load(open('.github/workflows/ask-quality-gate.yml'))"`)
- [ ] PR-level CI: this is a `pull_request` to `main` — the new step's `if:` guard is `event_name == 'push'`, so on this PR run the new step is **skipped** (expected). The existing test step uses `env.ANTHROPIC_API_KEY != ''`, so it runs if forks-vs-PR allows.
- [ ] Post-merge to `main`: protected-branch push fires; new step echoes "ANTHROPIC_API_KEY present (N chars)"; test step actually runs (no longer skipped).

Refs: #367