### PR TITLE
KAN-236: migrate reporium-api workflows from GCP_SA_KEY to WIF

### DIFF
--- a/.github/workflows/backfill_built_repos.yml
+++ b/.github/workflows/backfill_built_repos.yml
@@ -4,6 +4,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write   # KAN-236: required for Workload Identity Federation
 
 jobs:
   backfill:
@@ -15,9 +16,11 @@ jobs:
         with:
           python-version: '3.12'
 
-      - uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.9
+      # KAN-236: migrated from GCP_SA_KEY to Workload Identity Federation.
+      - uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          workload_identity_provider: projects/573778300586/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+          service_account: reporium-api@perditio-platform.iam.gserviceaccount.com
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write   # KAN-236: required for Workload Identity Federation
 
 jobs:
   deploy:
@@ -17,9 +18,15 @@ jobs:
         with:
           python-version: '3.12'
 
-      - uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.9
+      # KAN-236: migrated from GCP_SA_KEY (long-lived) to Workload Identity
+      # Federation. The github-pool/github-provider was set up for KAN-210
+      # / reporium-mcp deploys; this binding adds reporium-api as a second
+      # consumer (see iam.serviceAccountUser binding on the reporium-api SA
+      # for principalSet attribute.repository=perditioinc/reporium-api).
+      - uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
         with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          workload_identity_provider: projects/573778300586/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+          service_account: reporium-api@perditio-platform.iam.gserviceaccount.com
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary

The last two reporium-api workflows still authenticating to GCP via the long-lived `GCP_SA_KEY` secret (a JSON SA key) are now on Workload Identity Federation through the existing `github-pool/github-provider` that reporium-mcp's `deploy-http.yml` already uses (KAN-210 / KAN-215).

Workflows migrated:
- `deploy.yml` (push to main + workflow_dispatch)
- `backfill_built_repos.yml` (manual)

## Pre-requisite IAM binding (already in place)

```
gcloud iam service-accounts add-iam-policy-binding   reporium-api@perditio-platform.iam.gserviceaccount.com   --role=roles/iam.workloadIdentityUser   --member='principalSet://iam.googleapis.com/projects/573778300586/locations/global/workloadIdentityPools/github-pool/attribute.repository/perditioinc/reporium-api'
```

Verified: `gcloud iam service-accounts get-iam-policy reporium-api@...` shows the binding.

## Diff

- `permissions.id-token: write` added at workflow level (required by `actions/auth@v2` for OIDC mint).
- `auth@v2.1.13` step swapped from `credentials_json: ${{ secrets.GCP_SA_KEY }}` to `workload_identity_provider` + `service_account`.

## Test plan

- [ ] Merge → next push to main triggers `deploy.yml` → expect green deploy with no auth errors.
- [ ] After 1 successful deploy, manually trigger `backfill_built_repos.yml` → expect green run.
- [ ] Once both verified clean, operator can:
  1. Delete `GCP_SA_KEY` from `gh secret list -R perditioinc/reporium-api`.
  2. Disable the underlying SA key in GCP (`gcloud iam service-accounts keys delete <key-id> --iam-account=reporium-api@...`).

## Pairs with

- [reporium-ingestion#88](https://github.com/perditioinc/reporium-ingestion/pull/88) — same pattern for `nightly_graph_build.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)