### PR TITLE
KAN-169: close /intelligence/ask cache-hit gap from KAN-166

### DIFF
--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -2718,6 +2718,13 @@ class QueryContext:
     t_embed_ms: float = 0.0
     t_search_ms: float = 0.0
     t_context_ms: float = 0.0
+    # KAN-169: when True, skip both Redis and semantic-cache lookup AND skip
+    # writing this query's response back to either cache. Closes the cache-hit
+    # gap left by KAN-166: the negation post-filter only runs on the live
+    # retrieval path, so cached entries created before the fix (or by a
+    # not-yet-categorized variant) could re-surface a self-match. Set when
+    # _extract_negation_token captures a token.
+    skip_cache: bool = False
 
 
 async def _prepare_query(
@@ -2762,25 +2769,47 @@ async def _prepare_query(
     # "What is an LLM?" and "what is a large language model" share a cache row.
     normalized_question = _normalize_question(question)
     redis_cache_key = f"llm_response:{hashlib.md5(normalized_question.encode()).hexdigest()}"
-    redis_cached = await cache.get(redis_cache_key)
-    if redis_cached is not None:
-        logger.info("ask: Redis cache hit for question")
-        return QueryContext(
-            sources=redis_cached.get("sources", []),
-            context_text="",
-            model=redis_cached.get("model", "redis-cache"),
-            session_history=[],
-            cache_result={
-                "answer": redis_cached["answer"],
-                "sources": redis_cached.get("sources", []),
-                "tokens_used": redis_cached.get("tokens_used", {"input": 0, "output": 0, "total": 0}),
-                "cache_source": "redis",
-                "cache_hit": True,
-            },
-            query_embedding=None,
-            route_label=None,
-            redis_cache_key=redis_cache_key,
+
+    # KAN-169: detect negation queries and bypass the cache. Closes the gap
+    # left by KAN-166: the negation post-filter runs on the live retrieval
+    # path only, so a cached entry written before the fix (or under a query
+    # variant that didn't trip the regex) can still surface a self-match on
+    # HIT. We:
+    #   - skip the Redis lookup AND the semantic-cache lookup below
+    #   - leave redis_cache_key empty so the handler's cache.set is gated off
+    #     by the existing `if qctx.redis_cache_key:` checks
+    #   - drop redis_cache_key from the QueryContext returned at the end so
+    #     this query's answer is never written back to Redis either
+    # Negation queries are a small fraction of traffic, so the cache-miss cost
+    # is negligible relative to the correctness win.
+    _negated_token_for_cache = _extract_negation_token(question)
+    skip_cache = _negated_token_for_cache is not None
+    if skip_cache:
+        logger.info(
+            "ask: cache bypass for negation query (token=%r)",
+            _negated_token_for_cache,
         )
+
+    if not skip_cache:
+        redis_cached = await cache.get(redis_cache_key)
+        if redis_cached is not None:
+            logger.info("ask: Redis cache hit for question")
+            return QueryContext(
+                sources=redis_cached.get("sources", []),
+                context_text="",
+                model=redis_cached.get("model", "redis-cache"),
+                session_history=[],
+                cache_result={
+                    "answer": redis_cached["answer"],
+                    "sources": redis_cached.get("sources", []),
+                    "tokens_used": redis_cached.get("tokens_used", {"input": 0, "output": 0, "total": 0}),
+                    "cache_source": "redis",
+                    "cache_hit": True,
+                },
+                query_embedding=None,
+                route_label=None,
+                redis_cache_key=redis_cache_key,
+            )
 
     t_smart = time.perf_counter()
 
@@ -2833,26 +2862,28 @@ async def _prepare_query(
             redis_cache_key=redis_cache_key,
         )
 
-    # 2. Semantic cache check
-    cached = await _find_semantic_cache_hit(db, question_embedding=query_embedding)
-    if cached is not None:
-        cached_answer, cached_sources, cached_model = cached
-        return QueryContext(
-            sources=[s.model_dump() for s in cached_sources],
-            context_text="",
-            model=cached_model or "semantic-cache",
-            session_history=[],
-            cache_result={
-                "answer": cached_answer,
-                "sources": [s.model_dump() for s in cached_sources],
-                "tokens_used": {"input": 0, "output": 0, "total": 0},
-                "cache_source": "semantic",
-                "cache_hit": True,
-            },
-            query_embedding=query_embedding.tolist() if hasattr(query_embedding, 'tolist') else list(query_embedding),
-            route_label=None,
-            redis_cache_key=redis_cache_key,
-        )
+    # 2. Semantic cache check — KAN-169: skipped for negation queries; see
+    # the cache-bypass block above for rationale.
+    if not skip_cache:
+        cached = await _find_semantic_cache_hit(db, question_embedding=query_embedding)
+        if cached is not None:
+            cached_answer, cached_sources, cached_model = cached
+            return QueryContext(
+                sources=[s.model_dump() for s in cached_sources],
+                context_text="",
+                model=cached_model or "semantic-cache",
+                session_history=[],
+                cache_result={
+                    "answer": cached_answer,
+                    "sources": [s.model_dump() for s in cached_sources],
+                    "tokens_used": {"input": 0, "output": 0, "total": 0},
+                    "cache_source": "semantic",
+                    "cache_hit": True,
+                },
+                query_embedding=query_embedding.tolist() if hasattr(query_embedding, 'tolist') else list(query_embedding),
+                route_label=None,
+                redis_cache_key=redis_cache_key,
+            )
 
     t_embed = time.perf_counter()
 
@@ -3064,6 +3095,13 @@ async def _prepare_query(
         (t_context - t0) * 1000,
     )
 
+    # KAN-169: when negation bypass is active, blank out redis_cache_key. The
+    # handler's cache writes are gated on `if qctx.redis_cache_key:`, so an
+    # empty string prevents this answer from being written back to Redis.
+    # Combined with skip_cache=True (which the handler also reads to suppress
+    # writing the embedding to query_log), this closes the semantic-cache
+    # write path too — preventing future negation-shaped queries from hitting
+    # a stale row.
     return QueryContext(
         sources=[{
             "name": r["name"],
@@ -3082,7 +3120,8 @@ async def _prepare_query(
         query_embedding=query_embedding.tolist() if hasattr(query_embedding, 'tolist') else list(query_embedding),
         route_label=None,
         embedding_candidates=len(scored),
-        redis_cache_key=redis_cache_key,
+        redis_cache_key="" if skip_cache else redis_cache_key,
+        skip_cache=skip_cache,
         t_smart_ms=(t_smart - t0) * 1000,
         t_embed_ms=(t_embed - t_smart) * 1000,
         t_search_ms=(t_search - t_embed) * 1000,
@@ -3393,7 +3432,13 @@ async def _run_query(
         "tokens_used": tokens_used,
         "model": qctx.model,
     }
-    if _negative:
+    # KAN-169: gate Redis writes on redis_cache_key; the negation-bypass path
+    # in _prepare_query clears the key so this query's response is never
+    # written back to the cache.
+    if not qctx.redis_cache_key:
+        if qctx.skip_cache:
+            logger.info("ask: skipping Redis cache write (negation bypass)")
+    elif _negative:
         _cache_payload["negative"] = True
         asyncio.create_task(cache.set(qctx.redis_cache_key, _cache_payload, ttl=60)).add_done_callback(_task_done_callback)
         logger.info("ask: negative-cached low-quality answer (len=%d)", len(answer or ""))
@@ -3405,9 +3450,12 @@ async def _run_query(
     # invisible to the pgvector-backed semantic cache lookup (which filters
     # ``question_embedding_vec IS NOT NULL``). Keeps observability while
     # preventing bad answers from being recycled.
+    # KAN-169: same NULL-embedding trick for negation-bypass queries — keeps
+    # the row in query_log for observability but prevents the semantic cache
+    # from ever surfacing it on a future "alternatives to X" lookup.
     _log_embedding = (
         None
-        if _negative
+        if (_negative or qctx.skip_cache)
         else (np.array(qctx.query_embedding) if qctx.query_embedding else None)
     )
     asyncio.create_task(_log_query(
@@ -3887,16 +3935,24 @@ async def intelligence_ask_stream(
                         "tokens_used": tokens_info,
                         "model": qctx.model,
                     }
-                    if _stream_negative:
+                    # KAN-169: gate Redis writes on redis_cache_key; negation
+                    # bypass in _prepare_query clears the key so the streamed
+                    # answer is never written back to the cache.
+                    if not qctx.redis_cache_key:
+                        if qctx.skip_cache:
+                            logger.info("ask/stream: skipping Redis cache write (negation bypass)")
+                    elif _stream_negative:
                         _stream_payload["negative"] = True
                         asyncio.create_task(cache.set(qctx.redis_cache_key, _stream_payload, ttl=60)).add_done_callback(_task_done_callback)
                         logger.info("ask/stream: negative-cached low-quality answer (len=%d)", len(full_answer or ""))
                     else:
                         asyncio.create_task(cache.set(qctx.redis_cache_key, _stream_payload, ttl=1800)).add_done_callback(_task_done_callback)
-                    # Fire-and-forget log
+                    # Fire-and-forget log — KAN-169: NULL embedding for
+                    # negation-bypass queries so the semantic cache can never
+                    # recycle this row on a future "alternatives to X" lookup.
                     _stream_log_embedding = (
                         None
-                        if _stream_negative
+                        if (_stream_negative or qctx.skip_cache)
                         else (np.array(qctx.query_embedding) if qctx.query_embedding else None)
                     )
                     asyncio.create_task(_log_query(

--- a/tests/test_intelligence_quality.py
+++ b/tests/test_intelligence_quality.py
@@ -820,3 +820,180 @@ async def test_ask_no_negation_no_filter(client_no_db: AsyncClient):
     assert "pinecone-python-client" in source_names
     # And the others stay too.
     assert "weaviate" in source_names
+
+
+# ---------------------------------------------------------------------------
+# KAN-169: cache-hit gap from KAN-166 — negation queries must bypass cache
+#
+# KAN-166 added a post-filter that drops "alternatives to X" self-matches at
+# retrieval time. But the cache layers (Redis fast-path + pgvector semantic
+# cache) sit BEFORE the post-filter, so an entry written before the fix (or
+# under a query variant the regex didn't catch) can still surface a stale
+# self-match on HIT for up to TTL=1800s.
+#
+# Approach A (chosen): when _extract_negation_token captures a token, skip
+# both cache lookups in _prepare_query AND skip both cache writes in the
+# handler. Negation queries are rare; the cache-miss cost is well worth the
+# correctness guarantee.
+# ---------------------------------------------------------------------------
+
+
+def _patch_cache(llm_response_returns=None):
+    """
+    Patch app.routers.intelligence.cache.get to return ``llm_response_returns``
+    when called with a key matching the ``llm_response:`` prefix (the Redis
+    fast-path used by _prepare_query for the negation-bypass test). All other
+    cache namespaces (smart_route, graph_edges, etc.) get None — otherwise the
+    same stale payload would be misinterpreted as a smart-route result and
+    short-circuit before our negation gate even runs.
+
+    cache.set is replaced with a tracking AsyncMock so the test can assert it
+    is NOT called for negation queries (proves write-side bypass).
+
+    Uses ``new=AsyncMock(...)`` rather than ``side_effect`` so the patched
+    attribute is awaitable — a plain MagicMock would hang on ``await``.
+    """
+    from unittest.mock import AsyncMock
+
+    async def _get_side_effect(key):
+        if key and isinstance(key, str) and key.startswith("llm_response:"):
+            return llm_response_returns
+        return None
+
+    get_mock = AsyncMock(side_effect=_get_side_effect)
+    set_mock = AsyncMock()
+
+    cache_get_patch = patch(
+        "app.routers.intelligence.cache.get",
+        new=get_mock,
+    )
+    cache_set_patch = patch(
+        "app.routers.intelligence.cache.set",
+        new=set_mock,
+    )
+    return cache_get_patch, cache_set_patch, set_mock
+
+
+@pytest.mark.asyncio
+async def test_ask_negation_bypasses_cache(client_no_db: AsyncClient):
+    """
+    KAN-169: a negation query ("alternatives to pinecone") must bypass the
+    Redis cache even if a stale entry from before KAN-166 still has pinecone
+    in its sources. We pre-populate cache.get with that stale payload and
+    verify the live response is filtered AND that cache.set is NOT called
+    for this query (so the bypass is symmetric — no future calls inherit
+    a fresh self-match either).
+    """
+    from app.main import app
+    from app.database import get_db
+
+    _, override = _override_db(NEGATION_ROWS)
+    app.dependency_overrides[get_db] = override
+
+    # Stale cache entry: pre-fix payload that includes pinecone in sources.
+    # If the bypass works, this should NEVER appear in the response.
+    stale_payload = {
+        "answer": "STALE: Pinecone is the best vector database!",
+        "sources": [{
+            "name": "pinecone-python-client",
+            "owner": "pinecone-io",
+            "forked_from": "pinecone-io/pinecone-python-client",
+            "relevance_score": 0.95,
+            "integration_tags": ["vector-db", "managed"],
+        }],
+        "tokens_used": {"input": 0, "output": 0, "total": 0},
+        "model": "stale-cache",
+    }
+
+    cache_get_patch, cache_set_patch, set_mock = _patch_cache(llm_response_returns=stale_payload)
+
+    with (
+        _patch_embedding_model(),
+        _patch_anthropic_key(),
+        _patch_anthropic(),
+        _patch_log_query(),
+        _patch_create_task(),
+        cache_get_patch,
+        cache_set_patch,
+    ):
+        try:
+            response = await client_no_db.post(
+                "/intelligence/ask",
+                json={"question": "vector database alternatives to pinecone"},
+            )
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    # Stale cache answer must NOT have leaked through.
+    assert "STALE" not in data["answer"], (
+        "KAN-169 regression: stale cache entry returned for a negation query"
+    )
+    # Sources must NOT include pinecone — proves the negation filter ran on
+    # the live retrieval path (not the bypassed cache).
+    for s in data["sources"]:
+        full = f"{(s.get('owner') or '').lower()}/{(s.get('name') or '').lower()}"
+        assert "pinecone" not in full, (
+            f"KAN-169 regression: pinecone leaked into sources via cache as {full!r}"
+        )
+    # And cache.set must NOT have been called for this negation query — so
+    # this turn's response can't pollute future cache hits either.
+    assert set_mock.call_count == 0, (
+        f"KAN-169 regression: cache.set was called {set_mock.call_count} times "
+        f"for a negation query (expected 0). Calls: {set_mock.call_args_list}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ask_non_negation_uses_cache(client_no_db: AsyncClient):
+    """
+    KAN-169: a non-negation query MUST still use the Redis cache fast-path.
+    Verifies the bypass is scoped to negation queries only (no regression
+    on cache hit rate for the common case).
+    """
+    from app.main import app
+    from app.database import get_db
+
+    _, override = _override_db(GOLDEN_ROWS)
+    app.dependency_overrides[get_db] = override
+
+    # Cached entry for a normal RAG-frameworks question — must be returned.
+    cached_payload = {
+        "answer": "CACHED: LangChain and LlamaIndex are great RAG frameworks.",
+        "sources": [{
+            "name": "langchain",
+            "owner": "langchain-ai",
+            "forked_from": "langchain-ai/langchain",
+            "relevance_score": 0.93,
+            "integration_tags": ["llm", "rag"],
+        }],
+        "tokens_used": {"input": 0, "output": 0, "total": 0},
+        "model": "redis-cache",
+    }
+
+    cache_get_patch, cache_set_patch, set_mock = _patch_cache(llm_response_returns=cached_payload)
+
+    with (
+        _patch_embedding_model(),
+        _patch_anthropic_key(),
+        _patch_anthropic(),
+        _patch_log_query(),
+        _patch_create_task(),
+        cache_get_patch,
+        cache_set_patch,
+    ):
+        try:
+            response = await client_no_db.post(
+                "/intelligence/ask",
+                json={"question": "What are the best RAG frameworks?"},
+            )
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 200, response.text
+    data = response.json()
+    # Cache hit was honored — the cached answer text must come through.
+    assert data["answer"].startswith("CACHED:"), (
+        "KAN-169 regression: non-negation query did NOT use the Redis cache"
+    )


### PR DESCRIPTION
## The Gap

KAN-166 (PR #465, merged `ee558aa`) added a negation post-filter to `/intelligence/ask` so queries like "alternatives to pinecone" no longer surface pinecone in the response. But the filter runs *only* on the live retrieval path, **after** the cache lookup. So:

- Cached entries written before the fix can still serve a self-match on HIT for up to `TTL=1800s`.
- A query variant the regex didn't catch (e.g. someone asks "what is pinecone good at?", caches normally, then later asks "alternatives to pinecone" — same normalized form) can re-surface the pre-fix payload.
- The semantic cache (pgvector) has the same shape, with a longer effective TTL (rows live in `query_log` indefinitely).

## Approach A — cache bypass for negation queries

When `_extract_negation_token` captures a token in `_prepare_query`:
- skip the Redis fast-path lookup
- skip the semantic-cache lookup
- leave `redis_cache_key=""` so the existing `if qctx.redis_cache_key:` guards in the handler suppress the cache write
- write a NULL embedding to `query_log` (same trick already used for low-quality answers) so the semantic cache can never recycle this row on a future "alternatives to X" lookup

Picked over Approach B (re-apply filter on hit) because:
- pre-fix cached entries would otherwise need re-filtering on every read for the full TTL, not just for new entries
- the cached payload's source list might lose context the dropped repo carried (e.g., a cached answer that *names* pinecone in the prose can't be cleaned up by filtering sources alone)
- negation queries are a small fraction of traffic, so the cache-miss cost is negligible

## Why non-negation cache hit rate is preserved

The bypass is gated entirely on `_extract_negation_token(question) is not None`. No existing path is modified for non-negation queries — same Redis lookup, same semantic cache, same `cache.set` writes. New test `test_ask_non_negation_uses_cache` proves a "What are the best RAG frameworks?" query still honors the cached payload.

## Tests

- `test_ask_negation_bypasses_cache` — pre-populates Redis with a stale self-match payload (`STALE: Pinecone is the best...`); issues "vector database alternatives to pinecone"; asserts the response answer doesn't contain "STALE", asserts no source contains "pinecone", asserts `cache.set` was called 0 times (proves write-side bypass).
- `test_ask_non_negation_uses_cache` — pre-populates Redis with a `CACHED:` payload; issues a normal "best RAG frameworks" query; asserts the response answer starts with `CACHED:` (proves cache hit honored).

Tests follow the same pattern as the existing KAN-166 e2e suite (`test_ask_negation_drops_self_match` etc.). Local async-client tests on Windows hang in this dev box for unrelated reasons (`pytest-timeout` not installed; `client_no_db` fixture lifespan probe); CI runs the full suite on Linux.

## Constraints satisfied

- KAN-166's filter logic is untouched
- Caching is only bypassed for the negation path (every other query still hits Redis + semantic cache)
- Streaming and non-streaming handlers both gated symmetrically

## Test plan

- [ ] CI green on `tests/test_intelligence_quality.py` (full suite, including the 2 new cases)
- [ ] `ask-quality-gate` golden set still passes (no regression on baseline questions)
- [ ] Defensive rollup check passes
- [ ] Manual smoke after deploy: `curl -X POST .../intelligence/ask -d '{"question":"alternatives to pinecone"}'` should not include pinecone in `sources` even if a stale entry was previously cached for that query

JIRA: https://perditio.atlassian.net/browse/KAN-169

🤖 Generated with [Claude Code](https://claude.com/claude-code)