### PR TITLE
feat: $0 local-OSS dev substrate (docker-compose + Makefile + smoke) (#6)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Keep shell scripts LF so they run inside Linux containers / on *nix dev boxes.
+*.sh text eol=lf

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,13 @@
 ## [Unreleased] - 2026-04-08
 
 ### Added
+- **$0 local-OSS substrate** (`local/`, `Makefile`, `scripts/smoke.sh`): runs the full api stack locally at zero cloud spend by substituting paid GCP deps with OSS equivalents (Cloud SQL → pgvector, Memorystore → redis, GCP Pub/Sub → Pub/Sub emulator as the local broker, paid embeddings → baked-in sentence-transformers). `make up | down | smoke | seed`. App code unchanged; Pub/Sub substituted via `PUBSUB_EMULATOR_HOST` (no code change). Smoke proves up → healthy → `/health` db=ok → `down -v`. (REPORIUM-$0-01, system-design#6)
 - **Similar repos fallback**: If `/intelligence/similar/{owner}/{name}` returns zero candidates (repo has no categories or tags), falls back to surfacing repos sharing the same `primary_category`, ordered by star count.
 - **Edge type colors in 3D graph**: Knowledge graph edges now rendered in distinct colors per relationship type (amber=ALTERNATIVE_TO, green=COMPATIBLE_WITH, blue=DEPENDS_ON, violet=SIMILAR_TO, pink=EXTENDS).
 - **`/graph/edges` now returns typed relationship edges**: After fetching pgvector similarity edges, also queries the `repo_edges` table for ALTERNATIVE_TO, COMPATIBLE_WITH, DEPENDS_ON, EXTENDS edges. Typed edges override SIMILAR_TO when the same (source, target) pair exists. Degrades gracefully if `repo_edges` table is missing. `edgeTypes` field in response now lists all distinct types present in the data.
+
+### Fixed
+- **Alembic clean-DB `upgrade head` on `dev`**: ported `migrations/env.py` to `transaction_per_migration=True` + `engine.connect()` (already present on `main`), so migration 038's `autocommit_block()` (CREATE INDEX CONCURRENTLY) no longer raises `AssertionError` on a fresh database. Restores dev↔main parity; required for the local substrate to migrate a clean DB.
 
 ### Changed
 - **pgvector retrieval threshold**: Lowered from 0.45 → 0.40 in the adaptive top_k filter to surface more relevant repos per ask query.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+# Root passthrough to the $0 local-OSS substrate (REPORIUM-$0-01, issue #6).
+# Lets you run `make up | down | smoke | seed | logs | ps` from the repo root.
+# All real targets live in local/Makefile.
+
+.PHONY: up down smoke seed logs ps rebuild help
+up down smoke seed logs ps rebuild help:
+	@$(MAKE) -f local/Makefile $@

--- a/local/Makefile
+++ b/local/Makefile
@@ -1,0 +1,41 @@
+# Reporium $0 local-OSS substrate (REPORIUM-$0-01, issue #6)
+#
+# All targets run the OSS local stack with ZERO cloud spend. No GCP, no paid
+# services, no secrets. Run from the repo root:  make -f local/Makefile <target>
+# (a thin root passthrough is provided so `make up` also works.)
+
+COMPOSE := docker compose -f local/docker-compose.yml
+SMOKE   := bash scripts/smoke.sh
+
+.PHONY: help up down logs ps seed smoke rebuild
+
+help: ## Show this help
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
+		awk 'BEGIN{FS=":.*?## "}{printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}'
+
+up: ## Build + start the full local substrate, wait until healthy
+	$(COMPOSE) up -d --build --wait
+	@echo ""
+	@echo "Reporium local substrate is UP ($$0/local):"
+	@echo "  API     http://localhost:8080/health   (docs: /docs)"
+	@echo "  Postgres localhost:5432  (postgres/postgres, db=reporium)"
+	@echo "  Redis    localhost:6379"
+	@echo "  Pub/Sub  localhost:8681  (emulator, project=reporium-local)"
+
+down: ## Stop the stack and DELETE volumes (clean teardown)
+	$(COMPOSE) down -v
+
+logs: ## Tail logs from all services
+	$(COMPOSE) logs -f
+
+ps: ## Show service status
+	$(COMPOSE) ps
+
+seed: ## Apply DB migrations (idempotent; api `up` already runs this)
+	$(COMPOSE) run --rm migrate
+
+smoke: ## Bring up, health-check every service, then tear down -v
+	$(SMOKE)
+
+rebuild: ## Force a clean rebuild of the api image
+	$(COMPOSE) build --no-cache api migrate

--- a/local/README.md
+++ b/local/README.md
@@ -1,0 +1,77 @@
+# Reporium $0 local-OSS substrate
+
+> **REPORIUM-$0-01** (epic [#5], card [#6]). Run `reporium-api` and its whole
+> dependency stack **locally at $0** by substituting every paid GCP dependency
+> with an OSS / emulator equivalent. **Additive and local-only** — this does not
+> touch production, change any live cloud resource, or affect the paid
+> deployment. The application code is **unchanged**.
+
+## Why
+
+`reporium-api` runs in production on paid cloud (Cloud Run + Cloud SQL + GCP
+Pub/Sub + Memorystore + paid embeddings). For dev and ingestion we want the
+exact same app running with **zero spend**. This `local/` stack does that.
+
+## Cloud → OSS substitution map
+
+| Paid (production)        | $0 local substitute                                   | How it's transparent |
+|--------------------------|-------------------------------------------------------|----------------------|
+| Cloud SQL (Postgres)     | `pgvector/pgvector:pg16` container                    | `DATABASE_URL` env points at it; migrations run via alembic |
+| Memorystore (Redis)      | `redis:7-alpine` container                            | `REDIS_URL` env points at it |
+| GCP Pub/Sub              | Pub/Sub **emulator** (`thekevjames/gcloud-pubsub-emulator`) | `PUBSUB_EMULATOR_HOST` — the unmodified `google-cloud-pubsub` client auto-routes to the emulator. **No code change.** |
+| Cloud Run (api)          | local docker container                                | same image, same `Dockerfile` |
+| Paid embedding API       | `sentence-transformers` `all-MiniLM-L6-v2`, baked into the api image, CPU-only, offline | already in the prod `Dockerfile`; $0 |
+| Secret Manager           | plain env vars in `local/docker-compose.yml`          | never contacted (`ENVIRONMENT=development`) |
+
+No cloud credentials, no secrets, no paid services are used or required.
+
+## Quick start
+
+From the **repo root**:
+
+```bash
+make up      # build + start everything, wait until healthy
+make smoke   # up -> health-check every service -> down -v   (the proof)
+make down    # stop + delete volumes
+make ps      # service status
+make logs    # tail logs
+make seed    # (re)apply DB migrations  (api `up` already does this)
+```
+
+Or call the substrate Makefile directly: `make -f local/Makefile up`.
+
+Once up:
+
+| Service  | Address                          | Notes |
+|----------|----------------------------------|-------|
+| API      | http://localhost:8080/health     | OpenAPI docs at `/docs` |
+| Postgres | localhost:5432                   | `postgres` / `postgres`, db `reporium` |
+| Redis    | localhost:6379                   | |
+| Pub/Sub  | localhost:8681                   | emulator, project `reporium-local`, topic `reporium-events` |
+
+## What `make up` does
+
+1. Starts **Postgres (pgvector)**, **Redis**, and the **Pub/Sub emulator**, each
+   with a healthcheck.
+2. Runs a one-shot **`migrate`** service (`alembic upgrade head`) against the
+   local Postgres once it is healthy.
+3. Starts the **api** only after the DB is migrated and all brokers are healthy,
+   then waits for its `/health` endpoint to report `db: ok`.
+
+`make smoke` additionally asserts the Pub/Sub emulator pre-created the
+`reporium-events` topic and tears everything down with `-v`.
+
+## Scope / what this is NOT
+
+- This is the **$0-01** local dev substrate for `reporium-api`. Wiring the
+  *other* suite repos (frontend, ingestion, mcp) into one compose, and the
+  permanent cloud→OSS substitution + cost-cap / free-tier guardrails, are
+  tracked separately (card **$0-02 / #7**).
+- The Pub/Sub *emulator* is the local broker substitution. Swapping the
+  production broker (or making the publisher pluggable for a non-GCP broker
+  like NATS) is a code change owned by **#7**, not this card.
+- **$0 / OSS only.** Any CI added for this must use the repo's self-hosted
+  runner, never GitHub-hosted runners.
+
+[#5]: https://github.com/perditioinc/reporium-system-design/issues/5
+[#6]: https://github.com/perditioinc/reporium-system-design/issues/6

--- a/local/docker-compose.yml
+++ b/local/docker-compose.yml
@@ -1,0 +1,124 @@
+# Reporium $0 local-OSS substrate (REPORIUM-$0-01, issue #6).
+#
+# Stands up the whole reporium-api stack LOCALLY with ZERO cloud spend, by
+# substituting every paid GCP dependency with an OSS / emulator equivalent:
+#
+#   Paid (prod)        ->  $0 local substitute (this file)
+#   -----------------      ----------------------------------------------------
+#   Cloud SQL (pg)     ->  pgvector/pgvector:pg16        (db)
+#   Memorystore Redis  ->  redis:7-alpine               (redis)
+#   GCP Pub/Sub        ->  Pub/Sub emulator             (pubsub)  [local broker]
+#   Cloud Run (api)    ->  local docker container        (api)
+#   Paid embeddings    ->  sentence-transformers model baked into the api image
+#                          (all-MiniLM-L6-v2, runs CPU-only, offline) — $0
+#   Secret Manager     ->  plain env vars (this file)    — never contacted
+#
+# The api code is UNCHANGED. GCP Pub/Sub is substituted transparently via the
+# google-cloud client convention: when PUBSUB_EMULATOR_HOST is set, the client
+# talks to the local emulator instead of real Pub/Sub — no code change, $0.
+#
+# Usage (from repo root):  make -f local/Makefile up   (or: make up)
+# This file is SELF-CONTAINED — it does not depend on the root docker-compose.yml.
+
+name: reporium-local
+
+services:
+  db:
+    image: pgvector/pgvector:pg16
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: reporium
+    ports:
+      - '5432:5432'
+    volumes:
+      - reporium_local_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U postgres -d reporium']
+      interval: 3s
+      timeout: 3s
+      retries: 20
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - '6379:6379'
+    healthcheck:
+      test: ['CMD', 'redis-cli', 'ping']
+      interval: 3s
+      timeout: 3s
+      retries: 20
+
+  # Local broker — substitutes GCP Pub/Sub. Speaks the real Pub/Sub gRPC API,
+  # so the unmodified google-cloud-pubsub client in reporium-events/api works
+  # against it when PUBSUB_EMULATOR_HOST points here. Pre-creates the
+  # reporium-events topic so publishers don't 404 on first publish.
+  pubsub:
+    image: thekevjames/gcloud-pubsub-emulator:latest
+    environment:
+      # host:port the emulator binds (0.0.0.0 so the api container can reach it)
+      PUBSUB_EMULATOR_HOST: '0.0.0.0:8681'
+      # auto-create <project>,<topic>[,<topic>...] on startup
+      PUBSUB_PROJECT1: 'reporium-local,reporium-events'
+    ports:
+      - '8681:8681'
+    healthcheck:
+      # the emulator serves a plain TCP listener on 8681; a successful bash
+      # /dev/tcp connect proves it is accepting connections.
+      test: ['CMD-SHELL', 'timeout 2 bash -c "echo > /dev/tcp/127.0.0.1/8681"']
+      interval: 3s
+      timeout: 3s
+      retries: 20
+
+  # One-shot: apply alembic migrations against the local Postgres, then exit 0.
+  # Reuses the api image (alembic + app config are already inside it).
+  migrate:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    command: ['alembic', 'upgrade', 'head']
+    environment:
+      DATABASE_URL: 'postgresql+asyncpg://postgres:postgres@db:5432/reporium'
+      ENVIRONMENT: development
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: 'no'
+
+  api:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    environment:
+      DATABASE_URL: 'postgresql+asyncpg://postgres:postgres@db:5432/reporium'
+      REDIS_URL: 'redis://redis:6379'
+      INGESTION_API_KEY: local-dev-key
+      INGEST_API_KEY: local-dev-key
+      GH_USERNAME: perditioinc
+      ENVIRONMENT: development
+      PORT: '8080'
+      # Pub/Sub substitution — unmodified google client routes here.
+      PUBSUB_EMULATOR_HOST: 'pubsub:8681'
+      GOOGLE_CLOUD_PROJECT: 'reporium-local'
+      GCP_PROJECT: 'reporium-local'
+    ports:
+      - '8080:8080'
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      pubsub:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+    healthcheck:
+      test:
+        - 'CMD-SHELL'
+        - "python -c \"import urllib.request,sys; sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8080/health', timeout=3).status==200 else 1)\""
+      interval: 5s
+      timeout: 5s
+      retries: 30
+      start_period: 90s
+
+volumes:
+  reporium_local_pgdata:

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -31,14 +31,25 @@ def run_migrations_offline() -> None:
 
 
 def do_run_migrations(connection) -> None:
-    context.configure(connection=connection, target_metadata=target_metadata)
-    with context.begin_transaction():
-        context.run_migrations()
+    # transaction_per_migration=True is REQUIRED for op.get_context().autocommit_block()
+    # to work. autocommit_block() suspends the current Alembic-managed transaction and
+    # runs DDL in AUTOCOMMIT mode — needed for CREATE INDEX CONCURRENTLY (migration 038).
+    # Without this flag, autocommit_block() raises AssertionError because there's no
+    # Alembic-scoped transaction to suspend.
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        transaction_per_migration=True,
+    )
+    context.run_migrations()
 
 
 async def run_async_migrations() -> None:
+    # Use engine.connect() (not .begin()) so Alembic owns transaction boundaries via
+    # transaction_per_migration=True. engine.begin() would start a wrapping transaction
+    # that autocommit_block() can't suspend.
     engine = create_async_engine(settings.database_url)
-    async with engine.begin() as conn:
+    async with engine.connect() as conn:
         await conn.run_sync(do_run_migrations)
     await engine.dispose()
 

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Reporium $0 local-OSS substrate smoke test (REPORIUM-$0-01, issue #6).
+#
+# Proves the substrate runs $0/local end-to-end:
+#   1. docker compose up --build --wait   (all services report healthy)
+#   2. assert each OSS substitute is reachable (Postgres, Redis, Pub/Sub, API)
+#   3. assert the API /health reports db=ok (migrations applied, real DB query)
+#   4. assert the Pub/Sub emulator pre-created the reporium-events topic
+#   5. docker compose down -v             (clean teardown, volumes removed)
+#
+# No cloud, no secrets, no paid services. Exit 0 = PASS, non-zero = FAIL.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+COMPOSE="docker compose -f local/docker-compose.yml"
+
+pass() { printf '  [PASS] %s\n' "$1"; }
+fail() { printf '  [FAIL] %s\n' "$1"; FAILED=1; }
+FAILED=0
+
+cleanup() {
+  echo "--- teardown (down -v) ---"
+  $COMPOSE down -v || true
+}
+trap cleanup EXIT
+
+echo "=== Reporium local substrate smoke test ($$0/local) ==="
+
+echo "--- bringing stack up (build + wait healthy) ---"
+$COMPOSE up -d --build --wait
+
+echo "--- service health ---"
+for svc in db redis pubsub api; do
+  state="$($COMPOSE ps "$svc" --format '{{.Health}}' 2>/dev/null || true)"
+  if [ "$state" = "healthy" ]; then pass "$svc healthy"; else fail "$svc not healthy (state='$state')"; fi
+done
+
+echo "--- API /health (db-backed) ---"
+body="$(curl -fsS --max-time 10 http://localhost:8080/health || true)"
+echo "    response: $body"
+case "$body" in
+  *'"status":"ok"'*'"db":"ok"'*|*'"db":"ok"'*'"status":"ok"'*) pass "API /health status=ok db=ok" ;;
+  *) fail "API /health did not report ok/db=ok" ;;
+esac
+
+echo "--- Postgres pgvector extension reachable ---"
+if $COMPOSE exec -T db psql -U postgres -d reporium -tAc "SELECT 1" | grep -q 1; then
+  pass "Postgres query SELECT 1"
+else
+  fail "Postgres query failed"
+fi
+
+echo "--- Redis PING ---"
+if [ "$($COMPOSE exec -T redis redis-cli ping | tr -d '\r')" = "PONG" ]; then
+  pass "Redis PONG"
+else
+  fail "Redis did not PONG"
+fi
+
+echo "--- Pub/Sub emulator topic (local broker, replaces GCP Pub/Sub) ---"
+# The emulator's REST surface lists pre-created topics for the project.
+topics="$(curl -fsS --max-time 10 \
+  http://localhost:8681/v1/projects/reporium-local/topics || true)"
+echo "    topics: $topics"
+if echo "$topics" | grep -q "reporium-events"; then
+  pass "Pub/Sub emulator has topic reporium-events"
+else
+  fail "Pub/Sub emulator missing reporium-events topic"
+fi
+
+echo ""
+if [ "$FAILED" = "0" ]; then
+  echo "=== SMOKE PASS — substrate runs \$0/local ==="
+else
+  echo "=== SMOKE FAIL ==="
+fi
+exit "$FAILED"


### PR DESCRIPTION
## REPORIUM-$0-01 — Local-OSS dev substrate (epic perditioinc/reporium-system-design#5, card #6)

Run the whole `reporium-api` stack **locally at $0** by substituting every paid GCP dependency with an OSS / emulator equivalent. **Additive and local-only** — production, live cloud resources, and the running paid deployment are untouched. **Application code is unchanged.**

### Cloud → OSS substitution
| Paid (prod) | $0 local substitute | Transparent how |
|---|---|---|
| Cloud SQL (Postgres) | `pgvector/pgvector:pg16` | `DATABASE_URL` env |
| Memorystore (Redis) | `redis:7-alpine` | `REDIS_URL` env |
| GCP Pub/Sub | Pub/Sub **emulator** (`thekevjames/gcloud-pubsub-emulator`) | `PUBSUB_EMULATOR_HOST` — unmodified `google-cloud-pubsub` client auto-routes. **No code change.** |
| Cloud Run (api) | local docker container | same `Dockerfile` |
| Paid embeddings | `sentence-transformers all-MiniLM-L6-v2`, baked into the api image, CPU-only/offline | already in prod Dockerfile; $0 |
| Secret Manager | plain env in `local/docker-compose.yml` | never contacted (`ENVIRONMENT=development`) |

No cloud credentials, secrets, or paid services are used or required.

### What landed
- `local/docker-compose.yml` — self-contained stack (db, redis, pubsub emulator, one-shot `migrate`, api) with healthchecks and ordered startup (api waits for DB-migrated + brokers healthy).
- `local/Makefile` + root `Makefile` passthrough — `make up | down | smoke | seed | logs | ps | rebuild`.
- `scripts/smoke.sh` — `up --build --wait` → assert every service healthy → `/health` db=ok → Pub/Sub topic present → `down -v`.
- `local/README.md` — substitution map, usage, scope.
- `.gitattributes` — LF for `*.sh`.
- **Fix** `migrations/env.py` — ported `main`'s `transaction_per_migration=True` + `engine.connect()` so a clean-DB `alembic upgrade head` works on `dev` (migration 038 `autocommit_block()` / CREATE INDEX CONCURRENTLY otherwise raises `AssertionError`). Restores dev↔main parity; required for the substrate to migrate a fresh DB. See note below.

### Real validation
```
$ make smoke   (docker compose -f local/docker-compose.yml up -d --build --wait + asserts + down -v)
--- service health ---
  [PASS] db healthy
  [PASS] redis healthy
  [PASS] pubsub healthy
  [PASS] api healthy
--- API /health (db-backed) ---
    response: {"status":"ok","db":"ok"}
  [PASS] API /health status=ok db=ok
  [PASS] Postgres query SELECT 1
  [PASS] Redis PONG
  [PASS] Pub/Sub emulator has topic reporium-events
=== SMOKE PASS — substrate runs $0/local ===
--- teardown (down -v) ---   (0 containers / volumes left)
```
api image built locally (CPU torch + baked all-MiniLM-L6-v2 model: `Model downloaded OK`).

### Governance
- $0 / OSS only — no paid services, no cloud calls.
- No CI added; if any is later added it must use the repo's self-hosted runner (never GitHub-hosted).
- GitFlow: feature off `dev` → PR into `dev` per CONTRIBUTING.md.

### Heads-up for reviewer
`dev`'s `migrations/env.py` was **behind `main`** and a clean-DB `alembic upgrade head` fails at migration 038 (`autocommit_block` AssertionError). The fix here is byte-identical to what's already on `main`. Worth checking why `dev` regressed relative to `main`.

### Scope / remaining for #6
Done: api + DB + Redis + local broker (Pub/Sub emulator) + local embeddings in one compose, Makefile up/down/seed/smoke, validated $0/local. Remaining (suggest #7 / follow-ups): wire the *other* suite repos (frontend, ingestion, mcp) into the same compose; a `seed` that loads sample repo data; making the publisher broker-pluggable for a non-GCP local broker (NATS) — that's a code change owned by $0-02 / #7.

Refs #6, epic #5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)