### PR TITLE
KAN-228: align EXTENDS validator with shared-upstream-owner builder

### DIFF
--- a/app/routers/platform.py
+++ b/app/routers/platform.py
@@ -383,19 +383,31 @@ async def _graph_quality_snapshot(db: AsyncSession) -> dict[str, Any]:
         if len(source_tags & target_tags) >= 2:
             valid_compatible.add(edge)
 
-    # EXTENDS proxy - valid when the source fork still points at the target repo full name.
+    # EXTENDS proxy — valid when both repos share the same upstream owner.
+    # KAN-228: builder semantic was changed (reporium-ingestion#86) from
+    # "fork resolution" (KAN-155, produced 0 edges in production because
+    # perditioinc/* repos never have their forked_from string land back in
+    # the repos table) to "shared upstream owner" (KAN-164, ~1704 live
+    # edges). This validator now mirrors the new builder: an edge is valid
+    # iff both endpoints have a parsable forked_from with the same owner
+    # component (case-insensitive). Mirrors scripts/build_knowledge_graph.py
+    # build_extends() in reporium-ingestion.
     live_extends = live_edges_by_type.get("EXTENDS", set())
-    valid_extends: set[tuple[str, str]] = set()
-    eligible_extends_repos: set[str] = set()
+    upstream_owner_by_repo: dict[str, str] = {}
     for repo_id, row in repo_by_id.items():
         forked_from = row["forked_from"]
-        if not row["is_fork"] or not forked_from:
+        if not forked_from or "/" not in forked_from:
             continue
-        target_repo_id = full_name_index.get(forked_from)
-        if target_repo_id:
-            eligible_extends_repos.add(repo_id)
-            if (repo_id, target_repo_id) in live_extends:
-                valid_extends.add((repo_id, target_repo_id))
+        owner = forked_from.split("/", 1)[0].strip().lower()
+        if owner:
+            upstream_owner_by_repo[repo_id] = owner
+    eligible_extends_repos = set(upstream_owner_by_repo.keys())
+    valid_extends: set[tuple[str, str]] = set()
+    for edge in live_extends:
+        src_owner = upstream_owner_by_repo.get(edge[0])
+        tgt_owner = upstream_owner_by_repo.get(edge[1])
+        if src_owner and src_owner == tgt_owner:
+            valid_extends.add(edge)
 
     edge_types = {
         "DEPENDS_ON": depends_on,


### PR DESCRIPTION
## Summary

Mirror the new `build_extends()` semantic ([reporium-ingestion#86](https://github.com/perditioinc/reporium-ingestion/pull/86), commit `fe080916`) in the `/metrics/graph-quality` validator at `app/routers/platform.py`. An EXTENDS edge is now valid iff both endpoints share the same lower-cased upstream owner from `forked_from`.

## Why

The graph-build job started producing edges with the new `shared_upstream_owner` semantic. The old validator (KAN-155 fork-resolution) declared every one of those edges "invalid" and pinned `precision_proxy` at 0.0, which flunked the `test_graph_quality_precision_floors` invariant gate (failing for 5+ days running).

## Behavior change

| | Before | After |
|---|---|---|
| Validity rule | `target_repo_id = full_name_index.get(forked_from)` (always None for perditioinc/* corpus) | `upstream_owner_by_repo[src] == upstream_owner_by_repo[tgt]` (lowercased) |
| `precision_proxy` for live KAN-164 edges | 0.0 (1704 invalid) | ~1.0 (matches builder semantic) |
| `eligible_extends_repos` | repos whose forked_from resolves to a tracked repo (=0 in this corpus) | repos with parsable forked_from |

## Test plan

- [x] `python -m pytest tests/` → 679 passed, 345 skipped (DB-dependent), 0 failures.
- [x] No existing EXTENDS test fixture in `test_platform_metrics.py` asserts on the old fork-resolution behavior, so no test surgery required.
- [ ] Post-deploy + after the next graph-build cron firing: `curl /metrics/graph-quality` should report `EXTENDS.precision_proxy` close to 1.0 and `invalid_live_edges` close to 0 (instead of the current 1704 / 0.0).
- [ ] `nightly_invariants.yml` gate should clear EXTENDS once both halves ship.

## Pairs with

- [reporium-ingestion#86](https://github.com/perditioinc/reporium-ingestion/pull/86) (merged) — builder side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)