### PR TITLE
KAN-201 PR2: drop categories[].tags from /library/aggregates

### DIFF
--- a/app/routers/library_aggregates_helpers.py
+++ b/app/routers/library_aggregates_helpers.py
@@ -633,17 +633,18 @@ def build_categories(repos: list) -> list:
         "Data Science & Analytics": "\U0001F4CA",
     }
 
+    # KAN-201: drop the per-category `tags` array. It was the single largest
+    # contributor to /library/aggregates at ~1.52 MB / 40% of payload (KAN-195
+    # audit). The frontend now derives the same set client-side from per-repo
+    # `enrichedTags` filtered by `allCategories.includes(cat.name)` (see
+    # FilterBar `categoryTagsMap` and HomePageClient — KAN-201 PR1, reporium#306).
+    # Mirrors the KAN-193 trim that dropped `tagMetric.repos`.
     categories = []
     for cat, cat_repo_list in sorted(cat_repos.items()):
-        cat_tags = set()
-        for r in cat_repo_list:
-            cat_tags.update(r["enrichedTags"])
-
         categories.append({
             "id": cat.lower().replace(" ", "-"),
             "name": cat,
             "description": f"Repos related to {cat.lower()}",
-            "tags": sorted(cat_tags),
             "repoCount": len(cat_repo_list),
             "color": COLORS.get(cat, "#94a3b8"),
             "icon": ICONS.get(cat, "\U0001F4E6"),

--- a/tests/test_library_aggregates.py
+++ b/tests/test_library_aggregates.py
@@ -105,6 +105,37 @@ async def test_aggregates_tag_metrics_does_NOT_include_per_tag_repos_array(clien
 
 
 @pytest.mark.asyncio
+async def test_aggregates_categories_does_NOT_include_per_category_tags_array(client: AsyncClient):
+    """KAN-201 contract: categories entries MUST NOT carry a per-category `tags[]`.
+
+    KAN-195 audit identified `categories[].tags` as the single largest
+    contributor to /library/aggregates at ~1.52 MB / 40% of payload (3.54 MB
+    post-KAN-193). The frontend used to read this on `FilterBar.tsx:165` to
+    drive the per-category tag row; KAN-201 PR1 (reporium#306) rewired
+    FilterBar to derive the same set client-side from per-repo `enrichedTags`
+    filtered by `allCategories.includes(cat.name)`. This PR drops the field
+    server-side now that nothing reads it.
+
+    Mirrors the KAN-193 pattern (`tagMetric.repos` trim) — see
+    `test_aggregates_tag_metrics_does_NOT_include_per_tag_repos_array`.
+    """
+    resp = await client.get("/library/aggregates")
+    assert resp.status_code == 200
+    body = resp.json()
+
+    cats = body.get("categories") or []
+    for cat in cats:
+        assert "tags" not in cat, (
+            "KAN-201 regression: categories entry leaked the per-category "
+            "`tags` array. That field dominated /library/aggregates at "
+            "~1.52 MB / 40% before KAN-201 and was dropped because the only "
+            "consumer (FilterBar) now derives the same set from per-repo "
+            "enrichedTags. If a new consumer needs it, derive client-side or "
+            "revisit the design."
+        )
+
+
+@pytest.mark.asyncio
 async def test_aggregates_field_shapes_match_library_full(client: AsyncClient):
     """Each aggregate field's runtime shape matches /library/full's wire shape.
 


### PR DESCRIPTION
## Summary

Drops `categories[].tags` from `/library/aggregates` — the single largest contributor to the payload at **~1.52 MB / 40%** per the KAN-195 audit.

JIRA: https://perditio.atlassian.net/browse/KAN-201

The frontend's only consumer (`FilterBar.tsx:165`) was already rewired in KAN-201 PR1 ([reporium#306](https://github.com/perditioinc/reporium/pull/306) — merged to main at `c00dbff` and live on Vercel) to derive the per-category tag set client-side from per-repo `enrichedTags` filtered by `allCategories.includes(cat.name)`. Same pattern `MetricsSidebar.CategoryDetailView` already uses.

## Changes

- **`app/routers/library_aggregates_helpers.py::build_categories()`** — Stop aggregating `cat_tags` and stop emitting the `tags` field. Mirrors the KAN-193 trim (`tagMetric.repos`).
- **`tests/test_library_aggregates.py`** — Add a contract test asserting no `categories[]` entry carries a `tags` field. Parallel to the existing `test_aggregates_tag_metrics_does_NOT_include_per_tag_repos_array` (KAN-193).

## Sequencing — important

PR1 shipped FIRST and is on production main. The frontend already reads from a derived `categoryTagsMap` (from per-repo data) and ignores `categories[].tags` when present. Dropping the field server-side now is safe.

## Expected payload impact

| Endpoint | Pre KAN-201 | Post KAN-201 (expected) | Reduction |
| --- | --- | --- | --- |
| `/library/aggregates` Content-Length | ~3.54 MB (post-KAN-193) | ~2.27 MB | ~36% |

Will measure post-deploy and report on the JIRA.

## Verification

- Local `pytest -k 'not slow'`: 679 passed, 345 skipped (DB-dependent — run in CI).
- New contract test asserts the trim.

## Test plan

- [x] Unit tests pass locally
- [ ] CI green
- [ ] Post-deploy `curl Content-Length` on `/library/aggregates` confirms reduction
- [ ] Frontend production smoke: filter UI still surfaces tags per selected category (PR1's `categoryTagsMap` derivation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)