### PR TITLE
KAN-167: graph-quality floors realigned with corpus reality

### DIFF
--- a/tests/test_data_invariants.py
+++ b/tests/test_data_invariants.py
@@ -280,22 +280,39 @@ def test_graph_quality_edge_count_floors():
     """Asserts edge-count floors per type to catch the snapshot/edge-balancer
     clobber pattern.
 
-    KAN-156: DEPENDS_ON floor lowered from 1200 to 150. The original 1200
-    was aspirational, not measured: only ~89-150 dependency package names
-    happen to match in-DB repo names by coincidence (most pypi/npm packages
-    aren't tracked Reporium repos). 150 gives slack above current cardinality
-    while still catching dramatic regressions (e.g., the historical drop to 89
-    that #364 originally reported was within this band — but flagging the
-    expected steady-state as a regression was a false signal).
+    Goal of this gate: catch REGRESSIONS, not flag known-state. Floors should
+    sit just below current observed steady-state so that meaningful drops fire
+    while expected cardinality does not.
+
+    KAN-156: DEPENDS_ON floor lowered 1200 -> 150 (the original 1200 was
+    aspirational, not measured).
+    KAN-167: DEPENDS_ON floor lowered 150 -> 80. Post-KAN-156 nightly still
+    fired on live_edges=89 < 150. Investigation confirmed 89 reflects actual
+    corpus reality: only ~89 dependency package names happen to match in-DB
+    repo names by coincidence (most pypi/npm packages aren't tracked Reporium
+    repos). 80 gives slack above current ~89 cardinality while still catching
+    dramatic regressions.
+
+    KAN-167: COMPATIBLE_WITH dropped from EDGE_COUNT_FLOORS entirely. The
+    current build_compatible_with() rule (>=2 shared integration_tags) plus
+    sparse integration_tags data produces 0 edges. Asserting a count floor
+    is a known-state false positive. The precision_proxy assertion in
+    test_graph_quality_precision_floors still fires when COMPATIBLE_WITH
+    edges DO exist, so quality regressions are still caught. Once the
+    builder is tuned (KAN-158 follow-up), reinstate a count floor here.
 
     Future: once nightly history is captured, convert to delta-based check
     (live_edges >= prev_run * 0.8) per the original P1 investigation memo.
     """
     EDGE_COUNT_FLOORS = {
-        "DEPENDS_ON":     150,    # KAN-156: was 1200 (aspirational); reflects actual corpus reality
+        "DEPENDS_ON":     80,     # KAN-167: lowered from 150 (KAN-156). Most pypi/npm pkg names
+                                  # don't match in-DB repo names; current ~89 is corpus reality.
+                                  # Floor at 80 catches dramatic regressions without false positives.
         "ALTERNATIVE_TO": 5000,
         "EXTENDS":         100,
-        "COMPATIBLE_WITH": 100,
+        # COMPATIBLE_WITH removed (KAN-167) — current builder produces 0 edges given the
+        # >=2-shared-integration_tags rule on sparse tag data. Once builder is tuned (KAN-158
+        # follow-up), reinstate the floor. Edge precision_proxy is still asserted when edges exist.
     }
     TOTAL_EDGES_FLOOR = 8000
 


### PR DESCRIPTION
## Summary

Second floor-tweak in a row (after KAN-156's 1200->150). Post-KAN-156 nightly invariants still fire on two metrics that reflect corpus reality, not regressions:

- `DEPENDS_ON.live_edges=89 < 150` — only ~89 dependency package names happen to match in-DB repo names by coincidence. Most pypi/npm packages aren't tracked Reporium repos. Lower floor to **80** for slack above current cardinality.
- `COMPATIBLE_WITH.live_edges=0 < 100` — current `build_compatible_with()` rule (>=2 shared `integration_tags`) on sparse tag data produces 0 edges. **Drop count floor entirely**; precision_proxy assertion still fires when edges exist, so quality regressions are still caught. Reinstate once the builder is tuned (KAN-158 follow-up).

## Goal of this gate

Catch REGRESSIONS, not flag known-state. Floors should sit just below current observed steady-state so meaningful drops fire while expected cardinality does not. Daily Workato->JIRA noise on these two metrics was the cost of aspirational floors.

## What's NOT changing

- `precision_proxy` floors (KAN-158 + KAN-157 own those — different surface)
- `precision_proxy` assertions for any edge type (still fire when edges exist)
- `ALTERNATIVE_TO` (5000) and `EXTENDS` (100) count floors
- `TOTAL_EDGES_FLOOR` (8000)

`test_graph_quality_precision_floors` will continue to fail post-merge on `EXTENDS=0.0` and `ALTERNATIVE_TO=0.6557` — that's correct, those are real signals. KAN-157 architectural fork covers them.

## Refs

- KAN-167 (this ticket)
- KAN-158 (parent — implementation hand-off)
- KAN-156 (prior floor tweak: 1200 -> 150)
- KAN-157 (architectural fork — owns EXTENDS precision)

## Test plan

- [x] `python -m py_compile tests/test_data_invariants.py`
- [x] `pytest tests/test_data_invariants.py --collect-only -m invariants` (6 tests collected)
- [ ] CI green
- [ ] Post-merge: `nightly-invariants.yml` triggered manually; `test_graph_quality_edge_count_floors` PASSES
- [ ] Post-merge: `test_graph_quality_precision_floors` STILL FAILS as designed (KAN-157 owns)