### PR TITLE
KAN-176: cache Ask Quality Gate evaluator (Anthropic spend cut)

### DIFF
--- a/tests/test_ask_golden_eval_cache.py
+++ b/tests/test_ask_golden_eval_cache.py
@@ -1,0 +1,287 @@
+"""
+KAN-176: Tests for the Redis-backed evaluator cache layer used by
+`tests/test_ask_golden_numeric.py`.
+
+The Ask Quality Gate runs on every push + PR (per KAN-146). Each fixture
+entry triggers ~3-4 Anthropic calls inside `/intelligence/ask` (smart-route
+probe, semantic-cache embedding, main answer, optional judge). Caching the
+*evaluator response* by `(model, entry-yaml, question)` SHA in Redis with a
+24h TTL means identical re-runs (same fixture set) skip the entire Anthropic
+chain.
+
+Cache surface tested:
+  - Key shape: stable hash of `(model, entry, prompt)`.
+  - Hit path: pre-populated Redis returns the cached payload without calling
+    the underlying HTTP client.
+  - Miss path: empty Redis triggers a real POST and writes the response back
+    with TTL=86400.
+  - Sensitivity: changing one character of the entry's question changes the
+    cache key (no false positives across slightly-edited fixtures).
+"""
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from tests.test_ask_golden_numeric import (
+    _ASK_GATE_CACHE_PREFIX,
+    _ASK_GATE_CACHE_TTL_SECONDS,
+    _ask_with_cache,
+    _cache_model_id,
+    _CachedResponse,
+    _evaluator_cache_key,
+)
+
+
+# ---------------------------------------------------------------------------
+# Cache-key shape & sensitivity
+# ---------------------------------------------------------------------------
+
+def test_cache_key_has_expected_prefix_and_length():
+    key = _evaluator_cache_key("router", {"q": "x"}, "hello")
+    assert key.startswith(_ASK_GATE_CACHE_PREFIX), (
+        f"Key must use the {_ASK_GATE_CACHE_PREFIX!r} namespace so "
+        "`clear_prefix` can flush only eval-cache entries."
+    )
+    suffix = key[len(_ASK_GATE_CACHE_PREFIX):]
+    assert len(suffix) == 16, "Truncated SHA-256 must be 16 hex chars"
+    assert all(c in "0123456789abcdef" for c in suffix)
+
+
+def test_cache_key_stable_across_calls():
+    """Same inputs => same key (otherwise no cache would ever hit)."""
+    entry = {"name": "demo", "owner": "perditioinc", "question": "what?"}
+    k1 = _evaluator_cache_key("router", entry, "question text")
+    k2 = _evaluator_cache_key("router", entry, "question text")
+    assert k1 == k2
+
+
+def test_cache_key_changes_on_entry_modification():
+    """One-char change to the entry's question must change the cache key.
+
+    Anti-stale-cache safety: if a fixture is edited the next run MUST re-issue
+    the Anthropic call, otherwise the gate would silently grade the new
+    fixture against the old answer.
+    """
+    base = {"name": "demo", "question": "what does redis cache?"}
+    edited = {"name": "demo", "question": "what does redis cache!"}  # ? -> !
+    assert _evaluator_cache_key("router", base, "p") != _evaluator_cache_key(
+        "router", edited, "p"
+    )
+
+
+def test_cache_key_changes_on_prompt_modification():
+    entry = {"name": "demo"}
+    assert _evaluator_cache_key("router", entry, "alpha") != _evaluator_cache_key(
+        "router", entry, "beta"
+    )
+
+
+def test_cache_key_changes_on_model_modification():
+    """Bumping `ASK_GATE_CACHE_MODEL` must invalidate the cache."""
+    entry = {"name": "demo"}
+    assert _evaluator_cache_key("haiku-4-5", entry, "p") != _evaluator_cache_key(
+        "haiku-4-6", entry, "p"
+    )
+
+
+def test_cache_key_dict_order_insensitive():
+    """JSON serialisation must use sort_keys so dict-iteration order doesn't
+    flake the cache key across Python versions."""
+    a = {"x": 1, "y": 2}
+    b = {"y": 2, "x": 1}
+    assert _evaluator_cache_key("m", a, "p") == _evaluator_cache_key("m", b, "p")
+
+
+def test_cache_model_id_default():
+    """Default model id is 'router' (since the API picks Haiku/Sonnet itself)."""
+    with patch.dict("os.environ", {}, clear=False):
+        import os
+        os.environ.pop("ASK_GATE_CACHE_MODEL", None)
+        assert _cache_model_id() == "router"
+
+
+def test_cache_model_id_override():
+    with patch.dict("os.environ", {"ASK_GATE_CACHE_MODEL": "claude-haiku-4-6"}):
+        assert _cache_model_id() == "claude-haiku-4-6"
+
+
+def test_cache_model_id_blank_falls_back_to_router():
+    """Empty / whitespace override must not produce an empty model component."""
+    with patch.dict("os.environ", {"ASK_GATE_CACHE_MODEL": "   "}):
+        assert _cache_model_id() == "router"
+
+
+# ---------------------------------------------------------------------------
+# _CachedResponse adapter
+# ---------------------------------------------------------------------------
+
+def test_cached_response_mimics_httpx_surface():
+    """Caller reads `.status_code`, `.json()`, `.text`. Verify all three."""
+    payload = {"answer": "42", "sources": [], "tokens_used": {"total": 7}}
+    r = _CachedResponse(payload)
+    assert r.status_code == 200
+    assert r.json() == payload
+    # `.text` is consulted only on the error path; it's still populated for
+    # safety against future code paths.
+    assert "42" in r.text
+
+
+# ---------------------------------------------------------------------------
+# Hit / miss behaviour
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_evaluator_cache_hit_skips_anthropic():
+    """Pre-populated Redis must return the cached payload without POSTing."""
+    cached_payload = {
+        "answer": "cached",
+        "sources": [],
+        "tokens_used": {"total": 0},
+    }
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(
+        side_effect=AssertionError(
+            "client.post must NOT be called on cache hit — the whole point "
+            "of the cache is to skip the Anthropic chain."
+        )
+    )
+
+    fake_redis = MagicMock()
+    fake_redis.get = AsyncMock(return_value=cached_payload)
+    fake_redis.set = AsyncMock()
+
+    with patch("app.cache_redis.redis_cache", fake_redis):
+        response = await _ask_with_cache(
+            fake_client,
+            "router",
+            {"name": "fixture-a"},
+            "ping?",
+        )
+
+    assert response.status_code == 200
+    assert response.json() == cached_payload
+    fake_client.post.assert_not_called()
+    fake_redis.set.assert_not_called()  # No write on hit (TTL not refreshed)
+
+
+@pytest.mark.asyncio
+async def test_evaluator_cache_miss_calls_anthropic_then_writes():
+    """Empty Redis: real POST happens, response is written back with 24h TTL."""
+    api_payload = {"answer": "live", "sources": [], "tokens_used": {"total": 42}}
+    real_response = MagicMock()
+    real_response.status_code = 200
+    real_response.json = MagicMock(return_value=api_payload)
+
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=real_response)
+
+    fake_redis = MagicMock()
+    fake_redis.get = AsyncMock(return_value=None)  # MISS
+    fake_redis.set = AsyncMock()
+
+    with patch("app.cache_redis.redis_cache", fake_redis):
+        response = await _ask_with_cache(
+            fake_client,
+            "router",
+            {"name": "fixture-b"},
+            "ping?",
+        )
+
+    assert response is real_response
+    fake_client.post.assert_awaited_once_with(
+        "/intelligence/ask", json={"question": "ping?"}
+    )
+    fake_redis.set.assert_awaited_once()
+    args, kwargs = fake_redis.set.call_args
+    assert args[0].startswith(_ASK_GATE_CACHE_PREFIX)
+    assert args[1] == api_payload
+    assert kwargs.get("ttl") == _ASK_GATE_CACHE_TTL_SECONDS == 86400
+
+
+@pytest.mark.asyncio
+async def test_evaluator_cache_does_not_write_on_non_200():
+    """5xx / 4xx responses must NOT be cached — would pin transient failures."""
+    bad_response = MagicMock()
+    bad_response.status_code = 502
+    bad_response.json = MagicMock(return_value={"detail": "bad gateway"})
+
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=bad_response)
+
+    fake_redis = MagicMock()
+    fake_redis.get = AsyncMock(return_value=None)
+    fake_redis.set = AsyncMock()
+
+    with patch("app.cache_redis.redis_cache", fake_redis):
+        response = await _ask_with_cache(
+            fake_client,
+            "router",
+            {"name": "fixture-c"},
+            "ping?",
+        )
+
+    assert response.status_code == 502
+    fake_redis.set.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_evaluator_cache_redis_unavailable_falls_through():
+    """Redis import-fail / connection error must degrade to plain POST.
+
+    This is the path taken by the slim CI workflow today (REDIS_URL="").
+    Behaviour must be byte-identical to the pre-KAN-176 code: POST happens,
+    response is returned, no exception leaks.
+    """
+    api_payload = {"answer": "no-redis", "sources": []}
+    real_response = MagicMock()
+    real_response.status_code = 200
+    real_response.json = MagicMock(return_value=api_payload)
+
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=real_response)
+
+    # Simulate `redis_cache.get` raising — wrapper must swallow and POST.
+    fake_redis = MagicMock()
+    fake_redis.get = AsyncMock(side_effect=ConnectionError("no redis here"))
+    fake_redis.set = AsyncMock()
+
+    with patch("app.cache_redis.redis_cache", fake_redis):
+        response = await _ask_with_cache(
+            fake_client,
+            "router",
+            {"name": "fixture-d"},
+            "ping?",
+        )
+
+    assert response is real_response
+    fake_client.post.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cache_write_failure_does_not_break_response():
+    """A failed cache.set must not propagate — gate must keep running."""
+    api_payload = {"answer": "ok", "sources": []}
+    real_response = MagicMock()
+    real_response.status_code = 200
+    real_response.json = MagicMock(return_value=api_payload)
+
+    fake_client = MagicMock()
+    fake_client.post = AsyncMock(return_value=real_response)
+
+    fake_redis = MagicMock()
+    fake_redis.get = AsyncMock(return_value=None)
+    fake_redis.set = AsyncMock(side_effect=RuntimeError("write blew up"))
+
+    with patch("app.cache_redis.redis_cache", fake_redis):
+        # Must not raise.
+        response = await _ask_with_cache(
+            fake_client,
+            "router",
+            {"name": "fixture-e"},
+            "ping?",
+        )
+
+    assert response.status_code == 200

--- a/tests/test_ask_golden_numeric.py
+++ b/tests/test_ask_golden_numeric.py
@@ -69,6 +69,9 @@ from __future__ import annotations
 
 import asyncio
 import contextvars
+import hashlib
+import json
+import logging
 import os
 import uuid
 from pathlib import Path
@@ -80,6 +83,8 @@ import pytest_asyncio
 import yaml
 from httpx import ASGITransport, AsyncClient
 
+logger = logging.getLogger(__name__)
+
 # KAN-146: contextvar carries the per-coroutine mock DB so a single
 # process-global `dependency_overrides[get_db]` can route correctly under
 # `asyncio.gather`. Without this, the last writer of `dependency_overrides`
@@ -87,6 +92,126 @@ from httpx import ASGITransport, AsyncClient
 _CURRENT_MOCK_DB: contextvars.ContextVar[Any] = contextvars.ContextVar(
     "_CURRENT_MOCK_DB", default=None
 )
+
+
+# ---------------------------------------------------------------------------
+# KAN-176: Redis evaluator cache (24h TTL). Skip Anthropic on cache hit.
+# ---------------------------------------------------------------------------
+# Each `/intelligence/ask` invocation in the gate triggers ~3-4 Haiku calls
+# inside the API (smart-route probe, semantic-cache embedding, main answer,
+# optional judge). Caching the *response* keyed by `(model, entry, question)`
+# lets identical re-runs (same fixture set, same question text) skip the
+# Anthropic chain entirely.
+#
+# Cache scope:
+#   - Hit only when REDIS_URL is set and the runner can reach it. CI runners
+#     in `ask-quality-gate.yml` currently set REDIS_URL="" so the wrapper
+#     degrades to a pure pass-through (zero behaviour change). To realize the
+#     cost reduction, point CI at a real Redis (or Upstash) instance.
+#   - TTL is 24h: shorter than fixture-edit cadence (intentional invalidation
+#     comes from changing the entry yaml, which changes the hash anyway).
+#   - Key shape: `ask_gate:eval:<sha256[:16]>`. Truncated to keep keys short
+#     while leaving 64 bits of collision resistance — fine for ~tens of
+#     entries.
+#
+# Cache key model component: defaults to "router" because the API picks
+# Haiku vs Sonnet *per question* via `_COMPLEX_PATTERNS`. Override with
+# `ASK_GATE_CACHE_MODEL` to bust the cache when bumping model versions
+# (e.g. set to `claude-haiku-4-6` when migrating).
+_ASK_GATE_CACHE_PREFIX = "ask_gate:eval:"
+_ASK_GATE_CACHE_TTL_SECONDS = 24 * 3600  # 24h
+
+
+def _evaluator_cache_key(model: str, entry: dict[str, Any], prompt: str) -> str:
+    """SHA-256 hash of (model, entry-yaml, prompt) — first 16 hex chars."""
+    h = hashlib.sha256()
+    h.update(model.encode("utf-8"))
+    h.update(b"|")
+    # `default=str` so any non-JSON-serializable fixture value (Path, set, …)
+    # falls back to repr() rather than blowing up the test before the API call.
+    h.update(json.dumps(entry, sort_keys=True, default=str).encode("utf-8"))
+    h.update(b"|")
+    h.update(prompt.encode("utf-8"))
+    return f"{_ASK_GATE_CACHE_PREFIX}{h.hexdigest()[:16]}"
+
+
+def _cache_model_id() -> str:
+    """Identifier baked into the cache key — flip to invalidate on model swap."""
+    return os.getenv("ASK_GATE_CACHE_MODEL", "router").strip() or "router"
+
+
+class _CachedResponse:
+    """Drop-in stand-in for httpx.Response when serving from cache.
+
+    `_run_one_entry` only reads `.status_code`, `.json()`, and `.text` from
+    the response object, so we mimic just that surface.
+    """
+
+    __slots__ = ("status_code", "_payload", "text")
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.status_code = 200
+        self._payload = payload
+        # `.text` is consulted only on the error path (status != 200), but
+        # populate it defensively in case future code reads it on success.
+        self.text = json.dumps(payload)
+
+    def json(self) -> dict[str, Any]:
+        return self._payload
+
+
+async def _ask_with_cache(
+    client: AsyncClient,
+    model: str,
+    entry: dict[str, Any],
+    question: str,
+) -> Any:
+    """POST /intelligence/ask, consulting the Redis eval cache first.
+
+    Returns either an httpx.Response (cache miss / Redis unavailable) or a
+    `_CachedResponse` (cache hit). Both expose `.status_code`, `.json()`,
+    and `.text` so the caller is agnostic.
+
+    Cache writes happen only on 200 OK responses — error responses are
+    intentionally re-issued every run so transient API failures don't get
+    pinned for 24h.
+    """
+    key = _evaluator_cache_key(model, entry, question)
+
+    # Import lazily so test collection doesn't require Redis libs to be
+    # importable on every machine.
+    try:
+        from app.cache_redis import redis_cache
+    except Exception:
+        redis_cache = None  # type: ignore[assignment]
+
+    if redis_cache is not None:
+        try:
+            cached = await redis_cache.get(key)
+        except Exception:
+            cached = None
+        if cached is not None:
+            logger.info("ask_gate.cache_hit key=%s", key)
+            return _CachedResponse(cached)
+
+    response = await client.post(
+        "/intelligence/ask",
+        json={"question": question},
+    )
+
+    if redis_cache is not None and response.status_code == 200:
+        try:
+            await redis_cache.set(
+                key,
+                response.json(),
+                ttl=_ASK_GATE_CACHE_TTL_SECONDS,
+            )
+            logger.info("ask_gate.cache_write key=%s", key)
+        except Exception:
+            # Cache write must never break the gate.
+            logger.warning("ask_gate.cache_write_failed key=%s", key, exc_info=True)
+
+    return response
 
 pytestmark = [
     pytest.mark.skipif(
@@ -316,9 +441,16 @@ async def _run_one_entry(
     _CURRENT_MOCK_DB.set(mock_db)
 
     async with sem:
-        response = await client.post(
-            "/intelligence/ask",
-            json={"question": question},
+        # KAN-176: Redis-backed eval cache (24h TTL). Cache hit short-circuits
+        # the HTTP call entirely, skipping the ~3-4 Anthropic calls fanned out
+        # inside `/intelligence/ask`. Falls through to a real POST when Redis
+        # is unset/unreachable, preserving exact prior behaviour for
+        # REDIS_URL="" runners.
+        response = await _ask_with_cache(
+            client,
+            _cache_model_id(),
+            entry,
+            question,
         )
 
     result: dict[str, Any] = {


### PR DESCRIPTION
## Summary

Adds a Redis-backed evaluator cache to the Ask Quality Gate so identical re-runs (same fixture set, same question text) skip the Anthropic call chain inside `/intelligence/ask`.

Per the 4h cost audit:
- Slim CI: ~7 fixture entries × ~3-4 Haiku calls per entry = ~28 Haiku calls per gate run
- Gate runs on every push + PR (KAN-146 redesign)
- ~9000 Haiku calls/mo → ~$3-8/mo at $0.001-0.005/call

Estimated savings: ~60% Haiku call reduction on slim CI runs *once Redis is reachable* (see CI caveat below).

## Implementation

- New module-level helpers in `tests/test_ask_golden_numeric.py`:
  - `_evaluator_cache_key(model, entry, prompt)` → SHA-256 of `(model, JSON-sorted entry, prompt)`, prefixed `ask_gate:eval:`, truncated to 16 hex chars
  - `_cache_model_id()` → reads `ASK_GATE_CACHE_MODEL` env var (default `"router"`); flip to bust the cache on model bumps
  - `_CachedResponse` → minimal `httpx.Response` stand-in (`.status_code`, `.json()`, `.text`)
  - `_ask_with_cache(client, model, entry, question)` → consults `app.cache_redis.redis_cache` first, falls through to real POST on miss / Redis-unavailable, writes back successful responses with `ttl=86400`
- `_run_one_entry` now calls `_ask_with_cache` instead of `client.post` directly. Behavior on the no-Redis CI path is byte-identical.

## Tests

- **15 new unit tests** in `tests/test_ask_golden_eval_cache.py` covering:
  - Cache key shape (prefix, length, hex chars) and stability across calls
  - Sensitivity: changing entry, prompt, or model component all change the key
  - Dict-order insensitivity (`sort_keys=True` JSON serialisation)
  - Hit path: pre-populated Redis returns cached payload, **`client.post` is not called**
  - Miss path: real POST happens, response written back with `ttl=86400`
  - Non-200 responses are NOT cached (avoid pinning transient failures)
  - Redis-unavailable / `redis_cache.get` exception → wrapper degrades to plain POST
  - Cache write failure does not break the gate

```
$ pytest tests/test_ask_golden_eval_cache.py -v
... 15 passed in 0.07s
```

- `tests/test_ask_golden_numeric.py` collects cleanly; behavior unchanged on the no-Redis path.
- Full suite (excluding the live `test_ask_golden_numeric` which needs `ANTHROPIC_API_KEY`): 639 passed, 321 skipped (DB-dep), 2 pre-existing failures in `test_intelligence_quality.py::test_ask_negation_*` unrelated to this change.

## Caveat — Redis access in CI

`ask-quality-gate.yml` currently sets `REDIS_URL: ""` (line 33). With Redis unavailable the wrapper degrades to no-op and the gate runs identically to today. Realising the cost reduction requires pointing the workflow at a real Redis instance (Upstash is cheap and works from GHA runners). Follow-up ticket suggested for the workflow change so the cost reduction is testable independently from this code change.

## Constraints honored

- Gate pass/fail logic untouched
- This is the EVAL cache; KAN-169's negation-query anti-cache on the `/ask` request path is unrelated and not bypassed
- Test timeout from KAN-146 (600s) untouched
- Cache writes only on 200 OK so transient errors aren't pinned for 24h

## Test plan

- [x] `pytest tests/test_ask_golden_eval_cache.py -v` — 15/15 pass
- [x] `pytest tests/test_ask_golden_numeric.py --collect-only` — collects 1 test
- [x] `pytest tests/` (excluding live golden gate) — only pre-existing failures
- [ ] Ask Quality Gate (live with `ANTHROPIC_API_KEY`) — should pass cleanly; cache writes are no-ops with `REDIS_URL=""`