### PR TITLE
fix: skill-search SQL — column is sk.skill, not sk.skill_name

### DIFF
--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -1435,7 +1435,7 @@ async def _try_smart_route_inner(question: str, db: AsyncSession) -> dict | None
             FROM repo_ai_dev_skills sk
             JOIN repos r ON r.id = sk.repo_id
             WHERE r.is_private = false
-              AND sk.skill_name ILIKE :skill
+              AND sk.skill ILIKE :skill
             ORDER BY COALESCE(r.parent_stars, r.stargazers_count, 0) DESC
             LIMIT 10
         """), {"skill": f"%{skill}%"})


### PR DESCRIPTION
## Summary

One-character fix: `app/routers/intelligence.py:1438` referenced `sk.skill_name` on the `repo_ai_dev_skills` table, but the column name is `skill` (per `migrations/versions/001_initial_schema.py:179`). Production has been logging `ERROR: column sk.skill_name does not exist` on every skill-route invocation.

## Discovery

Caught by the KAN-229 schema-drift log-based metric on 2026-05-05 08:19 UTC during the 12h audit. Same family as KAN-223 / KAN-226 / KAN-227 — code references a column that doesn't exist in the live schema.

## Diff

```diff
-              AND sk.skill_name ILIKE :skill
+              AND sk.skill ILIKE :skill
```

Other column references in the same query (`r.parent_stars`, `r.stargazers_count`, `r.is_private`, `r.forked_from`, `r.primary_category`) are valid against the live schema (verified against `app/models/repo.py`).

## Test plan

- [x] `python -m pytest tests/test_intelligence.py` → 14 passed, 32 skipped (DB-dependent — those would catch this end-to-end if a real DB were attached).
- [ ] Post-deploy: send a skill-route query (e.g. "show me agents repos") to `/intelligence/ask` → expect a real result list instead of the smart-route bailing out to the generic LLM path.
- [ ] Schema-drift metric `schema_drift_undefined_column` should stop incrementing for this query.

🤖 Generated with [Claude Code](https://claude.com/claude-code)