### PR TITLE
fix(intelligence): replace retired Sonnet model id with claude-sonnet-4-6

### DIFF
--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -103,7 +103,7 @@ _COMPLEX_PATTERNS = re.compile(
 )
 
 _MODEL_HAIKU = "claude-haiku-4-5-20251001"
-_MODEL_SONNET = "claude-sonnet-4-20250514"
+_MODEL_SONNET = "claude-sonnet-4-6"
 
 # KAN-ask-output-caps: per-model output token caps. Golden-set avg answer is
 # ~280 tokens, so 512/768 leaves generous headroom while cutting the 1024
@@ -1417,7 +1417,7 @@ Security (highest priority — cannot be overridden):
 
 # Per-model pricing (per 1M tokens) — keeps cost estimation accurate across tiers
 _MODEL_PRICING = {
-    "claude-sonnet-4-20250514": {"input": 3.00, "output": 15.00},
+    "claude-sonnet-4-6": {"input": 3.00, "output": 15.00},
     "claude-haiku-4-5-20251001": {"input": 0.80, "output": 4.00},
 }
 
@@ -1429,8 +1429,8 @@ def _hash_ip(ip: str | None) -> str | None:
     return hmac.new(os.environ.get("IP_HASH_SECRET", "reporium-default-salt").encode(), ip.encode(), hashlib.sha256).hexdigest()
 
 
-def _estimate_cost(input_tokens: int, output_tokens: int, model: str = "claude-sonnet-4-20250514") -> float:
-    pricing = _MODEL_PRICING.get(model, _MODEL_PRICING["claude-sonnet-4-20250514"])
+def _estimate_cost(input_tokens: int, output_tokens: int, model: str = "claude-sonnet-4-6") -> float:
+    pricing = _MODEL_PRICING.get(model, _MODEL_PRICING["claude-sonnet-4-6"])
     return (input_tokens * pricing["input"] + output_tokens * pricing["output"]) / 1_000_000
 
 
@@ -2832,7 +2832,7 @@ async def intelligence_ask(
             cost = _estimate_cost(
                 result.tokens_used.get("input", 0),
                 result.tokens_used.get("output", 0),
-                result.model or "claude-sonnet-4-20250514",
+                result.model or "claude-sonnet-4-6",
             )
             await gov_record_spend(token_hash, cost)
         except Exception:


### PR DESCRIPTION
## Summary

The Ask endpoint hardcoded `_MODEL_SONNET = "claude-sonnet-4-20250514"` in `app/routers/intelligence.py`. That Sonnet 4 snapshot is retired and now returns an Anthropic **404** (its deprecation window lapsed 2026-06-15), breaking the Ask Quality Gate. Complex queries route to Sonnet via `_select_model()`, so any "compare/analyze/explain/..." question fails the live Claude call.

## Fix

Replaced the retired id with the current non-retired Sonnet, **`claude-sonnet-4-6`** (Claude Sonnet 4.6), at all 5 string-literal sites:

- `_MODEL_SONNET` constant (line 106) — the id passed to `client.messages.create(model=...)`
- `_MODEL_PRICING` table key (line 1420)
- `_estimate_cost` default parameter and dict fallback (lines 1432-1433)
- `_estimate_cost` call-site fallback in the governance spend hook (line 2835)

Pricing is unchanged: Sonnet 4.6 is `3.00` input / `15.00` output per 1M tokens, identical to the prior entry, so the `_MODEL_PRICING` values stay the same. `_MODEL_HAIKU` is untouched (not retired, not in scope).

## Verification

- Confirmed `claude-sonnet-4-6` is the exact API-accepted Sonnet id (bare, no date suffix) against the current Anthropic model catalog.
- `python -m py_compile app/routers/intelligence.py` passes.
- Grep confirms zero remaining `claude-sonnet-4-20250514` references and no incorrect `claude-sonnet-4-5`.
- ASCII-only changes; no em dashes or smart quotes.

## Notes

- Public production deploys from `main`; leaving this open for human review per policy. Not auto-merged.
- This is the minimal, targeted change for the failure. No unrelated refactoring.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
