### PR TITLE
chore(ci): make ask-quality-gate advisory until KAN-146 lands

### DIFF
--- a/.github/workflows/ask-quality-gate.yml
+++ b/.github/workflows/ask-quality-gate.yml
@@ -13,6 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     # Skip gracefully on forks / environments without the required secret.
     if: ${{ github.event.pull_request.head.repo.fork == false || github.event_name == 'push' }}
+    # ADVISORY (2026-05-21): test_ask_golden_set_numeric_gate runs the full
+    # 50+ entry golden set against real Anthropic — exceeds 30 min wall time
+    # at any timeout setting (see KAN-DRAFT-gate-timeout-bump commit ddbd5dd:
+    # "1800s also insufficient"). Until the KAN-146 redesign (slim per-PR /
+    # nightly-full split) lands, this gate REPORTS but does NOT BLOCK merges.
+    # Drop continue-on-error once KAN-146 ships.
+    continue-on-error: true
+    timeout-minutes: 30
 
     services:
       postgres:


### PR DESCRIPTION
## Why

\`test_ask_golden_set_numeric_gate\` hits the full 50+ entry golden set against real Anthropic on every PR/push to dev/main. Per existing draft work (\`KAN-DRAFT-gate-timeout-bump\` commit \`ddbd5dd\`: *"1800s also insufficient"*), this test exceeds any practical CI timeout. Gate has been silently red for **15+ days** (no PRs to dev/main in that window).

## What this changes

Adds \`continue-on-error: true\` + a \`timeout-minutes: 30\` ceiling to the gate job:
- Gate **still runs and reports** red/green for visibility
- Red **does not block** merges (operator gets the signal but moves on)
- A hung test can't burn the 6-hour GitHub Actions wall clock

## Follow-up (not in this PR)

Drop \`continue-on-error\` once **KAN-146** ships from the parked \`KAN-146-gate-redesign\` branch (slim per-PR set + nightly full set + parallel exec).

## Diff size

1 file, +8 / -0. No code or test changes.