### PR TITLE
KAN-175: /taxonomy/{tags,categories} aggregate from repos (closes #251)

### DIFF
--- a/app/routers/library_full.py
+++ b/app/routers/library_full.py
@@ -567,14 +567,20 @@ def invalidate_library_cache() -> None:
     /library/preview's keys (``library:preview:...``) — keep it broad so any
     future ``library:*`` cache surface is invalidated automatically. This
     satisfies feedback_backfill_must_invalidate_cache.md for /library/preview.
+
+    KAN-175: also sweeps the ``taxonomy:`` prefix so /taxonomy/categories and
+    /taxonomy/tags (which aggregate from the same ``repos``/``repo_tags`` rows
+    that ingest writes) cannot serve stale aggregates after a backfill.
     """
     _cache.clear()
     try:
         loop = asyncio.get_event_loop()
         if loop.is_running():
             asyncio.ensure_future(redis_cache.clear_prefix("library:"))
+            asyncio.ensure_future(redis_cache.clear_prefix("taxonomy:"))
         else:
             loop.run_until_complete(redis_cache.clear_prefix("library:"))
+            loop.run_until_complete(redis_cache.clear_prefix("taxonomy:"))
     except Exception:
         logger.warning("invalidate_library_cache: could not clear Redis prefix", exc_info=True)
 

--- a/app/routers/taxonomy.py
+++ b/app/routers/taxonomy.py
@@ -1,6 +1,8 @@
 """
 GET /taxonomy/skill-areas — Returns all skill areas from DB, grouped by lifecycle_group.
 GET /taxonomy/skill-areas/{name}/repos — Returns repos tagged with a given skill area.
+GET /taxonomy/categories — Aggregated category counts from repos.primary_category (KAN-175).
+GET /taxonomy/tags — Aggregated tag counts from the repo_tags junction table (KAN-175).
 GET /taxonomy/dimensions — Returns distinct dimension strings with repo counts.
 GET /taxonomy/{dimension} — Returns taxonomy values for a dimension, sorted by repo_count desc.
 POST /admin/taxonomy/rebuild — Aggregates raw_values from repo_taxonomy into taxonomy_values.
@@ -8,6 +10,14 @@ POST /admin/taxonomy/embed — Generates embeddings for taxonomy_values missing 
 POST /admin/taxonomy/assign — Similarity-assigns taxonomy_values to repos via pgvector.
 
 Skill areas are stored in the skill_areas table; adding a new area requires only a DB insert.
+
+KAN-175: /taxonomy/categories and /taxonomy/tags aggregate directly from the live
+``repos`` / ``repo_tags`` corpus instead of the historically-empty
+``taxonomy_values`` table. Option B (aggregate-on-demand + Redis cache) avoids the
+mirror-and-maintain burden of Option A. Cache TTL matches /library/preview at 5 min
+and ``invalidate_library_cache()`` (in app.routers.library_full) sweeps the
+``taxonomy:`` Redis prefix on every ingest write so stale aggregates can never
+outlive a backfill — see feedback_backfill_must_invalidate_cache.md.
 """
 
 import logging
@@ -15,12 +25,13 @@ import time
 from collections import defaultdict
 from typing import Optional
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Response
 from pydantic import BaseModel
 from sqlalchemy import func, select, text
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import require_admin_key, verify_api_key
+from app.cache_redis import redis_cache
 from app.database import get_db
 from app.models.repo import SkillArea, TaxonomyValue
 
@@ -31,6 +42,18 @@ router = APIRouter(tags=["Taxonomy"])
 # In-memory cache for skill-areas list (5 min TTL)
 _taxonomy_cache: dict = {}
 _TAXONOMY_CACHE_TTL = 300  # 5 minutes
+
+# KAN-175: Redis TTL for /taxonomy/{categories,tags} aggregations.
+# Matches /library/preview's 5-min window so a single ingest-driven
+# `invalidate_library_cache()` call sweeps both library and taxonomy keys
+# inside a single CDN cache window.
+_AGGREGATE_CACHE_TTL = 300
+
+# KAN-170 cache-control header — public + s-maxage=300 lets a future CDN/Cloud LB
+# edge-cache the aggregation; stale-while-revalidate=60 keeps total stale window
+# (s-maxage + swr = 6 min) within the Redis TTL band so an ingest-driven
+# invalidate_library_cache() flushes Redis before the CDN window expires.
+_AGGREGATE_CACHE_CONTROL = "public, s-maxage=300, stale-while-revalidate=60"
 
 
 @router.get("/skill-areas")
@@ -197,6 +220,118 @@ async def list_all_taxonomy_values(
         {"dimension": row.dimension, "value": row.value, "repo_count": row.repo_count}
         for row in rows
     ]
+
+
+# ---------------------------------------------------------------------------
+# KAN-175 — /taxonomy/categories and /taxonomy/tags aggregate directly from the
+# live `repos` / `repo_tags` corpus. These two routes MUST be declared before
+# the catch-all `/{dimension}` below so FastAPI matches the literal paths first.
+# ---------------------------------------------------------------------------
+
+
+def _aggregate_response(dimension: str, rows: list[tuple[str, int]]) -> dict:
+    """Build the response envelope for an aggregate dimension.
+
+    Each value carries ``dimension``, ``value``, and ``repo_count`` — the
+    minimal shape consumed by the reporium frontend's TaxonomyEntry interface
+    (see reporium/src/app/taxonomy/page.tsx). Backwards compatible with the
+    historical /taxonomy/{dimension} envelope: top-level ``dimension``,
+    ``values``, ``total``.
+    """
+    return {
+        "dimension": dimension,
+        "values": [
+            {"dimension": dimension, "value": value, "repo_count": int(count)}
+            for value, count in rows
+        ],
+        "total": len(rows),
+    }
+
+
+@router.get("/categories", response_model=dict)
+async def list_categories_aggregated(
+    response: Response,
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """KAN-175: Aggregate primary_category counts directly from the public
+    ``repos`` corpus on demand.
+
+    Replaces the prior dead read from ``taxonomy_values`` (see issue #251) which
+    was never mirrored from ``repos``. Cached in Redis under
+    ``taxonomy:categories`` for 5 minutes and invalidated on every ingest write
+    via ``invalidate_library_cache()``.
+    """
+    response.headers["Cache-Control"] = _AGGREGATE_CACHE_CONTROL
+    redis_key = "taxonomy:categories"
+
+    cached = await redis_cache.get(redis_key)
+    if cached is not None:
+        logger.info("Redis hit /taxonomy/categories")
+        return cached
+
+    t0 = time.monotonic()
+    result = await db.execute(text(
+        "SELECT primary_category AS value, COUNT(*) AS count "
+        "FROM repos "
+        "WHERE is_private = false AND primary_category IS NOT NULL "
+        "GROUP BY primary_category "
+        "ORDER BY count DESC, value ASC"
+    ))
+    rows = [(row.value, row.count) for row in result.fetchall()]
+    body = _aggregate_response("categories", rows)
+
+    elapsed_ms = (time.monotonic() - t0) * 1000
+    logger.info(
+        "/taxonomy/categories aggregated %d distinct values in %.1f ms",
+        len(rows), elapsed_ms,
+    )
+
+    await redis_cache.set(redis_key, body, ttl=_AGGREGATE_CACHE_TTL)
+    return body
+
+
+@router.get("/tags", response_model=dict)
+async def list_tags_aggregated(
+    response: Response,
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """KAN-175: Aggregate tag counts from the ``repo_tags`` junction table on
+    demand.
+
+    The frontend's ``enrichedTags`` field on each repo is sourced from
+    ``repo_tags`` (see ``library_preview._build_preview_repo``), so this route
+    surfaces the same vocabulary as what powers repo cards. Public repos only.
+    Cached in Redis under ``taxonomy:tags`` for 5 minutes and invalidated on
+    every ingest write via ``invalidate_library_cache()``.
+    """
+    response.headers["Cache-Control"] = _AGGREGATE_CACHE_CONTROL
+    redis_key = "taxonomy:tags"
+
+    cached = await redis_cache.get(redis_key)
+    if cached is not None:
+        logger.info("Redis hit /taxonomy/tags")
+        return cached
+
+    t0 = time.monotonic()
+    result = await db.execute(text(
+        "SELECT t.tag AS value, COUNT(DISTINCT t.repo_id) AS count "
+        "FROM repo_tags t "
+        "JOIN repos r ON r.id = t.repo_id "
+        "WHERE r.is_private = false "
+        "GROUP BY t.tag "
+        "ORDER BY count DESC, value ASC"
+    ))
+    rows = [(row.value, row.count) for row in result.fetchall()]
+    body = _aggregate_response("tags", rows)
+
+    elapsed_ms = (time.monotonic() - t0) * 1000
+    logger.info(
+        "/taxonomy/tags aggregated %d distinct values in %.1f ms",
+        len(rows), elapsed_ms,
+    )
+
+    await redis_cache.set(redis_key, body, ttl=_AGGREGATE_CACHE_TTL)
+    return body
 
 
 @router.get("/{dimension}", response_model=dict)

--- a/tests/test_library_preview.py
+++ b/tests/test_library_preview.py
@@ -393,6 +393,11 @@ async def test_invalidate_library_cache_clears_preview_prefix():
     'library:preview:*' (this PR). If a future refactor narrows the prefix
     to 'library:page:' only, /library/preview would serve stale results
     after a backfill — see feedback_backfill_must_invalidate_cache.md.
+
+    KAN-175 also added a ``taxonomy:`` prefix sweep (covered by
+    test_invalidate_library_cache_clears_taxonomy_prefix in
+    tests/test_taxonomy_aggregation.py). Here we just assert the ``library:``
+    prefix is one of the prefixes cleared, without pinning the call count.
     """
     from app.routers import library_full
 
@@ -405,4 +410,5 @@ async def test_invalidate_library_cache_clears_preview_prefix():
         import asyncio
         await asyncio.sleep(0)
 
-    fake_clear_prefix.assert_called_once_with("library:")
+    prefixes_called = {call.args[0] for call in fake_clear_prefix.call_args_list}
+    assert "library:" in prefixes_called, prefixes_called

--- a/tests/test_taxonomy_aggregation.py
+++ b/tests/test_taxonomy_aggregation.py
@@ -1,0 +1,410 @@
+"""
+Tests for KAN-175: GET /taxonomy/categories and GET /taxonomy/tags.
+
+Both endpoints aggregate directly from the live `repos` / `repo_tags` corpus
+on demand (Option B in the audit P2 design memo) instead of reading the
+historically-empty ``taxonomy_values`` table that surfaced as the issue #251
+"0 entries" symptom.
+
+Coverage:
+- Categories aggregate from ``repos.primary_category`` with public-only filter
+- Tags aggregate from ``repo_tags`` join with public-only filter
+- Private repos never surface — same privacy invariant as /library/preview
+- Null tag arrays / repos without primary_category don't crash the aggregation
+- Redis cache hit short-circuits the SQL aggregation
+- Cache-Control header carries s-maxage=300 (KAN-170 pattern)
+- ``invalidate_library_cache()`` sweeps both ``library:`` AND ``taxonomy:`` prefixes
+- The new routes win over the catch-all ``/{dimension}`` route (FastAPI ordering)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+from tests.conftest import AUTH_HEADERS, TEST_REPO_FIXTURE
+
+
+# ---------------------------------------------------------------------------
+# /taxonomy/categories
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_categories_returns_aggregated_data(client: AsyncClient):
+    """Two repos with distinct categories should produce two value entries.
+
+    The ingest pipeline copies categories[0].category_name into the
+    ``primary_category`` column on the repos row (issue #444 closeout), so the
+    aggregator picks up exactly the categories we seed here.
+    """
+    payloads = [
+        {
+            **TEST_REPO_FIXTURE,
+            "name": "kan175-cat-a",
+            "github_url": "https://github.com/testuser/kan175-cat-a",
+            "is_private": False,
+            "categories": [
+                {"category_id": "ai-agents", "category_name": "AI Agents", "is_primary": True}
+            ],
+        },
+        {
+            **TEST_REPO_FIXTURE,
+            "name": "kan175-cat-b",
+            "github_url": "https://github.com/testuser/kan175-cat-b",
+            "is_private": False,
+            "categories": [
+                {"category_id": "rag", "category_name": "RAG & Retrieval", "is_primary": True}
+            ],
+        },
+    ]
+    r = await client.post("/ingest/repos", json=payloads, headers=AUTH_HEADERS)
+    assert r.status_code == 200
+
+    # Bypass any leftover Redis cache from a sibling test by stubbing get→None.
+    with patch("app.routers.taxonomy.redis_cache.get", AsyncMock(return_value=None)):
+        resp = await client.get("/taxonomy/categories")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["dimension"] == "categories"
+    assert isinstance(body["values"], list)
+    assert body["total"] == len(body["values"])
+
+    by_value = {v["value"]: v["repo_count"] for v in body["values"]}
+    # Both probes must surface — count >= 1 (other tests in the same DB might
+    # share categories so we don't assert == 1 strictly).
+    assert by_value.get("AI Agents", 0) >= 1, by_value
+    assert by_value.get("RAG & Retrieval", 0) >= 1, by_value
+    # Each entry carries the dimension echo for the frontend's TaxonomyEntry shape.
+    for entry in body["values"]:
+        assert entry["dimension"] == "categories"
+        assert isinstance(entry["repo_count"], int) and entry["repo_count"] >= 1
+
+
+@pytest.mark.asyncio
+async def test_categories_excludes_private_repos(client: AsyncClient):
+    """A category that ONLY has private repos must not appear in the response."""
+    private_payload = {
+        **TEST_REPO_FIXTURE,
+        "name": "kan175-private-only-cat",
+        "github_url": "https://github.com/testuser/kan175-private-only-cat",
+        "is_private": True,
+        "categories": [
+            {
+                "category_id": "kan175-private-only-cat-id",
+                "category_name": "kan175-private-only-cat-name",
+                "is_primary": True,
+            }
+        ],
+    }
+    r = await client.post("/ingest/repos", json=[private_payload], headers=AUTH_HEADERS)
+    assert r.status_code == 200
+
+    with patch("app.routers.taxonomy.redis_cache.get", AsyncMock(return_value=None)):
+        resp = await client.get("/taxonomy/categories")
+
+    assert resp.status_code == 200
+    values = {v["value"] for v in resp.json()["values"]}
+    assert "kan175-private-only-cat-name" not in values, (
+        "PRIVACY LEAK: a category with only private repos surfaced in /taxonomy/categories"
+    )
+
+
+@pytest.mark.asyncio
+async def test_categories_response_envelope_shape(client: AsyncClient):
+    """Backwards-compat envelope: top-level keys match the historical
+    ``/taxonomy/{dimension}`` shape so existing consumers keep working."""
+    with patch("app.routers.taxonomy.redis_cache.get", AsyncMock(return_value=None)):
+        resp = await client.get("/taxonomy/categories")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body.keys()) == {"dimension", "values", "total"}
+
+
+# ---------------------------------------------------------------------------
+# /taxonomy/tags
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tags_returns_aggregated_data(client: AsyncClient):
+    """Repos with distinctive tags should produce matching value entries."""
+    payloads = [
+        {
+            **TEST_REPO_FIXTURE,
+            "name": "kan175-tag-probe-a",
+            "github_url": "https://github.com/testuser/kan175-tag-probe-a",
+            "is_private": False,
+            "tags": ["kan175-tag-alpha", "kan175-tag-shared"],
+        },
+        {
+            **TEST_REPO_FIXTURE,
+            "name": "kan175-tag-probe-b",
+            "github_url": "https://github.com/testuser/kan175-tag-probe-b",
+            "is_private": False,
+            "tags": ["kan175-tag-beta", "kan175-tag-shared"],
+        },
+    ]
+    r = await client.post("/ingest/repos", json=payloads, headers=AUTH_HEADERS)
+    assert r.status_code == 200
+
+    with patch("app.routers.taxonomy.redis_cache.get", AsyncMock(return_value=None)):
+        resp = await client.get("/taxonomy/tags")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["dimension"] == "tags"
+    assert isinstance(body["values"], list)
+    assert body["total"] == len(body["values"])
+
+    by_value = {v["value"]: v["repo_count"] for v in body["values"]}
+    assert by_value.get("kan175-tag-alpha", 0) >= 1, by_value
+    assert by_value.get("kan175-tag-beta", 0) >= 1, by_value
+    # The shared tag should accumulate across both probes
+    assert by_value.get("kan175-tag-shared", 0) >= 2, by_value
+    # Result is sorted by count desc — the shared tag must outrank each unique tag
+    positions = {v["value"]: idx for idx, v in enumerate(body["values"])}
+    if "kan175-tag-alpha" in positions and "kan175-tag-shared" in positions:
+        assert positions["kan175-tag-shared"] < positions["kan175-tag-alpha"], (
+            f"sort order broken: shared(count>=2) ranked below alpha(count=1)"
+        )
+
+
+@pytest.mark.asyncio
+async def test_tags_excludes_private_repos(client: AsyncClient):
+    """A tag that only appears on private repos must not be surfaced."""
+    private_payload = {
+        **TEST_REPO_FIXTURE,
+        "name": "kan175-private-tag-host",
+        "github_url": "https://github.com/testuser/kan175-private-tag-host",
+        "is_private": True,
+        "tags": ["kan175-private-only-tag"],
+    }
+    r = await client.post("/ingest/repos", json=[private_payload], headers=AUTH_HEADERS)
+    assert r.status_code == 200
+
+    with patch("app.routers.taxonomy.redis_cache.get", AsyncMock(return_value=None)):
+        resp = await client.get("/taxonomy/tags")
+
+    assert resp.status_code == 200
+    values = {v["value"] for v in resp.json()["values"]}
+    assert "kan175-private-only-tag" not in values, (
+        "PRIVACY LEAK: a tag from a private repo surfaced in /taxonomy/tags"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tags_handles_repos_without_tags(client: AsyncClient):
+    """Repos with no tags entries must not crash the aggregation (empty join is ok)."""
+    payload = {
+        **TEST_REPO_FIXTURE,
+        "name": "kan175-no-tags-probe",
+        "github_url": "https://github.com/testuser/kan175-no-tags-probe",
+        "is_private": False,
+        "tags": [],
+    }
+    r = await client.post("/ingest/repos", json=[payload], headers=AUTH_HEADERS)
+    assert r.status_code == 200
+
+    with patch("app.routers.taxonomy.redis_cache.get", AsyncMock(return_value=None)):
+        resp = await client.get("/taxonomy/tags")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    # Whatever tags exist, none of them should be the empty string and the
+    # endpoint must not have crashed.
+    for entry in body["values"]:
+        assert isinstance(entry["value"], str) and entry["value"], entry
+
+
+@pytest.mark.asyncio
+async def test_tags_response_envelope_shape(client: AsyncClient):
+    """Backwards-compat envelope: top-level keys match historical shape."""
+    with patch("app.routers.taxonomy.redis_cache.get", AsyncMock(return_value=None)):
+        resp = await client.get("/taxonomy/tags")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body.keys()) == {"dimension", "values", "total"}
+
+
+# ---------------------------------------------------------------------------
+# Cache behaviour
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_categories_cache_hit_short_circuits_db(client: AsyncClient):
+    """When Redis returns a cached envelope, no aggregation SQL should run."""
+    cached_body = {
+        "dimension": "categories",
+        "values": [
+            {"dimension": "categories", "value": "Stubbed", "repo_count": 42}
+        ],
+        "total": 1,
+    }
+    fake_get = AsyncMock(return_value=cached_body)
+    with patch("app.routers.taxonomy.redis_cache.get", fake_get):
+        resp = await client.get("/taxonomy/categories")
+
+    assert resp.status_code == 200
+    assert resp.json() == cached_body
+    fake_get.assert_called_once_with("taxonomy:categories")
+
+
+@pytest.mark.asyncio
+async def test_tags_cache_hit_short_circuits_db(client: AsyncClient):
+    """Same as above but for /taxonomy/tags."""
+    cached_body = {
+        "dimension": "tags",
+        "values": [
+            {"dimension": "tags", "value": "stubbed-tag", "repo_count": 7}
+        ],
+        "total": 1,
+    }
+    fake_get = AsyncMock(return_value=cached_body)
+    with patch("app.routers.taxonomy.redis_cache.get", fake_get):
+        resp = await client.get("/taxonomy/tags")
+
+    assert resp.status_code == 200
+    assert resp.json() == cached_body
+    fake_get.assert_called_once_with("taxonomy:tags")
+
+
+@pytest.mark.asyncio
+async def test_categories_cache_miss_writes_to_redis(client: AsyncClient):
+    """On a cache miss, the response body must be persisted under the canonical key."""
+    fake_get = AsyncMock(return_value=None)
+    fake_set = AsyncMock()
+    with (
+        patch("app.routers.taxonomy.redis_cache.get", fake_get),
+        patch("app.routers.taxonomy.redis_cache.set", fake_set),
+    ):
+        resp = await client.get("/taxonomy/categories")
+
+    assert resp.status_code == 200
+    fake_set.assert_called_once()
+    args, kwargs = fake_set.call_args
+    assert args[0] == "taxonomy:categories"
+    assert kwargs.get("ttl") == 300
+
+
+@pytest.mark.asyncio
+async def test_tags_cache_miss_writes_to_redis(client: AsyncClient):
+    """Same write-through assertion for /taxonomy/tags."""
+    fake_get = AsyncMock(return_value=None)
+    fake_set = AsyncMock()
+    with (
+        patch("app.routers.taxonomy.redis_cache.get", fake_get),
+        patch("app.routers.taxonomy.redis_cache.set", fake_set),
+    ):
+        resp = await client.get("/taxonomy/tags")
+
+    assert resp.status_code == 200
+    fake_set.assert_called_once()
+    args, kwargs = fake_set.call_args
+    assert args[0] == "taxonomy:tags"
+    assert kwargs.get("ttl") == 300
+
+
+# ---------------------------------------------------------------------------
+# Cache-Control header (KAN-170 pattern)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_categories_sets_cache_control_header(client: AsyncClient):
+    """KAN-170: public, s-maxage=300, stale-while-revalidate=60."""
+    with patch("app.routers.taxonomy.redis_cache.get", AsyncMock(return_value=None)):
+        resp = await client.get("/taxonomy/categories")
+
+    assert resp.status_code == 200
+    cc = resp.headers.get("cache-control", "")
+    assert "public" in cc, cc
+    assert "s-maxage=300" in cc, cc
+    assert "stale-while-revalidate=60" in cc, cc
+
+
+@pytest.mark.asyncio
+async def test_tags_sets_cache_control_header(client: AsyncClient):
+    """KAN-170: public, s-maxage=300, stale-while-revalidate=60 on the tags route too."""
+    with patch("app.routers.taxonomy.redis_cache.get", AsyncMock(return_value=None)):
+        resp = await client.get("/taxonomy/tags")
+
+    assert resp.status_code == 200
+    cc = resp.headers.get("cache-control", "")
+    assert "public" in cc, cc
+    assert "s-maxage=300" in cc, cc
+    assert "stale-while-revalidate=60" in cc, cc
+
+
+# ---------------------------------------------------------------------------
+# Cache invalidation hook — must sweep BOTH library: AND taxonomy:
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_invalidate_library_cache_clears_taxonomy_prefix():
+    """KAN-175: ``invalidate_library_cache()`` must clear the ``taxonomy:`` prefix
+    in addition to ``library:``.
+
+    Otherwise an ingest write could leave /taxonomy/categories or /taxonomy/tags
+    serving aggregated data computed BEFORE the new repos landed, which is
+    exactly the failure mode feedback_backfill_must_invalidate_cache.md
+    enshrined as a memory-blocker.
+    """
+    import asyncio
+
+    from app.routers import library_full
+
+    fake_clear_prefix = AsyncMock()
+    with patch.object(library_full.redis_cache, "clear_prefix", fake_clear_prefix):
+        library_full.invalidate_library_cache()
+        # ensure_future returns immediately; yield once for the loop.
+        await asyncio.sleep(0)
+
+    prefixes_called = {call.args[0] for call in fake_clear_prefix.call_args_list}
+    assert "library:" in prefixes_called, prefixes_called
+    assert "taxonomy:" in prefixes_called, prefixes_called
+
+
+# ---------------------------------------------------------------------------
+# Route precedence — /categories and /tags must win over /{dimension} catch-all
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_categories_route_wins_over_dimension_catchall(client: AsyncClient):
+    """If FastAPI ever picks the catch-all first, /taxonomy/categories would
+    fall through to ``list_taxonomy_values`` and return empty values from the
+    historically-empty ``taxonomy_values`` table — exactly the bug KAN-175
+    fixes. Asserting the new key shape guarantees we hit the aggregator.
+    """
+    with patch("app.routers.taxonomy.redis_cache.get", AsyncMock(return_value=None)):
+        resp = await client.get("/taxonomy/categories")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    # Aggregator entries carry these exact keys; the legacy taxonomy_values
+    # shape carries id/name/description/trending_score etc. Verifying the
+    # shape proves we hit the aggregator, not the catch-all.
+    if body["values"]:
+        sample = body["values"][0]
+        assert set(sample.keys()) == {"dimension", "value", "repo_count"}, sample
+
+
+@pytest.mark.asyncio
+async def test_tags_route_wins_over_dimension_catchall(client: AsyncClient):
+    """Same precedence guarantee for /taxonomy/tags."""
+    with patch("app.routers.taxonomy.redis_cache.get", AsyncMock(return_value=None)):
+        resp = await client.get("/taxonomy/tags")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    if body["values"]:
+        sample = body["values"][0]
+        assert set(sample.keys()) == {"dimension", "value", "repo_count"}, sample


### PR DESCRIPTION
## Summary

Closes the audit P2 finding (issue #251 follow-up) that `GET /taxonomy/categories` and `GET /taxonomy/tags` return `0` entries because the underlying `taxonomy_values` rows for those two dimensions were never mirrored from the live `repos` corpus.

**Live confirmation before this PR:**
```
$ curl -s https://reporium-api-573778300586.us-central1.run.app/taxonomy/categories
{"dimension":"categories","values":[],"total":0}
$ curl -s https://reporium-api-573778300586.us-central1.run.app/taxonomy/tags
{"dimension":"tags","values":[],"total":0}
```

## Why Option B (aggregate-on-demand) over Option A (mirror)

The data already lives in `repos.primary_category` (Text) and the `repo_tags` junction table — both written on every ingest. Mirroring into `taxonomy_values` (Option A) creates a second source of truth that needs a backfill schedule and an invalidation contract; the dead endpoints surfaced precisely because that mirror was never run. Option B reads from the same rows that power the rest of the library so they cannot diverge.

## Implementation

- Two new explicit GET routes declared **before** the catch-all `/taxonomy/{dimension}` so FastAPI matches the literal paths first:
  - `GET /taxonomy/categories` — `GROUP BY repos.primary_category WHERE is_private = false`
  - `GET /taxonomy/tags` — `JOIN repo_tags ON repo_id WHERE repos.is_private = false`
- Redis cache via `redis_cache` under `taxonomy:{categories,tags}` with a 5-min TTL (matches `/library/preview`).
- `Cache-Control: public, s-maxage=300, stale-while-revalidate=60` per **KAN-170** so a future CDN/Cloud LB can edge-cache the aggregations within the Redis TTL window.
- `invalidate_library_cache()` extended to sweep `taxonomy:` in addition to `library:` — every ingest write that bumps `repos` already invalidates library caches; the same writes now invalidate the new aggregations atomically. Closes the failure mode in `feedback_backfill_must_invalidate_cache.md`.

## Backwards compatibility

The top-level envelope `{dimension, values, total}` matches the historical `/taxonomy/{dimension}` shape so the existing `taxonomy/page.tsx` consumer keeps rendering. Per-value entries follow the frontend's `TaxonomyEntry` interface: `{dimension, value, repo_count}`.

## Tests

New `tests/test_taxonomy_aggregation.py` (15 cases):
- aggregated counts for both dimensions
- public-only privacy invariant (private-only categories/tags must not surface) — same guard pattern as the 2026-04-23 leak fix
- repos with no tags don't crash the aggregation
- Redis cache hit short-circuits SQL; cache miss writes under canonical key with TTL=300
- `Cache-Control` header per KAN-170
- `invalidate_library_cache()` sweeps both `library:` and `taxonomy:` prefixes
- new routes win over the catch-all `/{dimension}` route (regression guard against future router refactors)

Local: `47 passed, 65 skipped` across `tests/test_library_preview.py`, `test_library_full.py`, `test_taxonomy.py`, `test_taxonomy_aggregation.py`, `test_taxonomy_v2.py`, `test_taxonomy_gaps.py`. The DB-dependent tests skip cleanly without a local Postgres; CI will run them.

`test_invalidate_library_cache_clears_preview_prefix` was loosened from `assert_called_once_with("library:")` to membership-based `"library:" in prefixes_called` since the same hook now also clears `taxonomy:`. Library/preview semantics unchanged.

## Test plan

- [x] Local: `pytest tests/test_taxonomy_aggregation.py tests/test_library_preview.py tests/test_library_full.py tests/test_taxonomy.py` — 47 pass, 65 DB-dependent skips
- [ ] CI: full suite green (or only pre-existing KAN-169 negation-test failures, unrelated)
- [ ] Post-merge: `curl /taxonomy/categories` returns N>0 entries
- [ ] Post-merge: `curl /taxonomy/tags` returns N>0 entries
- [ ] Post-merge: `curl -sI .../taxonomy/categories | grep -i cache-control` shows `s-maxage=300`