### PR TITLE
KAN-182: fix KAN-169 cache-bypass regression (CI green without --admin)

### DIFF
--- a/tests/test_intelligence_quality.py
+++ b/tests/test_intelligence_quality.py
@@ -138,13 +138,20 @@ def _make_anthropic_message(
 
 def _make_mock_db(rows):
     """
-    Return an AsyncMock db session whose execute() returns the given rows for
-    the embedding query and an empty result for the other queries.
+    Return an AsyncMock db session whose execute() routes by SQL shape:
+      - semantic-cache lookup (``query_log`` + ``question_embedding_vec``)
+        → result.first() returns None (cache miss)
+      - pgvector similarity (``repo_embeddings`` JOIN ``repos``)
+        → result.fetchall() returns the repo rows
+      - knowledge-graph edges (``repo_edges``) → result.fetchall() returns []
 
-    The endpoint makes three DB calls in order:
-      1. _find_semantic_cache_hit  → result.first() should be None (cache miss)
-      2. pgvector similarity query → result.fetchall() returns the repo rows
-      3. knowledge-graph edge query → result.fetchall() returns []
+    KAN-182: previously this used an ordered ``side_effect=[cache, rows, edges]``
+    list. KAN-169 (PR #467) made the semantic-cache lookup conditional — for
+    negation queries (``alternatives to <token>``) ``_prepare_query`` skips
+    ``_find_semantic_cache_hit`` entirely, so the call count drops from 3 to 2
+    and the ordered list returns ``cache`` (a None-row mock) when the code
+    actually wanted ``rows`` — surfacing as an empty source list and silent
+    test breakage. Routing by SQL shape is robust to call-count changes.
     """
     mock_cache_result = MagicMock()
     mock_cache_result.first.return_value = None  # no semantic cache hit
@@ -155,9 +162,24 @@ def _make_mock_db(rows):
     mock_edge_result = MagicMock()
     mock_edge_result.fetchall.return_value = []
 
+    # Default for any unrecognized query — empty result, fail-soft.
+    mock_default = MagicMock()
+    mock_default.first.return_value = None
+    mock_default.fetchall.return_value = []
+
+    async def _route(stmt, *args, **kwargs):
+        # ``stmt`` is a SQLAlchemy ``TextClause``; str() yields the raw SQL.
+        sql = str(stmt).lower()
+        if "query_log" in sql and "question_embedding_vec" in sql:
+            return mock_cache_result
+        if "repo_embeddings" in sql and "repos" in sql:
+            return mock_result
+        if "repo_edges" in sql:
+            return mock_edge_result
+        return mock_default
+
     mock_db = AsyncMock()
-    # 1st → semantic cache check; 2nd → vector similarity search; 3rd → knowledge-graph edges
-    mock_db.execute = AsyncMock(side_effect=[mock_cache_result, mock_result, mock_edge_result])
+    mock_db.execute = AsyncMock(side_effect=_route)
     return mock_db
 
 
@@ -937,11 +959,23 @@ async def test_ask_negation_bypasses_cache(client_no_db: AsyncClient):
         assert "pinecone" not in full, (
             f"KAN-169 regression: pinecone leaked into sources via cache as {full!r}"
         )
-    # And cache.set must NOT have been called for this negation query — so
-    # this turn's response can't pollute future cache hits either.
-    assert set_mock.call_count == 0, (
-        f"KAN-169 regression: cache.set was called {set_mock.call_count} times "
-        f"for a negation query (expected 0). Calls: {set_mock.call_args_list}"
+    # And no ``llm_response:`` cache write must occur for this negation query
+    # — so this turn's response can't pollute future cache hits either.
+    #
+    # KAN-182: scope the assertion to the ``llm_response:`` namespace
+    # (mirroring the ``_get_side_effect`` filter above). The handler still
+    # legitimately writes ``llm_cost:<date>`` via ``cost_tracker.record_cost``
+    # for daily-budget accounting on EVERY live LLM call (KAN-169's bypass is
+    # explicitly scoped to the response cache, not unrelated counters).
+    # Asserting ``call_count == 0`` would conflate the two and silently fail
+    # whenever cost tracking runs.
+    llm_response_writes = [
+        c for c in set_mock.call_args_list
+        if c.args and isinstance(c.args[0], str) and c.args[0].startswith("llm_response:")
+    ]
+    assert len(llm_response_writes) == 0, (
+        f"KAN-169 regression: cache.set was called for the llm_response: namespace "
+        f"on a negation query (expected 0). llm_response: calls: {llm_response_writes}"
     )
 
 

--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -128,14 +128,27 @@ async def test_backfill_hn_mentions_inserts(client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_backfill_hn_idempotent(client: AsyncClient):
-    """Running backfill twice should not create duplicates."""
+    """Running backfill twice should not create duplicates.
+
+    KAN-184: The endpoint enforces a ~1 req/s rate limit via
+    ``await asyncio.sleep(1.0)`` between repos. By the time this test
+    runs, the session-scoped DB has accumulated repos from earlier
+    tests, and the LIMIT 200 query plus two backfill invocations would
+    push wall-time well past the 60s pytest-timeout ceiling.
+
+    The mocked ``httpx.AsyncClient`` already eliminates real network
+    cost; mocking ``asyncio.sleep`` removes the only remaining
+    time-dominating operation while preserving the idempotency
+    assertion (the on-conflict-do-nothing semantics in the SQL path).
+    """
 
     mock_client = AsyncMock()
     mock_client.get = AsyncMock(return_value=_mock_hn_response(FAKE_HN_HITS))
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
 
-    with patch("app.routers.admin.httpx.AsyncClient", return_value=mock_client):
+    with patch("app.routers.admin.httpx.AsyncClient", return_value=mock_client), \
+         patch("app.routers.admin.asyncio.sleep", new=AsyncMock(return_value=None)):
         r1 = await client.post(
             "/admin/backfill-hn-mentions",
             headers={"Authorization": f"Bearer {TEST_API_KEY}"},


### PR DESCRIPTION
## Summary

Two ask-negation tests have been failing on `main` since KAN-169 (`61e914d`, PR #467) merged on 2026-05-03. Four subsequent PRs — KAN-175 (#469), KAN-176 (#470), KAN-180 (#473), KAN-181 (#471) — all merged with `--admin` overrides through these failing tests. This is the silent-failure-becomes-loud-signal pattern, with the loudness being suppressed by the override.

This PR un-silences it: it ships honest fixes, no `--admin` required.

## Root cause

Both failures are stale fixture assumptions in tests, not bugs in KAN-169's logic:

### 1. `test_ask_negation_preserves_non_match` — `assert 'weaviate' in set()`

`_make_mock_db` used `side_effect=[cache_mock, rows_mock, edges_mock]` — three DB calls in a fixed order. KAN-169 made the semantic-cache lookup **conditional**: for negation queries `_prepare_query` now skips `_find_semantic_cache_hit`, dropping the call count from 3 to 2. With the old ordered list, the pgvector similarity call received the cache mock (whose `.fetchall()` returns an auto-generated MagicMock, not iterable rows) — sources came back empty, and `assert "weaviate" in source_names` failed.

`test_ask_negation_drops_self_match` was vacuously passing under the same broken fixture (its assertion is "pinecone NOT in sources"; an empty set trivially satisfies that). It now exercises real fixture rows + real filter, which is what it always claimed to do.

### 2. `test_ask_negation_bypasses_cache` — `cache.set was called 1 times for ('llm_cost:2026-05-03', 0.00232, ttl=90000)`

Asserted `set_mock.call_count == 0` for the entire `cache.set` surface. KAN-169's bypass is scoped to the `llm_response:` namespace — the guarantee is *"this query's answer is never written back to the response cache"*. `cost_tracker.record_cost` still calls `cache.set("llm_cost:<date>", ...)` on every live LLM call for daily-budget accounting, which is independent of the response cache.

## Fix shape

- `_make_mock_db`: route by SQL shape (TextClause string match) rather than call order. Robust to any future conditional-skip in this hot path.
- `test_ask_negation_bypasses_cache`: scope the assertion to keys starting with `llm_response:` (mirroring the existing `_get_side_effect` filter on the read side).

Neither assertion is relaxed:
- Test 1 still hard-asserts `weaviate`/`qdrant`/`chroma` survive in sources.
- Test 2 still hard-asserts no `llm_response:` write occurs (proves the bypass — both directions).

KAN-169's production logic is unchanged; neither `app/routers/intelligence.py` nor any cache code is touched.

## Test plan

- [ ] `pytest tests/test_intelligence_quality.py -v` — all negation tests green
- [ ] `pytest tests/` — full suite green
- [ ] Tests workflow on this PR — green WITHOUT `--admin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)