### PR TITLE
ci: skip Ask Quality Gate on doc/workflow-only changes (cost win)

### DIFF
--- a/.github/workflows/ask-quality-gate.yml
+++ b/.github/workflows/ask-quality-gate.yml
@@ -2,8 +2,24 @@ name: Ask Quality Gate
 on:
   push:
     branches: [dev, main]
+    # Cost win: skip Anthropic-billed gate on doc/workflow-only changes.
+    # 7-entry slim gate ≈ ~28 Anthropic Haiku calls per run; at ~5 PRs/day
+    # the gate runs on noise PRs that don't touch ask logic. Per cost audit
+    # 4h-run 2026-04-30, this avoids ~30% of Haiku calls.
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.github/workflows/**'
+      - 'README*'
+      - 'LICENSE*'
   pull_request:
     branches: [dev, main]
+    paths-ignore:
+      - 'docs/**'
+      - '**/*.md'
+      - '.github/workflows/**'
+      - 'README*'
+      - 'LICENSE*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Add `paths-ignore` to Ask Quality Gate triggers so doc/README/LICENSE/workflow-only PRs skip the Anthropic-billed gate. Per cost audit (4h-run 2026-04-30) this avoids ~30% of Haiku calls (~\$5–8/mo savings at current PR rate).

## Changes

```yaml
paths-ignore:
  - 'docs/**'
  - '**/*.md'
  - '.github/workflows/**'
  - 'README*'
  - 'LICENSE*'
```

Applied to both `push:` and `pull_request:` triggers. `workflow_dispatch:` unchanged (operator can still manually trigger for golden-set YAML updates).

## What still triggers the gate

- Any change to `app/`, `tests/`, `requirements*.txt`, alembic migrations
- `tests/golden_set_*.yaml` updates (NOT in paths-ignore — gate must run when golden set changes)
- Manual `workflow_dispatch`

## Test plan

- [ ] CI doesn't break (workflow YAML change only — but it's in paths-ignore so... ironic)
- [ ] After merge: next docs-only PR doesn't trigger Ask Quality Gate
- [ ] After merge: source-changing PR still triggers gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)