### PR TITLE
KAN-194: taxonomy doc reconciliation (API-side comments)

### DIFF
--- a/app/models/repo.py
+++ b/app/models/repo.py
@@ -93,7 +93,11 @@ class Repo(Base):
     # Structure: {risk_level, incident_reported, incident_date, incident_url, incident_summary}
     security_signals: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
 
-    # KAN-41 16-category taxonomy (backfilled by backfill_primary_category.py)
+    # KAN-41 fixed taxonomy (originally 16 categories; now 21 — see
+    # reporium-ingestion `ingestion/enrichment/taxonomy.py` `CATEGORIES`).
+    # Stores the category NAME (e.g. "AI Agents"), not an ID slug.
+    # Originally backfilled by backfill_primary_category.py (script removed);
+    # now derived from the canonical-pipeline payload during repo upsert.
     primary_category: Mapped[str | None] = mapped_column(Text, nullable=True)
     # Prod column is text[] (verified 2026-04-05). Prior JSONB declaration caused
     # `operator does not exist: text[] @> jsonb` in /repos/discover/cross-category.

--- a/tests/test_data_invariants.py
+++ b/tests/test_data_invariants.py
@@ -20,13 +20,14 @@ Run locally:
 NOTE on taxonomy dimensions
 ---------------------------
 The /taxonomy/<dim> endpoint uses the *repo_taxonomy dimension strings*, not
-the 16-category primary_category list from ENRICHMENT_PROMPT_V2.md.
+the 21-category primary_category list (ENRICHMENT_PROMPT_V2.md /
+reporium-ingestion ingestion/enrichment/taxonomy.py CATEGORIES).
 The 6 populated dims as of 2026-04-19 are:
     modality, use_case, deployment_context, skill_area, ai_trend, industry
 
-The 16 primary_category slugs (agents, rag-retrieval, …) are stored in
-repos.primary_category / repo_categories — a separate table — and are
-intentionally NOT queried here (they are covered by test_taxonomy_gaps.py).
+The 21 primary_category NAMES (e.g. "AI Agents", "RAG & Retrieval") are
+stored in repos.primary_category / repo_categories — a separate table — and
+are intentionally NOT queried here (they are covered by test_taxonomy_gaps.py).
 
 Audit finding: the two taxonomy systems are distinct. This invariant guards
 /taxonomy/<dim> (the taxonomy_values table populated by the rebuild job).
@@ -66,7 +67,7 @@ KNOWN_POPULATED_DIMS = [
 
 # Additional dims that may exist but are allowed to be empty (xfail-safe).
 # NOTE: "tags" and "categories" here refer to any future raw taxonomy dims,
-# not the 16-category primary_category slug list.
+# not the 21-category primary_category NAME list.
 POTENTIALLY_EMPTY_DIMS = {"tags", "categories"}
 
 MIN_POPULATED_DIMS = 3  # at least this many must return non-empty values
@@ -149,7 +150,7 @@ def test_taxonomy_dimensions_populated():
 
     Asserts that at least MIN_POPULATED_DIMS return a non-empty values list.
     These are the taxonomy_values dimensions populated by the rebuild job —
-    distinct from the 16-category primary_category slugs.
+    distinct from the 21-category primary_category NAME list.
 
     Catches: taxonomy_values table wipe, rebuild job failure, enrichment
     pipeline regression that zeroes out dimension counts.


### PR DESCRIPTION
## Summary

Companion to [reporium-ingestion KAN-194](https://github.com/perditioinc/reporium-ingestion/pulls?q=KAN-194) (`ENRICHMENT_PROMPT_V2.md` reconciliation). The canonical taxonomy lives in `reporium-ingestion/ingestion/enrichment/taxonomy.py` `CATEGORIES`, currently **21 entries**, and `repos.primary_category` stores the NAME (e.g. `"AI Agents"`), not an ID slug.

## What changed (comment-only)

- `app/models/repo.py:96` — KAN-41 comment said `# KAN-41 16-category taxonomy (backfilled by backfill_primary_category.py)`. Updated to note the current 21-name taxonomy, point at `taxonomy.py` as canonical, and acknowledge that the original backfill script no longer exists (the column is now derived from the canonical-pipeline payload during repo upsert per the 2026-04-26 audit).
- `tests/test_data_invariants.py` — three comments referencing `16-category primary_category list` / `16 primary_category slugs (agents, rag-retrieval, …)` updated to `21-category primary_category NAME list` / `21 primary_category NAMES (e.g. "AI Agents", "RAG & Retrieval")`.

## Why this is doc-only

`taxonomy.py` is the single source of truth and is untouched. Test code itself is unchanged — only the top-of-file documentation comment block. No DB migration, no behaviour change.

## Test plan

- [ ] CI green.
- [x] No code paths altered (only comments + docstrings).

JIRA: https://perditio.atlassian.net/browse/KAN-194