### PR TITLE
KAN-233: invalidate per-row cache after 3 admin backfills

### DIFF
--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -1736,6 +1736,7 @@ async def backfill_licenses(
     updated = 0
     failed = 0
     skipped = 0
+    updated_names: list[str] = []
 
     async with httpx.AsyncClient(headers=headers) as client:
         # Create tasks for all repos
@@ -1759,12 +1760,20 @@ async def backfill_licenses(
                 {"spdx": spdx, "id": str(row.id)},
             )
             updated += 1
+            updated_names.append(row.name)
         except Exception as exc:
             failed += 1
             logger.warning("License update failed for %s/%s: %s", row.owner, row.name, exc)
 
     if updated > 0:
         await db.commit()
+        # KAN-233: invalidate caches that include license_spdx so next
+        # /library/full and /repos/{name} reads see the new values immediately
+        # instead of waiting up to TTL for natural expiration.
+        await cache.invalidate("library:full*")
+        await cache.invalidate("repos:list:*")
+        for name in updated_names:
+            await cache.invalidate(f"repos:detail:{name}")
 
     return {"total": total, "updated": updated, "failed": failed, "skipped": skipped, "dry_run": False}
 
@@ -1948,6 +1957,7 @@ async def backfill_community_signals(
     updated = 0
     failed = 0
     skipped = 0
+    updated_names: list[str] = []
 
     async with httpx.AsyncClient(headers=headers) as client:
         tasks = [
@@ -1996,6 +2006,7 @@ async def backfill_community_signals(
                 params,
             )
             updated += 1
+            updated_names.append(row.name)
         except Exception as exc:
             failed += 1
             logger.warning(
@@ -2004,6 +2015,13 @@ async def backfill_community_signals(
 
     if updated > 0:
         await db.commit()
+        # KAN-233: invalidate caches that include quality_signals fields so
+        # next /library/preview and /repos/{name} reads see the new values
+        # immediately instead of waiting up to TTL for natural expiration.
+        await cache.invalidate("library:full*")
+        await cache.invalidate("repos:list:*")
+        for name in updated_names:
+            await cache.invalidate(f"repos:detail:{name}")
 
     return {"total": total, "updated": updated, "failed": failed, "skipped": skipped, "dry_run": False}
 
@@ -2326,6 +2344,7 @@ async def backfill_dependencies(
     dependencies_inserted = 0
     failed = 0
     skipped = 0
+    updated_names: list[str] = []
 
     sem = asyncio.Semaphore(10)
     headers = {
@@ -2387,6 +2406,7 @@ async def backfill_dependencies(
             if repo_inserted > 0:
                 repos_with_deps += 1
                 dependencies_inserted += repo_inserted
+                updated_names.append(row.name)
 
             # Commit per repo to avoid holding large transactions
             try:
@@ -2394,6 +2414,15 @@ async def backfill_dependencies(
             except Exception as exc:
                 logger.warning("Commit failed after %s/%s: %s", row.owner, row.name, exc)
                 failed += 1
+
+    # KAN-233: dependencies feed graph builders (DEPENDS_ON edges) and
+    # /repos/{name} responses. Invalidate after the per-repo commits so
+    # next reads see fresh data immediately.
+    if updated_names:
+        await cache.invalidate("library:full*")
+        await cache.invalidate("repos:list:*")
+        for name in updated_names:
+            await cache.invalidate(f"repos:detail:{name}")
 
     return {
         "total_repos": total_repos,


### PR DESCRIPTION
## Summary

- Adds `cache.invalidate()` calls after commit to 3 admin backfill endpoints that were silently leaving stale cached responses for up to TTL after successful writes.
- Mirrors the existing pattern at `app/routers/admin.py:1199-1205,1328-1329`.
- Affected endpoints: `/admin/backfill-licenses`, `/admin/backfill-community-signals`, `/admin/backfill-dependencies`.

## Why

Per `feedback_backfill_must_invalidate_cache.md` (and the KAN-444 / mem 4931 pattern): backfill endpoints that rewrite cached columns MUST invalidate per-row cache after commit, otherwise `/library/full` and `/repos/{name}` reads return stale data until natural TTL expiration.

## Diff shape (per endpoint)

1. Track `updated_names: list[str]` in the existing loop.
2. After `await db.commit()`, call:
   - `await cache.invalidate("library:full*")`
   - `await cache.invalidate("repos:list:*")`
   - `await cache.invalidate(f"repos:detail:{name}")` for each updated name

29 insertions, 0 deletions across one file.

## Note re: KAN-238

Redis is currently NOT configured on reporium-api production (separate ticket). The `cache.invalidate()` calls degrade to no-op until Redis is provisioned. This fix is correct-now and effective-when-Redis-lands; no negative impact in either state.

## Test plan

- [x] `python -m pytest tests/test_backfill_licenses.py tests/test_community_signals.py tests/test_dependencies.py` → 27 passed, 17 skipped (DB-dependent)
- [x] `python -m pytest tests/test_admin.py tests/test_admin_enrichment.py` → 32 passed, 9 skipped
- [x] `python -m py_compile app/routers/admin.py` → parse OK
- [ ] Once Redis is provisioned: trigger a small license backfill, hit `/library/full`, verify license_spdx is fresh on the just-backfilled row (no TTL wait).

🤖 Generated with [Claude Code](https://claude.com/claude-code)