### PR TITLE
KAN-184: fix test_backfill_hn_idempotent timeout flake (silent-failure cleanup)

### DIFF
--- a/tests/test_mentions.py
+++ b/tests/test_mentions.py
@@ -128,14 +128,27 @@ async def test_backfill_hn_mentions_inserts(client: AsyncClient):
 
 @pytest.mark.asyncio
 async def test_backfill_hn_idempotent(client: AsyncClient):
-    """Running backfill twice should not create duplicates."""
+    """Running backfill twice should not create duplicates.
+
+    KAN-184: The endpoint enforces a ~1 req/s rate limit via
+    ``await asyncio.sleep(1.0)`` between repos. By the time this test
+    runs, the session-scoped DB has accumulated repos from earlier
+    tests, and the LIMIT 200 query plus two backfill invocations would
+    push wall-time well past the 60s pytest-timeout ceiling.
+
+    The mocked ``httpx.AsyncClient`` already eliminates real network
+    cost; mocking ``asyncio.sleep`` removes the only remaining
+    time-dominating operation while preserving the idempotency
+    assertion (the on-conflict-do-nothing semantics in the SQL path).
+    """
 
     mock_client = AsyncMock()
     mock_client.get = AsyncMock(return_value=_mock_hn_response(FAKE_HN_HITS))
     mock_client.__aenter__ = AsyncMock(return_value=mock_client)
     mock_client.__aexit__ = AsyncMock(return_value=False)
 
-    with patch("app.routers.admin.httpx.AsyncClient", return_value=mock_client):
+    with patch("app.routers.admin.httpx.AsyncClient", return_value=mock_client), \
+         patch("app.routers.admin.asyncio.sleep", new=AsyncMock(return_value=None)):
         r1 = await client.post(
             "/admin/backfill-hn-mentions",
             headers={"Authorization": f"Bearer {TEST_API_KEY}"},


### PR DESCRIPTION
## Summary

Fixes the `tests/test_mentions.py::test_backfill_hn_idempotent` `Timeout >60.0s` flake that has been silently bypassed via `gh pr merge --admin` since KAN-179. Per the user's validate/secure/optimize directive, silent failures must surface — this PR fixes the test properly so [KAN-182 PR #474](https://github.com/perditioinc/reporium-api/pull/474) can merge cleanly without `--admin`.

JIRA: https://perditio.atlassian.net/browse/KAN-184

## Root cause

The `/admin/backfill-hn-mentions` endpoint enforces a ~1 req/s rate limit on the upstream HN Algolia API via `await asyncio.sleep(1.0)` between repos (`app/routers/admin.py:2543`). The mocked `httpx.AsyncClient` neutralizes the network cost, but the sleep is still real.

By the time `test_backfill_hn_idempotent` runs, the session-scoped test DB has accumulated repos from earlier tests in the suite. The `LIMIT 200` query × 1s sleep × 2 backfill invocations easily pushes wall-time past the 60s pytest-timeout ceiling.

The two earlier tests in the same file (`test_backfill_hn_mentions_dry_run`, `test_backfill_hn_mentions_inserts`) avoided the timeout because:
- `dry_run` runs early when the DB has few repos
- `inserts` finds N repos but the second run wasn't being executed

`idempotent` is the first test that runs the backfill twice, doubling its sleep budget.

## Fix (Approach 1: mock the slow primitive)

Mock `asyncio.sleep` alongside the existing `httpx.AsyncClient` mock:

```python
with patch("app.routers.admin.httpx.AsyncClient", return_value=mock_client),      patch("app.routers.admin.asyncio.sleep", new=AsyncMock(return_value=None)):
```

This removes the only remaining time-dominating operation. The idempotency assertion (the SQL path's `ON CONFLICT ON CONSTRAINT uq_repo_mentions_repo_source_ext DO NOTHING`) is fully preserved — the second run still has to execute the same code path, hit the same UNIQUE constraint, and return `mentions_inserted == 0`.

Pattern follows the established precedent at `tests/test_retention.py:95` (`patch("asyncio.sleep", new=AsyncMock())`).

## Why not approaches 2 or 3?

- **Function-scoped DB fixture** — would mask the underlying issue (rate-limit-during-tests) rather than fix it; also a much larger change touching `conftest.py`.
- **Bump per-test timeout** — last resort. Doesn't fix the flake, just makes it slower-failing. The root cause (real `asyncio.sleep` in mocked test) is solvable surgically.

## What this unblocks

- KAN-182 PR #474 can merge via `gh pr merge --squash --delete-branch` (NOT `--admin`)
- Future PRs that touch this code path will get honest CI signal

## Test plan

- [ ] CI green on this PR (no flake on `test_backfill_hn_idempotent`)
- [ ] All other tests in `tests/test_mentions.py` still pass
- [ ] Full `pytest tests/` green

## Constraints respected

- No `--admin` bypass
- Test not deleted, not skipped
- Mocking limited to the slow primitive (asyncio.sleep) — no over-mocking
- Idempotency assertion intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)