### PR TITLE
KAN-218 follow-up: fail loud on post-deploy admin probe errors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -266,35 +266,60 @@ jobs:
           INGEST_API_KEY: ${{ secrets.INGESTION_API_KEY }}
           ADMIN_API_KEY: ${{ secrets.ADMIN_API_KEY }}
         run: |
+          # KAN-218 follow-up: previous version used `curl -sf ... && echo "X
+          # triggered" || echo "X skipped"` which silently masks any failure
+          # (curl exits non-zero, the `||` always wins, workflow continues
+          # green even when the POST returned 5xx or timed out). That's the
+          # exact silent-failure pattern that hid the forksync 9-day outage
+          # surfaced 2026-05-03 (KAN-218). Same protocol applied here:
+          # capture HTTP status, emit ::warning:: annotation on non-2xx so
+          # the failure is visible in the GH Actions UI without blocking the
+          # deploy (these are best-effort post-deploy admin endpoints, NOT
+          # gates — service is already live before this step runs).
+          set +e  # don't abort on first non-zero — collect all warnings
+          fail_count=0
+
+          probe() {
+            local label="$1"; local url="$2"; shift 2
+            local body
+            body=$(mktemp)
+            local code
+            code=$(curl -s -o "$body" -w "%{http_code}" "$@" "$url")
+            local size; size=$(wc -c < "$body")
+            if [ "$code" -ge 200 ] && [ "$code" -lt 300 ]; then
+              echo "  $label: HTTP $code (${size}B)"
+            else
+              echo "::warning::$label: HTTP $code — body: $(head -c 300 "$body")"
+              fail_count=$((fail_count+1))
+            fi
+            rm -f "$body"
+          }
+
           # Wait for Cloud Run to be healthy
           sleep 15
-          # Rebuild taxonomy_values from repo_taxonomy (fast batch INSERT)
-          curl -sf -X POST "${API_URL}/taxonomy/rebuild" \
-            -H "Authorization: Bearer ${INGEST_API_KEY}" \
-            -H "X-Admin-Key: ${ADMIN_API_KEY}" \
-            -H "Content-Type: application/json" \
-            -d '{}' --max-time 60 \
-            && echo "Taxonomy rebuild triggered" || echo "Taxonomy rebuild skipped"
-          # Re-derive categories from current tags (idempotent)
-          curl -sf -X POST "${API_URL}/admin/backfill/categories" \
-            -H "Authorization: Bearer ${INGEST_API_KEY}" \
-            -H "X-Admin-Key: ${ADMIN_API_KEY}" \
-            -H "Content-Type: application/json" \
-            --max-time 60 \
-            && echo "Category backfill triggered" || echo "Category backfill skipped"
-          # Backfill embeddings (background — don't block deploy)
-          curl -sf -X POST "${API_URL}/admin/embeddings/backfill" \
-            -H "Authorization: Bearer ${INGEST_API_KEY}" \
-            -H "X-Admin-Key: ${ADMIN_API_KEY}" \
-            -H "Content-Type: application/json" \
-            --max-time 60 \
-            && echo "Embeddings backfill triggered" || echo "Embeddings backfill skipped"
-          # Bust graph edge cache so new typed-edge query is reflected immediately
-          curl -sf -X POST "${API_URL}/admin/cache/graph/invalidate" \
-            -H "X-Admin-Key: ${ADMIN_API_KEY}" \
-            -H "Content-Type: application/json" \
-            --max-time 30 \
-            && echo "Graph cache invalidated" || echo "Graph cache invalidation skipped"
+
+          probe "Taxonomy rebuild" "${API_URL}/taxonomy/rebuild" \
+            -X POST -H "Authorization: Bearer ${INGEST_API_KEY}" \
+            -H "X-Admin-Key: ${ADMIN_API_KEY}" -H "Content-Type: application/json" \
+            -d '{}' --max-time 60
+
+          probe "Category backfill" "${API_URL}/admin/backfill/categories" \
+            -X POST -H "Authorization: Bearer ${INGEST_API_KEY}" \
+            -H "X-Admin-Key: ${ADMIN_API_KEY}" -H "Content-Type: application/json" \
+            --max-time 60
+
+          probe "Embeddings backfill" "${API_URL}/admin/embeddings/backfill" \
+            -X POST -H "Authorization: Bearer ${INGEST_API_KEY}" \
+            -H "X-Admin-Key: ${ADMIN_API_KEY}" -H "Content-Type: application/json" \
+            --max-time 60
+
+          probe "Graph cache invalidate" "${API_URL}/admin/cache/graph/invalidate" \
+            -X POST -H "X-Admin-Key: ${ADMIN_API_KEY}" \
+            -H "Content-Type: application/json" --max-time 30
+
+          if [ "$fail_count" -gt 0 ]; then
+            echo "::warning::$fail_count of 4 post-deploy admin probes failed — see annotations above. Service is live but stale state may persist."
+          fi
 
       - name: Smoke test graph endpoint
         if: success()


### PR DESCRIPTION
## Summary

`Post-deploy taxonomy rebuild` step previously used the same silent-curl pattern that hid the forksync 9-day outage (KAN-218 / forksync#2). Each of the 4 admin endpoint POSTs was wrapped in `curl -sf ... && echo "X triggered" || echo "X skipped"` — the `||` swallows any non-zero exit from curl and the workflow continues green.

If `/taxonomy/rebuild`, `/admin/backfill/categories`, `/admin/embeddings/backfill`, or `/admin/cache/graph/invalidate` returns 5xx or times out post-deploy, the workflow logs "skipped" and ships. Stale taxonomy / categories / embeddings / graph cache go undetected indefinitely.

## Changes

Replace the 4 inline curls with a `probe()` shell function that:
- Captures HTTP status via `-w "%{http_code}"`
- Prints `success` lines for 2xx
- Emits `::warning::` annotations (with HTTP code + body excerpt) for non-2xx
- Tracks fail-count and emits a summary warning if any probe failed

Does NOT fail the workflow — service is already live and serving traffic before this step runs (deploy + alembic + traffic promotion are gates upstream). The fix surfaces failures in the GH Actions UI so an operator notices instead of trusting a green check.

## Audit

Searched all 14 reporium-* repos + forksync for the same `silent-fail` pattern (`curl` + `||` without `http_code`/`--fail` check). Result: 4 instances, all in this file. No others. forksync#2 already covered the only other occurrence.

## Test plan

- [ ] CI green on this branch (no behavior change for 2xx — still ships happy path)
- [ ] After merge, next deploy logs all 4 probes with HTTP 200 + size
- [ ] Future regression: admin endpoint failure surfaces as warning in Actions UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)