### PR TITLE
KAN-DRAFT: let ingestion preserve commit stats by sending null

### DIFF
--- a/app/routers/ingest.py
+++ b/app/routers/ingest.py
@@ -322,7 +322,18 @@ async def _upsert_repo(db: AsyncSession, item: RepoIngestItem) -> Repo:
     )
 
     if repo is None:
-        repo = Repo(**repo_fields)
+        # NOT-NULL columns with a server_default (commit counts, activity_score)
+        # must not be inserted as explicit NULL — drop None values so the DB
+        # default (0) applies for a brand-new repo. The UPDATE branch below
+        # already preserves existing values when None is sent.
+        insert_fields = {
+            k: v for k, v in repo_fields.items()
+            if not (v is None and k in {
+                "commits_last_7_days", "commits_last_30_days",
+                "commits_last_90_days", "activity_score",
+            })
+        }
+        repo = Repo(**insert_fields)
         db.add(repo)
     else:
         for key, val in repo_fields.items():

--- a/app/schemas/repo.py
+++ b/app/schemas/repo.py
@@ -174,12 +174,16 @@ class RepoIngestItem(BaseModel):
     open_issues_count: int = 0
     license_spdx: str | None = None
 
-    commits_last_7_days: int = 0
-    commits_last_30_days: int = 0
-    commits_last_90_days: int = 0
+    # None = "unknown, don't touch" — the _upsert_repo null-skip guard then
+    # preserves the stored value instead of overwriting it with 0. Ingestion
+    # sends None when GitHub commit-activity is unavailable for a repo, so a
+    # transient fetch failure can never blank out real commit counts.
+    commits_last_7_days: int | None = None
+    commits_last_30_days: int | None = None
+    commits_last_90_days: int | None = None
 
     readme_summary: str | None = None
-    activity_score: int = 0
+    activity_score: int | None = None
     activity_score_breakdown: dict | None = None
 
     github_updated_at: datetime | None = None

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -81,6 +81,56 @@ async def test_ingest_empty_arrays_preserve_existing_junction_data(client: Async
 
 
 @pytest.mark.asyncio
+async def test_ingest_null_commit_stats_preserve_existing(client: AsyncClient):
+    """Commit-stat freeze guard: a payload that omits commit counts / activity_score
+    (which deserialize to None) must NOT zero out the stored values. Ingestion sends
+    None when GitHub commit-activity is unavailable, so a transient fetch failure can
+    never blank real commit counts. A brand-new repo with no counts still defaults to 0.
+    """
+    from sqlalchemy import text as _text
+    import app.database as db_module
+
+    seeded = {
+        **TEST_REPO_FIXTURE,
+        "name": "commit-preserve-repo",
+        "github_url": "https://github.com/testuser/commit-preserve-repo",
+        "commits_last_7_days": 5,
+        "commits_last_30_days": 22,
+        "commits_last_90_days": 60,
+        "activity_score": 88,
+    }
+    assert (await client.post("/ingest/repos", json=[seeded], headers=AUTH_HEADERS)).status_code == 200
+
+    # Re-ingest with commit/activity fields omitted entirely (-> None on the model).
+    sparse = {k: v for k, v in seeded.items()
+              if k not in {"commits_last_7_days", "commits_last_30_days",
+                           "commits_last_90_days", "activity_score"}}
+    assert (await client.post("/ingest/repos", json=[sparse], headers=AUTH_HEADERS)).status_code == 200
+
+    async with db_module.async_session_factory() as session:
+        row = (await session.execute(
+            _text("SELECT commits_last_7_days, commits_last_30_days, commits_last_90_days, "
+                  "activity_score FROM repos WHERE name = :n"),
+            {"n": "commit-preserve-repo"},
+        )).one()
+    assert tuple(row) == (5, 22, 60, 88), f"omitted commit stats were not preserved: {tuple(row)}"
+
+    # A brand-new repo whose counts are unknown must insert cleanly with the 0 default.
+    new_repo = {k: v for k, v in TEST_REPO_FIXTURE.items()
+                if k not in {"commits_last_7_days", "commits_last_30_days",
+                             "commits_last_90_days", "activity_score"}}
+    new_repo |= {"name": "commit-new-repo",
+                 "github_url": "https://github.com/testuser/commit-new-repo"}
+    assert (await client.post("/ingest/repos", json=[new_repo], headers=AUTH_HEADERS)).status_code == 200
+    async with db_module.async_session_factory() as session:
+        row = (await session.execute(
+            _text("SELECT commits_last_7_days, activity_score FROM repos WHERE name = :n"),
+            {"n": "commit-new-repo"},
+        )).one()
+    assert tuple(row) == (0, 0), f"new repo without counts should default to 0, got {tuple(row)}"
+
+
+@pytest.mark.asyncio
 async def test_ingest_cannot_republish_private_repo(client: AsyncClient):
     private_payload = {
         **TEST_REPO_FIXTURE,


### PR DESCRIPTION
## Summary
Makes `RepoIngestItem.commits_last_7/30/90_days` and `activity_score` nullable (`int | None = None`). `None` now means **"unknown — don't touch"**: the existing `_upsert_repo` null-skip guard preserves the stored value instead of overwriting it with 0.

This is the API half of the commit-stat freeze fix. It lets the ingestion commit-stats refresh send `None` when GitHub commit-activity is unavailable for a repo, so a transient fetch failure can never blank real commit counts.

## Changes
- `app/schemas/repo.py`: the three commit-count fields + `activity_score` on `RepoIngestItem` are now `int | None = None`.
- `app/routers/ingest.py`: the INSERT branch drops `None` values for these NOT-NULL-with-`server_default` columns, so a brand-new repo still defaults to 0 (no `None`-into-NOT-NULL insert error). The UPDATE branch already skips `None` (preserve).

## Pairs with
reporium-ingestion PR #98 (the refresh phase that sends `None` on failure). **Deploy this API change first.**

## Test plan
- [x] `test_ingest_null_commit_stats_preserve_existing`: omitted counts preserve stored values; a new repo without counts inserts cleanly at 0
- [x] schema validation: omitted → `None`, present → `int`
- [ ] run full `pytest tests/test_ingest.py` against the test Postgres in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)