### PR TITLE
KAN-226: retention.py — query_log column is timestamp, not created_at (silent purge failure)

### DIFF
--- a/app/retention.py
+++ b/app/retention.py
@@ -14,11 +14,21 @@ RETENTION_INTERVAL_SECONDS = 24 * 60 * 60  # 24 hours
 
 
 async def purge_old_query_logs(days: int = RETENTION_DAYS) -> int:
-    """Delete query_log rows older than ``days`` days. Returns row count."""
+    """Delete query_log rows older than ``days`` days. Returns row count.
+
+    Bug fix: previously referenced `created_at` column which doesn't exist
+    on `query_log` — the actual column is `timestamp` (per app/models/query_log.py).
+    Migration 037's docstring also says `created_at DESC` but the actual SQL
+    correctly uses `timestamp DESC`. The retention_loop has been failing every
+    24h with `column "created_at" does not exist` (~1/day in Cloud SQL ERROR
+    logs since the column reference was introduced); the broad except in
+    retention_loop swallowed the error so old query_log rows accumulated
+    without being purged. PII/cost data leak risk over time.
+    """
     async with async_session_factory() as db:
         # Parameterized interval to avoid SQL injection
         result = await db.execute(
-            text("DELETE FROM query_log WHERE created_at < NOW() - (:days || ' days')::interval"),
+            text("DELETE FROM query_log WHERE timestamp < NOW() - (:days || ' days')::interval"),
             {"days": days},
         )
         await db.commit()

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -36,7 +36,13 @@ async def test_purge_old_query_logs_executes_parameterized_delete():
     sql_clause = call_args.args[0]
     params = call_args.args[1]
     assert "DELETE FROM query_log" in str(sql_clause)
-    assert "created_at" in str(sql_clause)
+    # KAN-226: column is `timestamp` (not `created_at`) per app/models/query_log.py.
+    # The original test asserted `created_at`, which validated a real bug — the
+    # SQL used a column that doesn't exist on the live DB; retention silently
+    # failed for the column-reference's lifetime. Fixed in retention.py and
+    # this test updated to assert the correct column.
+    assert "timestamp" in str(sql_clause)
+    assert "created_at" not in str(sql_clause)
     assert params == {"days": 90}
 
 


### PR DESCRIPTION
## Summary

`retention.py:21` references `created_at` on `query_log` but the column is `timestamp` (per `app/models/query_log.py:9-12`). The retention loop has been failing every 24h with `column "created_at" does not exist`. The broad `except Exception:` swallowed the error — query_log NEVER got purged. PII (questions + answers) and cost_usd accumulated indefinitely.

## Discovery

Found 2026-05-04 00:55 UTC during 5h-run audit. After [KAN-223](https://perditio.atlassian.net/browse/KAN-223) shipped a fix for `ask_sessions.created_at`, the same `column "created_at" does not exist` errors continued in Cloud SQL logs (~1/day). Counted PG error position (29) — that's `c` of `created_at` in `DELETE FROM query_log WHERE created_at...` (NOT the ask_sessions SELECT).

Same shape as [KAN-218](https://perditio.atlassian.net/browse/KAN-218) and [KAN-223](https://perditio.atlassian.net/browse/KAN-223): silent failure caught broadly, "everything looks green" while a feature is broken downstream.

## Fix

1-line change: `WHERE created_at` → `WHERE timestamp`. Same logic, correct column name. After deploy, retention_loop will start purging old query_log rows on next 24h cycle. **First run may delete a LARGE batch** (table has accumulated >90 days of data without purges).

## Followups

- Migration 037's index name `idx_query_log_created_at_desc` is misleading (actual indexed column is `timestamp`). Cosmetic rename for a future PR.
- Startup probe per KAN-223 follow-up suggestion would catch this at boot instead of 24h later. Could be a single ticket covering both schema drifts.

## Test plan

- [ ] CI green
- [ ] Post-merge: monitor Cloud SQL logs for `column "created_at" does not exist` — should drop to zero within 24h (after next retention_loop tick)
- [ ] Post-merge: monitor query_log row count — should start dropping if there are old PII rows past 90d retention

🤖 Generated with [Claude Code](https://claude.com/claude-code)