### PR TITLE
KAN-181: ask-quality-gate workflow_dispatch + Redis env

### DIFF
--- a/.github/workflows/ask-quality-gate.yml
+++ b/.github/workflows/ask-quality-gate.yml
@@ -4,6 +4,7 @@ on:
     branches: [dev, main]
   pull_request:
     branches: [dev, main]
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -30,7 +31,7 @@ jobs:
 
     env:
       DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/reporium_test
-      REDIS_URL: ""
+      REDIS_URL: ${{ secrets.REDIS_URL }}
       INGESTION_API_KEY: test-api-key
       GH_USERNAME: testuser
       # `ENVIRONMENT=test` skips the embedding-model pre-warm in


### PR DESCRIPTION
## Summary
Two-line patch to `.github/workflows/ask-quality-gate.yml`:

1. Add `workflow_dispatch:` to the `on:` triggers — enables `gh workflow run ask-quality-gate.yml` (was returning HTTP 422 before because no manual trigger existed; surfaced during KAN-176 verification).
2. Wire `REDIS_URL: ${{ secrets.REDIS_URL }}` (replaces the literal `REDIS_URL: ""`) — lets the eval cache wrapper (KAN-176, PR #470, squash 7636a5b) connect when an operator provisions the secret.

## Why
- KAN-176 shipped the Anthropic eval-output cache wrapper. The wrapper is designed to **degrade gracefully** when `REDIS_URL` is empty / unreachable, so no functional change today; it just unblocks operator provisioning later.
- `workflow_dispatch` enables manual cache-warming verification once the secret is provisioned, plus on-demand re-runs for debugging.

## Out of scope
- **Operator action required:** provision `REDIS_URL` secret via `gh secret set REDIS_URL --repo perditioinc/reporium-api`. Until then, the env value evaluates to empty and the wrapper continues its existing graceful-degradation path.
- No changes to the cache wrapper itself (KAN-176 logic untouched).
- No additional triggers beyond `workflow_dispatch`.

## Test plan
- [ ] CI gate runs and stays green on this PR (proves `pull_request` trigger still works and `secrets.REDIS_URL`-empty path still degrades)
- [ ] Post-merge: `gh workflow run ask-quality-gate.yml --repo perditioinc/reporium-api` succeeds (was HTTP 422)
- [ ] Manually-triggered run completes successfully (cache wrapper degrades cleanly without Redis)

JIRA: https://perditio.atlassian.net/browse/KAN-181