### PR TITLE
KAN-180: extend Cache-Control: s-maxage to /trends/report + /repos/{owner}/{name}

### DIFF
--- a/app/routers/repos.py
+++ b/app/routers/repos.py
@@ -2,7 +2,7 @@ import hashlib
 import json
 import math
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from slowapi import Limiter
 from slowapi.util import get_remote_address
 from sqlalchemy import func, select, or_, cast, Text
@@ -432,8 +432,19 @@ async def get_repo(name: str, db: AsyncSession = Depends(get_db)) -> RepoDetail:
 
 
 @router.get("/repos/{owner}/{repo}", response_model=RepoDetail)
-async def get_repo_by_owner(owner: str, repo: str, db: AsyncSession = Depends(get_db)) -> RepoDetail:
+async def get_repo_by_owner(
+    owner: str,
+    repo: str,
+    response: Response,
+    db: AsyncSession = Depends(get_db),
+) -> RepoDetail:
     """Get a single repo by owner/name."""
+    # KAN-180: extend KAN-170 Cache-Control pattern (s-maxage + swr) to repo detail.
+    # Read-only public-data fetch keyed by owner/name; CDN edge can re-serve the
+    # detail payload for 5 min before revalidating. Browsers ignore s-maxage and
+    # still hit origin every visit, so freshness on first paint is unaffected.
+    response.headers["Cache-Control"] = "public, s-maxage=300, stale-while-revalidate=60"
+
     stmt = (
         select(Repo)
         .where(Repo.owner == owner, Repo.name == repo, public_repo_filter())

--- a/app/routers/trends.py
+++ b/app/routers/trends.py
@@ -102,7 +102,17 @@ async def get_trends(response: Response, db: AsyncSession = Depends(get_db)) -> 
 
 
 @router.get("/trends/report", response_model=TrendReportOut)
-async def get_trends_report(db: AsyncSession = Depends(get_db)) -> TrendReportOut:
+async def get_trends_report(
+    response: Response,
+    db: AsyncSession = Depends(get_db),
+) -> TrendReportOut:
+    # KAN-180: extend KAN-170 Cache-Control pattern (s-maxage + swr) to /trends/report.
+    # Read-only public-data fetch with 5-min Redis TTL; aligning the CDN window with
+    # the cache TTL means edge caches see a fresh report no later than ingestion's
+    # next refresh. Header is set unconditionally (before cache check) so cache hits
+    # also carry the directive.
+    response.headers["Cache-Control"] = "public, s-maxage=300, stale-while-revalidate=60"
+
     cached = await cache.get("trends:report")
     if cached:
         return TrendReportOut(**cached)

--- a/tests/test_repos.py
+++ b/tests/test_repos.py
@@ -128,3 +128,33 @@ async def test_repo_detail_includes_stargazers_count(client: AsyncClient):
     data = response.json()
     assert "stargazers_count" in data
     assert data["stargazers_count"] == 42
+
+
+# ---------------------------------------------------------------------------
+# KAN-180: Cache-Control header on /repos/{owner}/{name}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_repos_detail_response_has_cache_control(client: AsyncClient):
+    """KAN-180: /repos/{owner}/{name} must carry public, s-maxage=300, swr=60.
+
+    Extends the KAN-170 pattern (originally only on /library/preview) to repo
+    detail by owner/name. Set unconditionally so CDN edges can cache the
+    response for 5 min while browsers still revalidate on every visit.
+    """
+    await client.post("/ingest/repos", json=[TEST_REPO_FIXTURE], headers=AUTH_HEADERS)
+
+    owner = TEST_REPO_FIXTURE["owner"]
+    name = TEST_REPO_FIXTURE["name"]
+    response = await client.get(f"/repos/{owner}/{name}")
+    assert response.status_code == 200
+
+    cc = response.headers.get("cache-control", "")
+    assert "public" in cc, f"KAN-180: expected 'public' in Cache-Control, got: {cc!r}"
+    assert "s-maxage=300" in cc, (
+        f"KAN-180: expected s-maxage=300 in Cache-Control, got: {cc!r}"
+    )
+    assert "stale-while-revalidate=60" in cc, (
+        f"KAN-180: expected stale-while-revalidate=60 in Cache-Control, got: {cc!r}"
+    )

--- a/tests/test_trends.py
+++ b/tests/test_trends.py
@@ -97,3 +97,45 @@ async def test_get_trends_report_returns_sorted_report(monkeypatch):
     assert payload["trending"][0]["repoCount"] == 12
     assert payload["trending"][0]["changePercent"] == 200.0
     assert payload["emerging"][0]["name"] == "Agents"
+
+
+# ---------------------------------------------------------------------------
+# KAN-180: Cache-Control header on /trends/report
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_trends_report_response_has_cache_control(monkeypatch):
+    """KAN-180: /trends/report must carry public, s-maxage=300, swr=60.
+
+    Extends the KAN-170 pattern (originally only on /library/preview) to a
+    second read-only public-data endpoint. The header is set unconditionally
+    so it appears on both miss-path and cache-hit responses.
+    """
+    async def fake_get_db():
+        yield FakeTrendSession()
+
+    async def fake_cache_get(_key):
+        return None
+
+    async def fake_cache_set(_key, _value, ttl=None):
+        return None
+
+    app.dependency_overrides[get_db] = fake_get_db
+    monkeypatch.setattr(trends_router.cache, "get", fake_cache_get)
+    monkeypatch.setattr(trends_router.cache, "set", fake_cache_set)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.get("/trends/report")
+
+    app.dependency_overrides.clear()
+
+    assert response.status_code == 200
+    cc = response.headers.get("cache-control", "")
+    assert "public" in cc, f"KAN-180: expected 'public' in Cache-Control, got: {cc!r}"
+    assert "s-maxage=300" in cc, (
+        f"KAN-180: expected s-maxage=300 in Cache-Control, got: {cc!r}"
+    )
+    assert "stale-while-revalidate=60" in cc, (
+        f"KAN-180: expected stale-while-revalidate=60 in Cache-Control, got: {cc!r}"
+    )


### PR DESCRIPTION
## Summary

Extends the KAN-170 `Cache-Control` pattern (`public, s-maxage=300, stale-while-revalidate=60`) from `/library/preview` to two more read-only public-data endpoints:

- `/trends/report`
- `/repos/{owner}/{name}`

Per the 4h perf audit P3 recommendation. KAN-170 (PR #466, squash `3241182c`) was a deliberately conservative rollout to a single endpoint; this is the conservative extension to the next two endpoints with the lowest coupling risk.

## Why these two

Both are read-only public-data fetches with existing 5-min Redis caches. `s-maxage` only affects shared/CDN caches, so any future Cloud LB / CDN in front of Cloud Run can edge-cache repeated requests. Browsers ignore `s-maxage` and still revalidate every visit — user-perceived freshness on first paint is unchanged.

## What is intentionally skipped

- `/library/full` — legacy consumers (Workato, MCP, eval) may have implicit staleness assumptions; needs a separate regression-testing pass before tagging it cacheable.
- `/metrics/*` — operational dashboards often want fresh data; cacheability there is a per-endpoint judgment call, not a blanket extension.

## Implementation notes

- Header is set BEFORE the cache check (matching the KAN-170 implementation in `library_preview.py`) so cache hits also carry the directive — important so a CDN sees the same `Cache-Control` for first miss and subsequent hits.
- Neither endpoint had an existing `Cache-Control` header, so this is additive (no merge / overwrite).
- No response shapes changed; no cache TTLs changed; no Redis layer changes.

## Test plan

- [x] `pytest tests/test_trends.py` — new `test_trends_report_response_has_cache_control` passes locally
- [x] `pytest tests/test_repos.py` — new `test_repos_detail_response_has_cache_control` skips locally (no Postgres) but runs in CI alongside the existing `/repos` integration tests
- [x] Full suite: no new regressions vs. `origin/main` (the 2 `test_intelligence_quality.py` failures pre-exist on main and are unrelated to this change)
- [ ] Post-merge: `curl -sI https://reporium-api-573778300586.us-central1.run.app/trends/report | grep cache-control`
- [ ] Post-merge: `curl -sI https://reporium-api-573778300586.us-central1.run.app/repos/perditioinc/agno | grep cache-control`

## Refs

- KAN-180: https://perditio.atlassian.net/browse/KAN-180
- KAN-170 (original PR): #466