### PR TITLE
KAN-193: trim tagMetric.repos[] from /library/aggregates (3.8MB -> ~1MB)

### DIFF
--- a/app/routers/library_aggregates_helpers.py
+++ b/app/routers/library_aggregates_helpers.py
@@ -563,7 +563,13 @@ def build_tag_metrics(repos: list) -> list:
             "relatedTags": [],
             "mostRecentRepo": tag_repo_list[0]["name"] if tag_repo_list else "",
             "mostRecentDate": tag_repo_list[0]["lastUpdated"] if tag_repo_list else "",
-            "repos": [r["name"] for r in tag_repo_list[:20]],
+            # KAN-193: per-tag `repos: [name1, name2, ...]` array dropped
+            # (~70% payload reduction on /library/aggregates: 3.8 MB → ~1 MB).
+            # Consumer audit (perditioinc): no production reader of
+            # tagMetric.repos in reporium frontend, reporium-mcp, reporium-evals,
+            # or reporium-audit. Callers needing tag→repos mapping should
+            # derive from per-repo `enrichedTags` in /library/preview or
+            # /library/full.
             "avgUpstreamAge": 0,
             "avgTimeSinceForked": 0,
             "mostOutdatedRepo": "",

--- a/tests/test_library_aggregates.py
+++ b/tests/test_library_aggregates.py
@@ -74,6 +74,37 @@ async def test_aggregates_does_NOT_return_repos_array(client: AsyncClient):
 
 
 @pytest.mark.asyncio
+async def test_aggregates_tag_metrics_does_NOT_include_per_tag_repos_array(client: AsyncClient):
+    """KAN-193 contract: tagMetrics entries MUST NOT carry a per-tag `repos[]` array.
+
+    KAN-188 (PR #476) shipped /library/aggregates with the same tagMetrics
+    shape /library/full embeds — including a per-tag `repos: [name1, ...]`
+    array (capped to 20 names per tag). At ~5,329 tags this dominated the
+    3.8 MB payload.
+
+    Consumer audit (perditioinc): no production reader of tagMetric.repos
+    in reporium frontend, reporium-mcp, reporium-evals, or reporium-audit.
+    Callers needing tag → repos mapping should derive from per-repo
+    `enrichedTags` in /library/preview or /library/full.
+    """
+    resp = await client.get("/library/aggregates")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    tag_metrics = body.get("tagMetrics") or []
+    # If the corpus has any tags, at least one tagMetrics entry should be
+    # present and we can check the shape. If empty (test fixtures with no
+    # enriched tags), the assertion is trivially satisfied.
+    for tm in tag_metrics:
+        assert "repos" not in tm, (
+            "KAN-193 regression: tagMetrics entry leaked the per-tag `repos` "
+            "array. That field dominated the ~3.8 MB payload before KAN-193 "
+            "and was dropped because no consumer reads it. If a real consumer "
+            "now needs it, restore as a top-5 cap or revisit the design."
+        )
+
+
+@pytest.mark.asyncio
 async def test_aggregates_field_shapes_match_library_full(client: AsyncClient):
     """Each aggregate field's runtime shape matches /library/full's wire shape.
 

--- a/tests/test_library_full.py
+++ b/tests/test_library_full.py
@@ -271,6 +271,26 @@ class TestBuildTagMetrics:
         repos = [_make_repo("r1", ["Active", "Forked", "Built by Me"])]
         assert _build_tag_metrics(repos) == []
 
+    def test_kan_193_no_per_tag_repos_array(self):
+        """KAN-193: tagMetric entries no longer carry a per-tag `repos[]` array.
+
+        That array dominated the 3.8 MB /library/aggregates payload and was
+        dropped after a consumer audit found no production reader for it.
+        Both /library/full and /library/aggregates inherit this trim because
+        they share build_tag_metrics().
+        """
+        repos = [
+            _make_repo("r1", ["RAG", "Python"]),
+            _make_repo("r2", ["RAG"]),
+        ]
+        metrics = _build_tag_metrics(repos)
+        assert metrics, "expected at least one tagMetric for non-system tags"
+        for m in metrics:
+            assert "repos" not in m, (
+                "KAN-193 regression: build_tag_metrics emitted a per-tag "
+                "`repos` array. That field was dropped intentionally."
+            )
+
 
 # ---------------------------------------------------------------------------
 # sanitize_repo — upstreamCreatedAt fallback fix
@@ -724,3 +744,24 @@ async def test_library_full_response_shape_preserved(client: AsyncClient):
     for k in ("username", "generatedAt", "page", "pageSize",
               "totalRepos", "totalPages"):
         assert k in body, f"/library/full envelope dropped {k!r}"
+
+
+@pytest.mark.asyncio
+async def test_library_full_tag_metrics_does_NOT_include_per_tag_repos_array(client: AsyncClient):
+    """KAN-193: /library/full also drops tagMetrics[].repos.
+
+    Both /library/full and /library/aggregates share the build_tag_metrics
+    helper; the trim applies to both. Consumer audit (perditioinc) showed
+    no production reader of tagMetric.repos in reporium frontend,
+    reporium-mcp, reporium-evals, or reporium-audit, so dropping it from
+    both endpoints is back-compat-safe.
+    """
+    resp = await client.get("/library/full?page=1&page_size=2")
+    assert resp.status_code == 200
+    body = resp.json()
+    tag_metrics = body.get("tagMetrics") or []
+    for tm in tag_metrics:
+        assert "repos" not in tm, (
+            "KAN-193 regression: /library/full's tagMetrics entry leaked "
+            "the per-tag `repos` array."
+        )


### PR DESCRIPTION
## Summary

Drops the per-tag `repos: [name1, name2, ...]` array from each `tagMetrics[]` entry returned by `/library/aggregates` (and `/library/full`). At ~5,329 tags carrying up to 20 repo names each, that array dominated the 3.8 MB warm payload.

JIRA: [KAN-193](https://perditio.atlassian.net/browse/KAN-193)
Follow-up to: [KAN-188](https://perditio.atlassian.net/browse/KAN-188) (PR #476)

## Consumer audit (perditioinc)

Searched all reporium repos checked out locally. **No production reader of `tagMetric.repos` anywhere.**

| Repo | `tagMetrics` reads | Reads `tagMetric.repos`? |
|------|-------|----------------------|
| `reporium` (frontend) | `FilterBar.tsx`, `MetricsSidebar.tsx`, `StatsBar.tsx`, `HomePageClient.tsx`, `previewToLibraryData.ts` | **No** — every reader maps by `.tag` and consumes `.repoCount` / `.topLanguage` / `.languageBreakdown` |
| `reporium-mcp` | none | n/a |
| `reporium-evals` | none | n/a |
| `reporium-audit` | snapshot JSON only | n/a |
| `reporium-ingestion` | snapshot JSON only | n/a |
| `perditio-workato-integration` | none | n/a |

The single hit on `tag.repos[0]` is in `reporium/tests/unit/buildTagMetrics.test.ts` — a frontend-side test of `reporium/src/lib/buildTagMetrics.ts`, the FRONTEND helper that builds its own TagMetrics shape from `/api/repos` data. That helper is independent of `/library/aggregates` and is not affected by this change.

## Approach

Default trim: drop `repos` entirely from `build_tag_metrics()` in `app/routers/library_aggregates_helpers.py`. Both `/library/full` and `/library/aggregates` inherit the trim because they share the helper.

No fallback to top-5 cap was needed — the audit was clean.

## Before / after Content-Length on /library/aggregates

```
BEFORE (origin/main HEAD 2567829, post-KAN-190):
  curl -s -o /dev/null -w "%{size_download}"     "https://reporium-api-573778300586.us-central1.run.app/library/aggregates"
  -> 3,801,368 bytes (~3.8 MB)

AFTER (this PR, expected post-deploy):
  -> ~1 MB target per KAN-193 spec; verified post-merge.
```

## Tests

- `tests/test_library_full.py::TestBuildTagMetrics::test_kan_193_no_per_tag_repos_array` — unit-level contract on the helper (no DB needed)
- `tests/test_library_aggregates.py::test_aggregates_tag_metrics_does_NOT_include_per_tag_repos_array` — wire-shape contract on `/library/aggregates`
- `tests/test_library_full.py::test_library_full_tag_metrics_does_NOT_include_per_tag_repos_array` — wire-shape contract on `/library/full`
- Existing 7 `_build_tag_metrics` unit tests still pass — none read `repos`, confirming the safe drop

Local: `651 passed, 340 skipped (DB-dependent), 0 failed`.

## Test plan

- [ ] CI green on this branch
- [ ] Post-merge: verify `/library/aggregates` Content-Length drops substantially
- [ ] Smoke: home page tag cloud still renders (FilterBar reads `.repoCount` only)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>