### PR TITLE
KAN-192: admin endpoint for enrichment quality probe

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -26,7 +26,7 @@ from app.rate_limit import rate_limit_storage
 from app.prometheus_metrics import record_http_request
 from app.slo_observer import slo_observer
 from app.database import async_session_factory, check_db_connection, engine
-from app.routers import admin, admin_visibility, analytics, compare, dependencies, graph, ingest, intelligence, library, library_aggregates, library_full, library_preview, mentions, nl_filter, platform, recommendations, repos, search, taxonomy, trends, webhooks, wiki
+from app.routers import admin, admin_enrichment, admin_visibility, analytics, compare, dependencies, graph, ingest, intelligence, library, library_aggregates, library_full, library_preview, mentions, nl_filter, platform, recommendations, repos, search, taxonomy, trends, webhooks, wiki
 from app.telemetry import init_telemetry
 
 
@@ -416,6 +416,7 @@ app.include_router(library_aggregates.router)
 app.include_router(taxonomy.router, prefix="/taxonomy")
 app.include_router(compare.router)
 app.include_router(admin.router)
+app.include_router(admin_enrichment.router)
 app.include_router(admin_visibility.router)
 app.include_router(webhooks.router)
 

--- a/app/routers/admin_enrichment.py
+++ b/app/routers/admin_enrichment.py
@@ -1,0 +1,474 @@
+"""
+Admin endpoint that runs the enrichment quality probe (KAN-191) in-process.
+
+KAN-192: the original probe lives in ``reporium-ingestion/ingestion/enrichment/
+quality_probe.py`` and connects to the DB directly via psycopg2. That works
+inside the Cloud Run Job (Unix-socket Cloud SQL connector) but fails from
+GitHub Actions, where ``DATABASE_URL`` points at a socket path that isn't
+mounted.
+
+Mirroring the established ``/admin/graph/rebuild-snapshot`` pattern: the API
+runs in-VPC where ``DATABASE_URL`` already works, so we expose the probe as
+an admin endpoint and let GitHub Actions call it via curl + ``X-Admin-Key``.
+
+The check logic here is a faithful port of the ground-truth probe in
+``reporium-ingestion@b10eae9``: same canonical category vocabulary, same
+sample-shape semantics, same floor thresholds. The probe-side Python module
+is preserved upstream for local development; this is the production path the
+nightly workflow now hits.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import require_admin_key
+from app.database import get_db
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(tags=["Admin"])
+
+
+# ── Canonical vocabulary ──────────────────────────────────────────────────────
+#
+# ``primary_category`` in the DB stores the human-readable category NAME (see
+# reporium-ingestion/ingestion/main.py — written as ``category_name``). This
+# must match what ``taxonomy.assign_primary_category()`` returns on the
+# enrichment side. The list below is copied verbatim from
+# ``reporium-ingestion/ingestion/enrichment/taxonomy.py`` (commit b10eae9).
+#
+# Drift risk: if the ingestion side adds/removes a category, this list must
+# be updated in the same change. The KAN-191 probe noted that
+# ``ENRICHMENT_PROMPT_V2.md`` is already out of sync with the live
+# ``taxonomy.py`` — we deliberately mirror the live code, not the doc.
+CANONICAL_CATEGORY_NAMES: frozenset[str] = frozenset(
+    {
+        "Foundation Models",
+        "AI Agents",
+        "RAG & Retrieval",
+        "Model Training",
+        "Evals & Benchmarking",
+        "Observability & Monitoring",
+        "Inference & Serving",
+        "Generative Media",
+        "Computer Vision",
+        "Robotics",
+        "Spatial & XR",
+        "MLOps & Infrastructure",
+        "Dev Tools & Automation",
+        "Cloud & Platforms",
+        "Learning Resources",
+        "Industry: Healthcare",
+        "Industry: FinTech",
+        "Industry: Audio & Music",
+        "Industry: Gaming",
+        "Security & Safety",
+        "Data Science & Analytics",
+    }
+)
+
+
+# Telltale strings that indicate the LLM refused / errored / hallucinated a
+# meta-comment instead of producing a clean summary. Match anywhere in the
+# summary, case-insensitive. Verbatim from the upstream probe.
+LLM_FAILURE_MARKERS: tuple[str, ...] = (
+    "I cannot",
+    "As an AI",
+    "I don't have",
+    "I do not have",
+    "Sorry, I",
+    "I'm unable",
+    "I am unable",
+    "I'm sorry",
+    "I am sorry",
+)
+
+
+# ── Result types ──────────────────────────────────────────────────────────────
+
+
+@dataclass
+class CheckResult:
+    name: str
+    passed: bool
+    floor: str
+    observed: str
+    failures: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class ProbeReport:
+    run_at: str
+    sample_size_target: int
+    sample_size_actual: int
+    total_enriched_in_corpus: int
+    overall_passed: bool
+    checks: list[CheckResult]
+
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        logger.warning("Invalid %s=%r — using default %d", name, raw, default)
+        return default
+
+
+@dataclass
+class ProbeConfig:
+    sample_size: int = 20
+    tags_total_floor: int = 100
+    summary_min_chars: int = 50
+    summary_max_chars: int = 2000
+    tag_max_chars: int = 50
+    total_enriched_floor: int = 1500
+    freshness_hours: int = 36
+
+    @classmethod
+    def from_env(cls) -> "ProbeConfig":
+        return cls(
+            sample_size=_env_int("PROBE_SAMPLE_SIZE", 20),
+            tags_total_floor=_env_int("PROBE_TAGS_TOTAL_FLOOR", 100),
+            summary_min_chars=_env_int("PROBE_SUMMARY_MIN_CHARS", 50),
+            summary_max_chars=_env_int("PROBE_SUMMARY_MAX_CHARS", 2000),
+            tag_max_chars=_env_int("PROBE_TAG_MAX_CHARS", 50),
+            total_enriched_floor=_env_int("PROBE_TOTAL_ENRICHED_FLOOR", 1500),
+            freshness_hours=_env_int("PROBE_FRESHNESS_HOURS", 36),
+        )
+
+
+# ── DB helpers ────────────────────────────────────────────────────────────────
+
+
+async def _fetch_sample(
+    db: AsyncSession, sample_size: int, freshness_hours: int
+) -> list[dict[str, Any]]:
+    """Pull a sample of recently-enriched repos for inspection.
+
+    "Recently enriched" = ``updated_at`` within ``freshness_hours`` AND has at
+    least one non-null enrichment field. There is no ``last_enriched_at``
+    column today; ``updated_at`` is the closest proxy because the enrichment
+    UPDATE bumps it (KAN-191 follow-up could add an explicit column).
+
+    If fewer than ``sample_size`` fresh rows exist, falls back to the most-
+    recently-updated enriched rows so the probe can still run on demand
+    (matches upstream probe behavior).
+    """
+    sql = text(
+        """
+        SELECT
+            id::text          AS id,
+            owner,
+            name,
+            primary_category,
+            integration_tags,
+            readme_summary,
+            updated_at
+        FROM repos
+        WHERE is_private = false
+          AND (
+              primary_category IS NOT NULL
+              OR integration_tags IS NOT NULL
+              OR readme_summary IS NOT NULL
+          )
+          AND updated_at >= NOW() - make_interval(hours => :hours)
+        ORDER BY updated_at DESC
+        LIMIT :limit
+        """
+    )
+    result = await db.execute(sql, {"hours": freshness_hours, "limit": sample_size})
+    rows = [dict(r._mapping) for r in result.fetchall()]
+
+    if len(rows) < sample_size:
+        fallback_sql = text(
+            """
+            SELECT
+                id::text          AS id,
+                owner,
+                name,
+                primary_category,
+                integration_tags,
+                readme_summary,
+                updated_at
+            FROM repos
+            WHERE is_private = false
+              AND (
+                  primary_category IS NOT NULL
+                  OR integration_tags IS NOT NULL
+                  OR readme_summary IS NOT NULL
+              )
+            ORDER BY updated_at DESC
+            LIMIT :limit
+            """
+        )
+        result = await db.execute(fallback_sql, {"limit": sample_size})
+        rows = [dict(r._mapping) for r in result.fetchall()]
+    return rows
+
+
+async def _fetch_total_enriched(db: AsyncSession) -> int:
+    """Corpus-shape check: how many public repos have any enrichment at all."""
+    sql = text(
+        """
+        SELECT COUNT(*)
+        FROM repos
+        WHERE is_private = false
+          AND (
+              readme_summary IS NOT NULL
+              OR primary_category IS NOT NULL
+              OR integration_tags IS NOT NULL
+          )
+        """
+    )
+    result = await db.execute(sql)
+    return int(result.scalar() or 0)
+
+
+def _coerce_tags(raw: Any) -> list[str]:
+    """``integration_tags`` is JSONB — SQLAlchemy/asyncpg auto-decode to list/
+    dict, but tolerate strings (raw JSON) and None for safety.
+    """
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        return [t for t in raw if isinstance(t, str)]
+    if isinstance(raw, str):
+        try:
+            decoded = json.loads(raw)
+        except json.JSONDecodeError:
+            return []
+        return (
+            [t for t in decoded if isinstance(t, str)]
+            if isinstance(decoded, list)
+            else []
+        )
+    return []
+
+
+# ── Checks ────────────────────────────────────────────────────────────────────
+
+
+def _short(repo: dict[str, Any]) -> str:
+    return f"{repo.get('owner') or '?'}/{repo.get('name') or '?'}"
+
+
+def check_category_in_vocabulary(sample: list[dict[str, Any]]) -> CheckResult:
+    failures: list[dict[str, Any]] = []
+    for repo in sample:
+        cat = repo.get("primary_category")
+        if cat is None:
+            # Allow null — sample includes any-enrichment rows; null
+            # primary_category is a separate corpus-shape concern (DQ gate).
+            continue
+        if cat not in CANONICAL_CATEGORY_NAMES:
+            failures.append({"repo": _short(repo), "primary_category": cat})
+    passed = len(failures) == 0
+    return CheckResult(
+        name="primary_category_in_vocabulary",
+        passed=passed,
+        floor="100% of non-null primary_category values must match taxonomy.CATEGORIES names",
+        observed=f"{len(sample) - len(failures)}/{len(sample)} valid (or null), {len(failures)} out-of-vocab",
+        failures=failures,
+    )
+
+
+def check_tags_present_and_length(
+    sample: list[dict[str, Any]],
+    *,
+    tag_max_chars: int,
+    tags_total_floor: int,
+) -> CheckResult:
+    failures: list[dict[str, Any]] = []
+    total_tags = 0
+    empty_count = 0
+    for repo in sample:
+        tags = _coerce_tags(repo.get("integration_tags"))
+        if not tags:
+            empty_count += 1
+            failures.append({"repo": _short(repo), "issue": "empty_tags"})
+            continue
+        total_tags += len(tags)
+        for t in tags:
+            if len(t) > tag_max_chars:
+                failures.append(
+                    {
+                        "repo": _short(repo),
+                        "issue": "tag_too_long",
+                        "tag": t[:80],
+                        "len": len(t),
+                    }
+                )
+    if total_tags < tags_total_floor:
+        failures.append(
+            {
+                "issue": "total_tags_below_floor",
+                "total_tags": total_tags,
+                "floor": tags_total_floor,
+            }
+        )
+    passed = len(failures) == 0
+    return CheckResult(
+        name="integration_tags_present_and_sane",
+        passed=passed,
+        floor=(
+            f">=1 tag per repo, each tag <= {tag_max_chars} chars, "
+            f"total >= {tags_total_floor}"
+        ),
+        observed=(
+            f"{len(sample) - empty_count}/{len(sample)} repos have tags, "
+            f"total tags = {total_tags}"
+        ),
+        failures=failures,
+    )
+
+
+def check_summary_length(
+    sample: list[dict[str, Any]],
+    *,
+    min_chars: int,
+    max_chars: int,
+) -> CheckResult:
+    failures: list[dict[str, Any]] = []
+    in_range = 0
+    for repo in sample:
+        s = repo.get("readme_summary")
+        if s is None:
+            failures.append({"repo": _short(repo), "issue": "null_summary"})
+            continue
+        n = len(s)
+        if n < min_chars:
+            failures.append({"repo": _short(repo), "issue": "too_short", "len": n})
+        elif n > max_chars:
+            failures.append({"repo": _short(repo), "issue": "too_long", "len": n})
+        else:
+            in_range += 1
+    passed = len(failures) == 0
+    return CheckResult(
+        name="readme_summary_length_in_range",
+        passed=passed,
+        floor=f"100% of summaries in [{min_chars}, {max_chars}] chars",
+        observed=f"{in_range}/{len(sample)} in range, {len(failures)} out of range or null",
+        failures=failures,
+    )
+
+
+def check_no_llm_failure_markers(sample: list[dict[str, Any]]) -> CheckResult:
+    failures: list[dict[str, Any]] = []
+    for repo in sample:
+        s = repo.get("readme_summary")
+        if not s:
+            continue
+        s_lower = s.lower()
+        for marker in LLM_FAILURE_MARKERS:
+            if marker.lower() in s_lower:
+                failures.append(
+                    {"repo": _short(repo), "marker": marker, "snippet": s[:160]}
+                )
+                break  # one hit per repo is enough
+    passed = len(failures) == 0
+    return CheckResult(
+        name="no_llm_failure_markers_in_summary",
+        passed=passed,
+        floor="0 occurrences across sample",
+        observed=f"{len(failures)} repos contain a failure marker",
+        failures=failures,
+    )
+
+
+def check_total_enriched_floor(total_enriched: int, floor: int) -> CheckResult:
+    passed = total_enriched >= floor
+    return CheckResult(
+        name="total_enriched_corpus_floor",
+        passed=passed,
+        floor=f">= {floor} enriched public repos",
+        observed=f"{total_enriched} enriched public repos",
+        failures=(
+            []
+            if passed
+            else [{"issue": "below_floor", "observed": total_enriched, "floor": floor}]
+        ),
+    )
+
+
+# ── Orchestration ─────────────────────────────────────────────────────────────
+
+
+async def run_probe(db: AsyncSession, config: ProbeConfig) -> ProbeReport:
+    sample = await _fetch_sample(db, config.sample_size, config.freshness_hours)
+    total_enriched = await _fetch_total_enriched(db)
+
+    checks = [
+        check_category_in_vocabulary(sample),
+        check_tags_present_and_length(
+            sample,
+            tag_max_chars=config.tag_max_chars,
+            tags_total_floor=config.tags_total_floor,
+        ),
+        check_summary_length(
+            sample,
+            min_chars=config.summary_min_chars,
+            max_chars=config.summary_max_chars,
+        ),
+        check_no_llm_failure_markers(sample),
+        check_total_enriched_floor(total_enriched, config.total_enriched_floor),
+    ]
+
+    return ProbeReport(
+        run_at=datetime.now(timezone.utc).isoformat(),
+        sample_size_target=config.sample_size,
+        sample_size_actual=len(sample),
+        total_enriched_in_corpus=total_enriched,
+        overall_passed=all(c.passed for c in checks),
+        checks=checks,
+    )
+
+
+# ── HTTP endpoint ─────────────────────────────────────────────────────────────
+
+
+@router.post("/admin/enrichment/quality-probe", response_model=dict)
+async def enrichment_quality_probe(
+    db: AsyncSession = Depends(get_db),
+    _admin_key: None = Depends(require_admin_key),
+) -> dict:
+    """KAN-192 — run the KAN-191 enrichment quality probe in-process.
+
+    Returns ``200`` with the full probe report when every check passes, or
+    ``422`` with the same shape when any check fails. The HTTP non-2xx is
+    what the caller (GitHub Actions ``nightly_enrichment_quality_probe.yml``)
+    pivots on to fail the workflow and trigger the existing Workato → JIRA
+    notify-on-failure pipeline.
+
+    Config is read from environment variables on the API side (``PROBE_*``,
+    same names as the upstream probe), not from the request body, so that
+    changing thresholds is an ops action against the running deployment
+    rather than a CI-side knob exposed to anyone with the admin key.
+    """
+    config = ProbeConfig.from_env()
+    report = await run_probe(db, config)
+    payload = asdict(report)
+
+    if not report.overall_passed:
+        # 422 Unprocessable Entity: the request was well-formed but the
+        # probe found data-quality breaches that the caller must surface.
+        # Body still includes the full report so the workflow log can show
+        # exactly which check tripped without a second round-trip.
+        raise HTTPException(status_code=422, detail=payload)
+
+    return payload

--- a/tests/test_admin_enrichment.py
+++ b/tests/test_admin_enrichment.py
@@ -1,0 +1,353 @@
+"""Tests for the KAN-192 admin enrichment quality probe endpoint.
+
+The probe logic itself is a port of the KAN-191 ground-truth probe in
+``reporium-ingestion``. These tests cover both:
+
+  * The pure check functions (no DB) — verifies the port matches the
+    upstream behavior for boundary cases on every check.
+  * The HTTP endpoint round-trip (auth + DB + status code) — verifies the
+    wiring that GitHub Actions pivots on.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+
+from app.database import async_session_factory
+from app.routers.admin_enrichment import (
+    CANONICAL_CATEGORY_NAMES,
+    LLM_FAILURE_MARKERS,
+    ProbeConfig,
+    check_category_in_vocabulary,
+    check_no_llm_failure_markers,
+    check_summary_length,
+    check_tags_present_and_length,
+    check_total_enriched_floor,
+)
+
+
+# ── Pure check functions ──────────────────────────────────────────────────────
+
+
+def _repo(
+    *,
+    owner: str = "octocat",
+    name: str = "demo",
+    primary_category: str | None = None,
+    integration_tags=None,
+    readme_summary: str | None = None,
+) -> dict:
+    return {
+        "owner": owner,
+        "name": name,
+        "primary_category": primary_category,
+        "integration_tags": integration_tags,
+        "readme_summary": readme_summary,
+    }
+
+
+def test_canonical_vocabulary_has_expected_size():
+    # The upstream probe enumerates 21 categories — guards against a silent
+    # taxonomy drop that would let any LLM output through unchallenged.
+    assert len(CANONICAL_CATEGORY_NAMES) == 21
+    assert "AI Agents" in CANONICAL_CATEGORY_NAMES
+    assert "Data Science & Analytics" in CANONICAL_CATEGORY_NAMES
+
+
+def test_check_category_passes_when_all_in_vocab():
+    sample = [
+        _repo(primary_category="AI Agents"),
+        _repo(primary_category="RAG & Retrieval"),
+        _repo(primary_category=None),  # null is allowed (separate concern)
+    ]
+    result = check_category_in_vocabulary(sample)
+    assert result.passed is True
+    assert result.failures == []
+
+
+def test_check_category_fails_on_out_of_vocab():
+    sample = [
+        _repo(primary_category="AI Agents"),
+        _repo(owner="bad", name="repo", primary_category="Made Up Category"),
+    ]
+    result = check_category_in_vocabulary(sample)
+    assert result.passed is False
+    assert len(result.failures) == 1
+    assert result.failures[0]["repo"] == "bad/repo"
+    assert result.failures[0]["primary_category"] == "Made Up Category"
+
+
+def test_check_tags_passes_with_enough_total():
+    # 20 repos × 5 tags = 100 tags total — exactly at floor
+    sample = [_repo(integration_tags=["a", "b", "c", "d", "e"]) for _ in range(20)]
+    result = check_tags_present_and_length(
+        sample, tag_max_chars=50, tags_total_floor=100
+    )
+    assert result.passed is True
+
+
+def test_check_tags_fails_on_empty():
+    sample = [_repo(integration_tags=[]), _repo(integration_tags=["ok"])]
+    result = check_tags_present_and_length(
+        sample, tag_max_chars=50, tags_total_floor=1
+    )
+    assert result.passed is False
+    assert any(f.get("issue") == "empty_tags" for f in result.failures)
+
+
+def test_check_tags_fails_on_overlong_tag():
+    long_tag = "x" * 51
+    sample = [_repo(integration_tags=[long_tag, "ok"])]
+    result = check_tags_present_and_length(
+        sample, tag_max_chars=50, tags_total_floor=1
+    )
+    assert result.passed is False
+    assert any(f.get("issue") == "tag_too_long" for f in result.failures)
+
+
+def test_check_tags_fails_on_total_below_floor():
+    sample = [_repo(integration_tags=["only-one"])]
+    result = check_tags_present_and_length(
+        sample, tag_max_chars=50, tags_total_floor=100
+    )
+    assert result.passed is False
+    assert any(f.get("issue") == "total_tags_below_floor" for f in result.failures)
+
+
+def test_check_tags_handles_jsonb_string_form():
+    # JSONB usually decodes to list, but tolerate string-of-JSON.
+    sample = [_repo(integration_tags='["a", "b", "c"]')]
+    result = check_tags_present_and_length(
+        sample, tag_max_chars=50, tags_total_floor=1
+    )
+    # 3 tags total, none too long → passes the floor of 1
+    assert result.passed is True
+
+
+def test_check_summary_passes_in_range():
+    sample = [_repo(readme_summary="x" * 100), _repo(readme_summary="y" * 500)]
+    result = check_summary_length(sample, min_chars=50, max_chars=2000)
+    assert result.passed is True
+
+
+def test_check_summary_fails_on_too_short():
+    sample = [_repo(owner="a", name="b", readme_summary="too short")]
+    result = check_summary_length(sample, min_chars=50, max_chars=2000)
+    assert result.passed is False
+    assert any(f.get("issue") == "too_short" for f in result.failures)
+
+
+def test_check_summary_fails_on_too_long():
+    sample = [_repo(owner="a", name="b", readme_summary="x" * 3000)]
+    result = check_summary_length(sample, min_chars=50, max_chars=2000)
+    assert result.passed is False
+    assert any(f.get("issue") == "too_long" for f in result.failures)
+
+
+def test_check_summary_fails_on_null():
+    sample = [_repo(owner="a", name="b", readme_summary=None)]
+    result = check_summary_length(sample, min_chars=50, max_chars=2000)
+    assert result.passed is False
+    assert any(f.get("issue") == "null_summary" for f in result.failures)
+
+
+def test_check_no_llm_failure_markers_passes_clean():
+    sample = [_repo(readme_summary="A useful library for vector search.")]
+    result = check_no_llm_failure_markers(sample)
+    assert result.passed is True
+
+
+@pytest.mark.parametrize("marker", LLM_FAILURE_MARKERS)
+def test_check_llm_failure_markers_catches_each(marker):
+    sample = [_repo(owner="a", name="b", readme_summary=f"{marker} help with this.")]
+    result = check_no_llm_failure_markers(sample)
+    assert result.passed is False
+    assert len(result.failures) == 1
+    assert result.failures[0]["marker"] == marker
+
+
+def test_check_llm_failure_markers_is_case_insensitive():
+    sample = [_repo(owner="a", name="b", readme_summary="i CANNOT do that, sorry.")]
+    result = check_no_llm_failure_markers(sample)
+    assert result.passed is False
+
+
+def test_check_total_enriched_floor_passes_at_threshold():
+    result = check_total_enriched_floor(1500, 1500)
+    assert result.passed is True
+
+
+def test_check_total_enriched_floor_fails_below():
+    result = check_total_enriched_floor(1499, 1500)
+    assert result.passed is False
+    assert result.failures[0]["issue"] == "below_floor"
+
+
+# ── Config from env ───────────────────────────────────────────────────────────
+
+
+def test_probe_config_defaults():
+    config = ProbeConfig.from_env()
+    # Defaults should match the upstream probe verbatim.
+    assert config.sample_size == 20
+    assert config.tags_total_floor == 100
+    assert config.summary_min_chars == 50
+    assert config.summary_max_chars == 2000
+    assert config.tag_max_chars == 50
+    assert config.total_enriched_floor == 1500
+    assert config.freshness_hours == 36
+
+
+def test_probe_config_env_overrides(monkeypatch):
+    monkeypatch.setenv("PROBE_SAMPLE_SIZE", "5")
+    monkeypatch.setenv("PROBE_TOTAL_ENRICHED_FLOOR", "10")
+    config = ProbeConfig.from_env()
+    assert config.sample_size == 5
+    assert config.total_enriched_floor == 10
+
+
+def test_probe_config_invalid_env_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("PROBE_SAMPLE_SIZE", "not-a-number")
+    config = ProbeConfig.from_env()
+    assert config.sample_size == 20  # falls back
+
+
+# ── HTTP endpoint integration ────────────────────────────────────────────────
+#
+# These tests exercise the full request → DB → response path. They depend on
+# the conftest test DB fixture (skipped automatically when the test Postgres
+# is unreachable, same as every other admin test).
+
+
+@pytest.fixture
+def test_admin_key(monkeypatch):
+    """Set ADMIN_API_KEY to a known value AND switch to production mode so
+    require_admin_key actually enforces it (default test config leaves it
+    unset and require_admin_key short-circuits in non-prod)."""
+    monkeypatch.setenv("ADMIN_API_KEY", "test-admin-key")
+    monkeypatch.setenv("ENVIRONMENT", "production")
+    yield "test-admin-key"
+
+
+@pytest.mark.asyncio
+async def test_quality_probe_requires_admin_key(client: AsyncClient, test_admin_key):
+    response = await client.post("/admin/enrichment/quality-probe")
+    assert response.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_quality_probe_rejects_wrong_key(client: AsyncClient, test_admin_key):
+    response = await client.post(
+        "/admin/enrichment/quality-probe",
+        headers={"X-Admin-Key": "nope"},
+    )
+    assert response.status_code == 403
+
+
+async def _seed_enriched_repos(count: int, *, fresh: bool = True) -> list[str]:
+    """Insert ``count`` minimal enriched public repos directly via SQL.
+
+    Bypasses the ORM so we can write JSONB/UUID values without bringing in
+    the full ingest payload. Returns the inserted IDs for cleanup.
+    """
+    inserted: list[str] = []
+    updated_at = datetime.now(timezone.utc) - (
+        timedelta(hours=1) if fresh else timedelta(days=30)
+    )
+    async with async_session_factory() as session:
+        for i in range(count):
+            rid = str(uuid.uuid4())
+            inserted.append(rid)
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO repos (
+                        id, owner, name, github_url, primary_category,
+                        integration_tags, readme_summary, is_private,
+                        created_at, updated_at
+                    ) VALUES (
+                        :id, :owner, :name, :url, :pc,
+                        CAST(:tags AS JSONB), :summary, false,
+                        NOW(), :updated_at
+                    )
+                    """
+                ),
+                {
+                    "id": rid,
+                    "owner": "kan192",
+                    "name": f"repo-{i}",
+                    "url": f"https://github.com/kan192/repo-{i}",
+                    "pc": "AI Agents",
+                    "tags": '["agents", "llm", "tools", "memory", "planning"]',
+                    "summary": "A minimal but realistic README summary used for the KAN-192 probe integration test. " * 2,
+                    "updated_at": updated_at,
+                },
+            )
+        await session.commit()
+    return inserted
+
+
+async def _purge_repos(ids: list[str]) -> None:
+    if not ids:
+        return
+    async with async_session_factory() as session:
+        await session.execute(
+            text("DELETE FROM repos WHERE id = ANY(CAST(:ids AS uuid[]))"),
+            {"ids": ids},
+        )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_quality_probe_returns_422_on_empty_corpus(
+    client: AsyncClient, test_admin_key, monkeypatch
+):
+    """With a fresh test DB the corpus is empty — total_enriched is 0,
+    well below the default 1500 floor, so the probe must FAIL.
+    """
+    # Lower floors so the test isn't dependent on huge sample seeding.
+    monkeypatch.setenv("PROBE_TOTAL_ENRICHED_FLOOR", "1500")
+    response = await client.post(
+        "/admin/enrichment/quality-probe",
+        headers={"X-Admin-Key": test_admin_key},
+    )
+    assert response.status_code == 422
+    body = response.json()
+    detail = body["detail"]
+    assert detail["overall_passed"] is False
+    # The total_enriched check must be one of the failures.
+    names = {c["name"] for c in detail["checks"] if not c["passed"]}
+    assert "total_enriched_corpus_floor" in names
+
+
+@pytest.mark.asyncio
+async def test_quality_probe_returns_200_when_all_pass(
+    client: AsyncClient, test_admin_key, monkeypatch
+):
+    """With a small seeded corpus and lowered thresholds, every check
+    should pass and the endpoint should return 200 with the report."""
+    # Lower floors to match what we can realistically seed in a test DB.
+    monkeypatch.setenv("PROBE_TOTAL_ENRICHED_FLOOR", "5")
+    monkeypatch.setenv("PROBE_TAGS_TOTAL_FLOOR", "5")
+    monkeypatch.setenv("PROBE_SAMPLE_SIZE", "5")
+
+    seeded = await _seed_enriched_repos(5, fresh=True)
+    try:
+        response = await client.post(
+            "/admin/enrichment/quality-probe",
+            headers={"X-Admin-Key": test_admin_key},
+        )
+        assert response.status_code == 200, response.text
+        body = response.json()
+        assert body["overall_passed"] is True
+        assert body["sample_size_actual"] == 5
+        assert body["total_enriched_in_corpus"] >= 5
+        # Every check must report passed=True
+        assert all(c["passed"] for c in body["checks"])
+    finally:
+        await _purge_repos(seeded)

--- a/tests/test_admin_enrichment.py
+++ b/tests/test_admin_enrichment.py
@@ -269,11 +269,11 @@ async def _seed_enriched_repos(count: int, *, fresh: bool = True) -> list[str]:
                     INSERT INTO repos (
                         id, owner, name, github_url, primary_category,
                         integration_tags, readme_summary, is_private,
-                        created_at, updated_at
+                        updated_at
                     ) VALUES (
                         :id, :owner, :name, :url, :pc,
                         CAST(:tags AS JSONB), :summary, false,
-                        NOW(), :updated_at
+                        :updated_at
                     )
                     """
                 ),


### PR DESCRIPTION
## Summary

KAN-192 wires the KAN-191 enrichment quality probe so it can actually run from GitHub Actions. Today the workflow fails at psycopg2 connection because `DATABASE_URL` points at a Cloud SQL Unix socket only mounted in GCP runtimes; the GHA runner has no socket.

This PR mirrors the `/admin/graph/rebuild-snapshot` pattern (used by `nightly_graph_build.yml`): expose the probe as an admin endpoint here, where the API runs in-VPC and `DATABASE_URL` works, and let the workflow call it via `curl` + `X-Admin-Key`.

`POST /admin/enrichment/quality-probe` runs the same five checks as the ground-truth probe in [reporium-ingestion@b10eae9](https://github.com/perditioinc/reporium-ingestion/commit/b10eae9):

1. `primary_category` in canonical 21-category vocabulary
2. `integration_tags` non-empty + each tag < 50 chars + total >= 100
3. `readme_summary` length in [50, 2000] chars
4. No LLM-failure markers in summaries
5. Total enriched corpus >= 1500

Returns `200` with the report on pass, `422` with the same shape on fail. The non-2xx is what the workflow pivots on to fail the run and trigger the existing Workato -> JIRA notify-on-failure pipeline.

The 21-name canonical vocabulary is copied verbatim from `reporium-ingestion/ingestion/enrichment/taxonomy.py` (~70 LOC duplication, well under the KAN-192 150-LOC threshold). A drift-guard test asserts the size and a couple of representative names so a silent vocabulary drop fails CI.

This is PR 1 of 2 — PR 2 (reporium-ingestion) rewrites the workflow to call this endpoint.

## Test plan

- [x] 28 pure check tests (vocabulary, tag length, summary length, every LLM marker parametrized, total floor, config from env)
- [x] 4 HTTP integration tests (auth, wrong key, empty-corpus 422, seeded-corpus 200) — auto-skip without local PG, run in CI
- [x] App-import + route-mount sanity check
- [ ] CI green (test x2, ask-quality-gate, migration-smoke)
- [ ] Live endpoint after merge: `curl -X POST .../admin/enrichment/quality-probe -H "X-Admin-Key: ..."`

## Notes

- Threshold config is read from `PROBE_*` env vars on the API side (same names as the upstream probe), not from request body — changing thresholds is an ops action against the running deployment, not a CI-side knob.
- The local `quality_probe.py` Python module in reporium-ingestion stays put for development testing; the workflow just no longer invokes it directly.