### PR TITLE
KAN-148: fix nightly-invariants silent no-op (deps + pipefail + secret)

### DIFF
--- a/.github/workflows/nightly-invariants.yml
+++ b/.github/workflows/nightly-invariants.yml
@@ -28,9 +28,14 @@ jobs:
           cache: pip
 
       - name: Install dependencies
+        # KAN-148: install full requirements so tests/conftest.py imports
+        # (sqlalchemy, app.database, app.main) resolve. Previously this only
+        # installed httpx + pytest + pytest-asyncio, so conftest crashed with
+        # ModuleNotFoundError: sqlalchemy before any test could run — causing
+        # the workflow to silently no-op while reporting SUCCESS.
         run: |
           pip install --upgrade pip
-          pip install httpx pytest pytest-asyncio
+          pip install -r requirements.txt
 
       - name: Run invariant tests
         id: invariants
@@ -41,7 +46,12 @@ jobs:
           # require_metrics_access). Without it, the graph-quality invariants
           # skip rather than fail (see _get_admin helper in test module).
           ADMIN_API_KEY: ${{ secrets.ADMIN_API_KEY }}
+        # KAN-148: `set -o pipefail` ensures pytest's non-zero exit propagates
+        # through the `| tee` pipeline. Without it, tee's exit 0 masked pytest
+        # failures and the step (and job) reported SUCCESS even when tests
+        # errored out at collection time.
         run: |
+          set -o pipefail
           pytest -m invariants -v --tb=short 2>&1 | tee pytest-output.txt
           echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## Summary

The `Nightly Data Invariants` workflow has been reporting `SUCCESS` while running ZERO tests for at least 5 days. All 7+ wired invariants (KAN-147 graph-quality + the existing 6) have been **inert** until this lands.

Three compounding bugs masked each other. Each on its own would have produced a visible failure; together they conspired to produce a silent green check.

### Bug #1 — `STAGING_API_URL` secret unset
- Every test in `tests/test_data_invariants.py` has `pytestmark.skipif(not STAGING_API_URL, ...)`. With the secret empty, every test silently skipped.
- **Fixed externally**: secret provisioned at `2026-05-02T12:27:59Z` to `https://reporium-api-573778300586.us-central1.run.app` (production URL — no staging Cloud Run exists; metrics endpoints are read-only so safe to hit prod from CI).
- The YAML reference on line 44 was already correct; no code change needed for this bug, but #2 and #3 wouldn't have helped without the secret being live.

### Bug #2 — workflow installs incomplete deps (this PR)
- Old: `pip install httpx pytest pytest-asyncio`
- `tests/conftest.py` imports `sqlalchemy`, `app.database`, `app.main`, etc. — so collection crashed with `ModuleNotFoundError: sqlalchemy` before any test ran.
- **Fix**: `pip install -r requirements.txt`. The pinned `sqlalchemy[asyncio]==2.0.35` and all other conftest imports come along for free.

### Bug #3 — `tee` masks pytest exit code (this PR)
- Old: `pytest ... 2>&1 | tee pytest-output.txt`
- Without `set -o pipefail`, `tee`'s exit 0 wins and the step (and job) report SUCCESS even when pytest exits non-zero.
- **Fix**: `set -o pipefail` immediately before the pipeline.

## What lands when this merges
- KAN-147's nightly graph-quality gate (precision floors + edge-count floors) becomes live.
- The pre-existing 6 invariants resume running for the first time in 5+ days.

## Expected post-merge outcome: FAILURE (by design)
The four open P1s — #362, #363, #364 — document real graph-quality regressions in prod. The graph-quality precision/edge-count assertions are **expected to fail tonight**. That visible failure is the design intent of KAN-147; it is the first real measurement signal we'll have on those P1s.

If the post-merge manual run comes back GREEN, that contradicts the P1 issue bodies and warrants drilling into per-test conclusions.

## CI scope of this PR
The PR's own CI does NOT run `nightly-invariants.yml` — that workflow only fires on `cron` + `workflow_dispatch`. The standard PR checks (test, migration-smoke, ask-quality-gate) should pass independently and are unrelated to this YAML change.

## Test plan
- [ ] Confirm `gh secret list --repo perditioinc/reporium-api` shows `STAGING_API_URL` (already verified: provisioned `2026-05-02T12:27:59Z`).
- [ ] After merge: `gh workflow run nightly-invariants.yml --repo perditioinc/reporium-api`.
- [ ] Confirm conclusion=`failure` (expected) AND that pytest collection succeeded (i.e., the failure is from assertions, not from `ModuleNotFoundError`).
- [ ] Capture the failing assertion messages verbatim — these are the first real measurement signal on the four P1s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)