### PR TITLE
KAN-223: idempotent ask_sessions.created_at migration (silent feature outage)

### DIFF
--- a/migrations/versions/040_idempotent_ask_sessions_created_at.py
+++ b/migrations/versions/040_idempotent_ask_sessions_created_at.py
@@ -1,0 +1,48 @@
+"""Idempotently ensure ask_sessions.created_at column exists (KAN-223).
+
+Production DB started failing with `column "created_at" does not exist`
+when /intelligence/ask called _load_session_turns() per intelligence.py:2140.
+The function catches the error broadly and returns [] so /ask still 200's,
+but conversational memory loads as empty — silent feature degradation
+since whenever the column went missing.
+
+Migration 021 originally creates ask_sessions WITH `created_at TIMESTAMPTZ
+DEFAULT NOW()`. The exact reason this column is absent from prod is
+unclear — possibilities: (a) table was created manually before migrations
+were wired, then 021 was skipped to avoid 'table exists' error, leaving
+the column-less manual table in place; (b) snapshot restored from a
+pre-021 backup; (c) the column was dropped by an out-of-band operation.
+
+Fix: idempotent ALTER TABLE — `ADD COLUMN IF NOT EXISTS` so this is
+safe whether the column is missing or already present. NOT NULL with a
+DEFAULT NOW() so any existing rows get a sensible timestamp (these rows
+were unaddressable by the 24h cutoff anyway, so backfilling to NOW() is
+fine — they'll fall outside the window after 24h naturally).
+
+Revision ID: 040
+Revises: 039
+"""
+
+from alembic import op
+
+
+revision = "040"
+down_revision = "039"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # ADD COLUMN IF NOT EXISTS is idempotent — safe whether the column
+    # missing (KAN-223 scenario) or present (most envs).
+    op.execute("""
+        ALTER TABLE ask_sessions
+        ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    """)
+
+
+def downgrade() -> None:
+    # Don't drop on downgrade — losing this column re-introduces the
+    # silent failure described in KAN-223. Down-migration is for schema
+    # rollback testing; if needed, run the SQL manually.
+    pass


### PR DESCRIPTION
## Summary

Production Cloud SQL is missing the `ask_sessions.created_at` column despite migration 021 specifying it. Live error recurring on every `/intelligence/ask` call with a session_id:

```
ERROR:  column "created_at" does not exist at character 29
```

Surfaced 2026-05-04 00:01 UTC during 5h-run audit. 10+ occurrences in past 24h. Silently caught by `intelligence.py:_load_session_turns()` (`try/except Exception: log_nonfatal(); return []`), so `/ask` still 200's but **conversational memory loads as empty**. KAN-158 (conversational memory) has been silently degraded for an unknown duration.

Same shape as the [KAN-218](https://perditio.atlassian.net/browse/KAN-218) forksync 9-day silent outage: green health, broken downstream behavior.

## Root cause

Migration 021_ask_sessions.py creates the table WITH `created_at`, but production DB is missing it. Likely cause: the table was created manually pre-021 (without `created_at`), then 021 was skipped on this DB to avoid the `table exists` error, leaving the column-less manual table in place.

## Fix

New migration 040: `ALTER TABLE ask_sessions ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`. Idempotent — safe whether column missing (KAN-223) or present (staging/dev). DEFAULT NOW() ensures existing rows get sensible timestamps; they fall outside the 24h cutoff naturally.

Downgrade is intentionally a no-op — losing this column re-introduces the silent failure.

## Verification plan

- [ ] CI green
- [ ] Merge → next deploy runs alembic step → migration applies
- [ ] Post-deploy: cloud SQL logs stop showing `column "created_at" does not exist` errors
- [ ] Post-deploy: `/intelligence/ask` with session_id loads prior turns into context (verify via prompt that references prior turn)

## Follow-up consideration

Add a startup probe in `app.main.lifespan` that runs `SELECT created_at FROM ask_sessions LIMIT 1` and fails loudly if the column is missing, so future schema drift is caught at boot rather than at first user request. Filing as separate ticket if approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)