### PR TITLE
KAN-147: nightly graph-quality invariant gate

### DIFF
--- a/.github/workflows/nightly-invariants.yml
+++ b/.github/workflows/nightly-invariants.yml
@@ -37,6 +37,10 @@ jobs:
         env:
           # Populated via: gh secret set STAGING_API_URL -R perditioinc/reporium-api
           STAGING_API_URL: ${{ secrets.STAGING_API_URL }}
+          # KAN-147: required for /metrics/* invariants (X-Admin-Key auth via
+          # require_metrics_access). Without it, the graph-quality invariants
+          # skip rather than fail (see _get_admin helper in test module).
+          ADMIN_API_KEY: ${{ secrets.ADMIN_API_KEY }}
         run: |
           pytest -m invariants -v --tb=short 2>&1 | tee pytest-output.txt
           echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"

--- a/tests/test_data_invariants.py
+++ b/tests/test_data_invariants.py
@@ -87,6 +87,30 @@ def _get(path: str, params: dict | None = None, timeout: float = 60) -> httpx.Re
     return resp
 
 
+def _get_admin(path: str, params: dict | None = None, timeout: float = 60) -> httpx.Response:
+    """Same as _get but adds X-Admin-Key for /metrics/* (require_metrics_access).
+
+    Raises pytest.skip if ADMIN_API_KEY is not set so local runs (no admin key)
+    don't false-fire; the nightly workflow injects it via secret.
+    """
+    admin_key = os.getenv("ADMIN_API_KEY")
+    if not admin_key:
+        pytest.skip("ADMIN_API_KEY not set — required for /metrics/* invariants")
+    url = f"{_base_url()}{path}"
+    headers = {"X-Admin-Key": admin_key}
+    resp = httpx.get(url, params=params, headers=headers, timeout=timeout)
+    return resp
+
+
+def _graph_quality() -> dict:
+    """Fetch /metrics/graph-quality and return parsed JSON dict."""
+    resp = _get_admin("/metrics/graph-quality")
+    assert resp.status_code == 200, (
+        f"GET /metrics/graph-quality returned {resp.status_code}: {resp.text[:300]}"
+    )
+    return resp.json()
+
+
 # ---------------------------------------------------------------------------
 # Invariant 1 — totalRepos floor
 # ---------------------------------------------------------------------------
@@ -198,3 +222,85 @@ def test_trend_snapshots_exist():
         f"trends/report.period.snapshots={snapshots} — "
         "no snapshot data; weekly ingestion cron may not be running"
     )
+
+
+# ---------------------------------------------------------------------------
+# Invariant 7 — graph quality (KAN-147; closes #362/#363/#364 measurement gap)
+# ---------------------------------------------------------------------------
+#
+# Hard-gate from day 1 (no soft-gate window). Workato->JIRA will fire nightly
+# until the four P1 issues' underlying graph-builder regressions are fixed:
+#   #362 ALTERNATIVE_TO precision_proxy ~0.38 (vs floor 0.70)
+#   #363 EXTENDS precision_proxy = 0.0
+#   #364 DEPENDS_ON live_edges floored at 89 (vs floor 1200)
+#   #365 graph quality unmonitored (this gate addresses it)
+# That visible nightly pressure is the design intent.
+
+
+@pytest.mark.invariants
+def test_graph_quality_endpoint_available():
+    """Catches the case where repo_edges table is dropped or _graph_quality_snapshot raises."""
+    snapshot = _graph_quality()
+    assert snapshot.get("available") is True, (
+        f"Graph-quality endpoint reports available=false: {snapshot}"
+    )
+
+
+@pytest.mark.invariants
+def test_graph_quality_precision_floors():
+    """Asserts precision/precision_proxy floors per edge type. Hard-gate from day 1.
+
+    KAN-147: known-broken metrics from issues #362 (ALTERNATIVE_TO 0.38),
+    #363 (EXTENDS 0.0). Will fire Workato->JIRA nightly until the underlying
+    graph-builder regressions are fixed. That is intentional.
+    """
+    PRECISION_FLOOR_EXACT = 0.95   # DEPENDS_ON exact match (not proxy)
+    PRECISION_FLOOR_PROXY = 0.70   # ALTERNATIVE_TO / EXTENDS / COMPATIBLE_WITH (issue authors' value)
+
+    snapshot = _graph_quality()
+    edge_types = snapshot.get("edge_types", {})
+
+    failures = []
+
+    deps = edge_types.get("DEPENDS_ON", {})
+    if "precision" in deps and deps["precision"] < PRECISION_FLOOR_EXACT:
+        failures.append(f"DEPENDS_ON.precision={deps['precision']:.4f} < {PRECISION_FLOOR_EXACT}")
+
+    for et in ("ALTERNATIVE_TO", "EXTENDS", "COMPATIBLE_WITH"):
+        info = edge_types.get(et, {})
+        proxy = info.get("precision_proxy")
+        if proxy is not None and proxy < PRECISION_FLOOR_PROXY:
+            failures.append(f"{et}.precision_proxy={proxy:.4f} < {PRECISION_FLOOR_PROXY}")
+
+    assert not failures, "Graph-quality precision regressions: " + "; ".join(failures)
+
+
+@pytest.mark.invariants
+def test_graph_quality_edge_count_floors():
+    """Asserts edge-count floors per type to catch the snapshot/edge-balancer
+    clobber pattern (#364: DEPENDS_ON normally 1300+, dropped to 89 silently).
+    """
+    EDGE_COUNT_FLOORS = {
+        "DEPENDS_ON":     1200,
+        "ALTERNATIVE_TO": 5000,
+        "EXTENDS":         100,
+        "COMPATIBLE_WITH": 100,
+    }
+    TOTAL_EDGES_FLOOR = 8000
+
+    snapshot = _graph_quality()
+    summary = snapshot.get("summary", {})
+    edge_types = snapshot.get("edge_types", {})
+
+    failures = []
+    total = summary.get("total_edges", 0)
+    if total < TOTAL_EDGES_FLOOR:
+        failures.append(f"total_edges={total} < {TOTAL_EDGES_FLOOR}")
+
+    for et, floor in EDGE_COUNT_FLOORS.items():
+        info = edge_types.get(et, {})
+        live = info.get("live_edges", 0)
+        if live < floor:
+            failures.append(f"{et}.live_edges={live} < {floor}")
+
+    assert not failures, "Graph-quality edge-count regressions: " + "; ".join(failures)


### PR DESCRIPTION
## Summary

Wires the existing `GET /metrics/graph-quality` endpoint (shipped in PR #393, un-asserted for 14 days) into the nightly invariants suite as three new tests in `tests/test_data_invariants.py`:

- `test_graph_quality_endpoint_available` — catches `available=false`
- `test_graph_quality_precision_floors` — `DEPENDS_ON.precision >= 0.95`; `ALTERNATIVE_TO/EXTENDS/COMPATIBLE_WITH.precision_proxy >= 0.70`
- `test_graph_quality_edge_count_floors` — per-type `live_edges` floors (1200/5000/100/100) and `total_edges >= 8000`

Adds an `_get_admin` / `_graph_quality` helper because `/metrics/*` is gated by `require_metrics_access` (X-Admin-Key, not the X-App-Token used by other paths).

Wires `ADMIN_API_KEY` secret into `.github/workflows/nightly-invariants.yml`. Secret already existed (verified via `gh secret list`); only the workflow env block needed updating.

## Design intent: day-1 hard-gate

Day-1 hard-gate. Workato->JIRA will fire nightly until the four P1s (#362 / #363 / #364 / #365) underlying graph-builder regressions are fixed. That visible nightly pressure is the goal. Known-broken metrics on staging today:

- `EXTENDS.precision_proxy = 0.0` (#363)
- `ALTERNATIVE_TO.precision_proxy = 0.3846` (#362)
- `DEPENDS_ON.live_edges = 89` floored (#364, normally 1300+)

These will trip the new gates on the next nightly run. That is intentional — converts 14-day silent debt into a daily JIRA signal until the graph-builder is fixed.

Design memo: `.audit/2026-05-02/graph-quality-gate-design.md`
JIRA: https://perditio.atlassian.net/browse/KAN-147

## Constraints honored

- Single-file edit to `tests/test_data_invariants.py` + 1 yaml line for ADMIN_API_KEY wiring
- Did NOT reshape the endpoint response (`tests/test_platform_metrics.py:204-222` still pins the shape)
- Did NOT remove or reorder the existing 3 invariants
- Did NOT change the workflow cron schedule
- Did NOT lower the precision floors below the issue authors' values

## Test plan

- [x] `python -m py_compile tests/test_data_invariants.py`
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/nightly-invariants.yml'))"`
- [x] `pytest tests/test_data_invariants.py --collect-only -m invariants` collects all 6 (3 existing + 3 new)
- [x] `pytest tests/test_data_invariants.py --collect-only` collects all 6
- [ ] Post-merge: trigger nightly-invariants workflow_dispatch and verify the 3 new tests fail with the expected precision/edge-count messages