### PR TITLE
feat(intelligence): flag-gated cross-encoder reranking (proven +19% nDCG on realistic queries)

### DIFF
--- a/app/rerank.py
+++ b/app/rerank.py
@@ -15,12 +15,14 @@ from __future__ import annotations
 import logging
 import os
 import re
+import threading
 
 logger = logging.getLogger(__name__)
 
-# "alternatives to X" / "similar to X" / "like X" queries want the exact-named
-# repo; the offline eval showed reranking HURTS these (dense ordering wins), so
-# the caller skips reranking for them.
+# "alternatives to X" / "similar to X" / "replacement for X" queries want the
+# exact-named repo; the offline eval showed reranking HURTS these (dense ordering
+# wins), so the caller skips reranking for them. (Kept deliberately narrow to
+# avoid false positives like "I would like a tool for ...".)
 _NAME_LOOKUP_RE = re.compile(r"\b(alternatives?\s+to|similar\s+to|replacement\s+for)\b", re.I)
 
 
@@ -28,8 +30,10 @@ def is_name_lookup_query(question: str) -> bool:
     return bool(question and _NAME_LOOKUP_RE.search(question))
 
 _reranker = None
+_reranker_lock = threading.Lock()
 _DEFAULT_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"
 _DEFAULT_FETCH_N = 50
+_MAX_FETCH_N = 100  # hard cap so a bad env value cannot blow up DB fetch + rerank cost
 _MAX_TEXT_LEN = 512
 
 
@@ -38,11 +42,15 @@ def rerank_enabled() -> bool:
 
 
 def rerank_fetch_n() -> int:
-    """How many dense candidates to fetch for reranking (more than top_k)."""
+    """How many dense candidates to fetch for reranking (more than top_k), bounded."""
     try:
-        return max(1, int(os.environ.get("RERANK_FETCH_N", _DEFAULT_FETCH_N)))
+        val = int(os.environ.get("RERANK_FETCH_N", _DEFAULT_FETCH_N))
     except ValueError:
         return _DEFAULT_FETCH_N
+    clamped = min(max(1, val), _MAX_FETCH_N)
+    if clamped != val:
+        logger.warning("RERANK_FETCH_N=%s clamped to %d", val, clamped)
+    return clamped
 
 
 def _model_name() -> str:
@@ -50,13 +58,15 @@ def _model_name() -> str:
 
 
 def get_reranker():
-    """Lazy-load the CrossEncoder once (mirrors app.embeddings.get_embedding_model)."""
+    """Lazy-load the CrossEncoder once, concurrency-safe (mirrors get_embedding_model)."""
     global _reranker
     if _reranker is None:
-        from sentence_transformers import CrossEncoder
-        logger.info("Loading cross-encoder reranker %s ...", _model_name())
-        _reranker = CrossEncoder(_model_name())
-        logger.info("Cross-encoder reranker loaded")
+        with _reranker_lock:
+            if _reranker is None:  # double-checked: only the first caller loads
+                from sentence_transformers import CrossEncoder
+                logger.info("Loading cross-encoder reranker %s ...", _model_name())
+                _reranker = CrossEncoder(_model_name())
+                logger.info("Cross-encoder reranker loaded")
     return _reranker
 
 

--- a/app/rerank.py
+++ b/app/rerank.py
@@ -1,0 +1,85 @@
+"""Flag-gated local cross-encoder reranking of dense retrieval candidates.
+
+PROVEN (offline pooled-relevance eval) to significantly improve ranking on
+realistic semantic queries: nDCG@10 0.69 -> 0.82, MRR 0.87 -> 0.97 (95% CI
+excludes 0). Reuses the sentence-transformers stack the API already ships (the
+embedding model), so no new heavyweight dependency.
+
+OFF by default (RERANK_ENABLED!=1). The caller skips reranking for name-literal
+"alternatives to X" / "similar to X" queries, where dense alone wins. The main
+cost is latency (cross-encoder over the dense candidate set), so deploy is gated
+on an A/B + latency check.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+
+logger = logging.getLogger(__name__)
+
+# "alternatives to X" / "similar to X" / "like X" queries want the exact-named
+# repo; the offline eval showed reranking HURTS these (dense ordering wins), so
+# the caller skips reranking for them.
+_NAME_LOOKUP_RE = re.compile(r"\b(alternatives?\s+to|similar\s+to|replacement\s+for)\b", re.I)
+
+
+def is_name_lookup_query(question: str) -> bool:
+    return bool(question and _NAME_LOOKUP_RE.search(question))
+
+_reranker = None
+_DEFAULT_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+_DEFAULT_FETCH_N = 50
+_MAX_TEXT_LEN = 512
+
+
+def rerank_enabled() -> bool:
+    return os.environ.get("RERANK_ENABLED", "0") == "1"
+
+
+def rerank_fetch_n() -> int:
+    """How many dense candidates to fetch for reranking (more than top_k)."""
+    try:
+        return max(1, int(os.environ.get("RERANK_FETCH_N", _DEFAULT_FETCH_N)))
+    except ValueError:
+        return _DEFAULT_FETCH_N
+
+
+def _model_name() -> str:
+    return os.environ.get("RERANK_MODEL", _DEFAULT_MODEL)
+
+
+def get_reranker():
+    """Lazy-load the CrossEncoder once (mirrors app.embeddings.get_embedding_model)."""
+    global _reranker
+    if _reranker is None:
+        from sentence_transformers import CrossEncoder
+        logger.info("Loading cross-encoder reranker %s ...", _model_name())
+        _reranker = CrossEncoder(_model_name())
+        logger.info("Cross-encoder reranker loaded")
+    return _reranker
+
+
+def build_rerank_text(repo: dict, max_len: int = _MAX_TEXT_LEN) -> str:
+    """Concatenate the repo fields a cross-encoder should judge against the query."""
+    parts = []
+    for field in ("name", "forked_from", "description", "readme_summary", "problem_solved"):
+        val = repo.get(field)
+        if val:
+            parts.append(str(val))
+    return " ".join(parts)[:max_len]
+
+
+def rerank_candidates(question: str, scored: list[dict], *, model=None) -> list[dict]:
+    """Reorder `scored` (repo dicts) by cross-encoder relevance to `question`.
+
+    Returns a NEW list, best-first, each with a `rerank_score`. Empty or singleton
+    input is returned unchanged (nothing to reorder).
+    """
+    if not question or len(scored) < 2:
+        return scored
+    model = model or get_reranker()
+    pairs = [[question, build_rerank_text(r)] for r in scored]
+    ce_scores = model.predict(pairs, show_progress_bar=False)
+    order = sorted(range(len(scored)), key=lambda i: -float(ce_scores[i]))
+    return [dict(scored[i], rerank_score=float(ce_scores[i])) for i in order]

--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -2215,7 +2215,14 @@ async def _prepare_query(
         )
 
     # 2. Semantic cache check
-    cached = await _find_semantic_cache_hit(db, question_embedding=query_embedding)
+    # When reranking is enabled, BYPASS the semantic-cache READ: the cache holds
+    # dense-ordered answers, so serving them would mask the rerank and muddy any
+    # A/B. The rerank arm always computes fresh. (Write-side cache partitioning
+    # by rerank mode is a tracked pre-deploy follow-up before mixed-traffic use.)
+    cached = (
+        None if _rerank.rerank_enabled()
+        else await _find_semantic_cache_hit(db, question_embedding=query_embedding)
+    )
     if cached is not None:
         cached_answer, cached_sources, cached_model = cached
         return QueryContext(
@@ -2317,7 +2324,9 @@ async def _prepare_query(
     if (_rerank.rerank_enabled() and len(scored) > 1
             and not _rerank.is_name_lookup_query(question)):
         try:
-            scored = _rerank.rerank_candidates(question, scored)
+            # Offload the sync CPU/Torch work to a thread so it never blocks the
+            # event loop (and other /ask requests) on this async path.
+            scored = await asyncio.to_thread(_rerank.rerank_candidates, question, scored)
         except Exception as exc:  # never let reranking break the answer path
             logger.warning("rerank skipped (error): %s", exc)
     top_for_answer = scored[:top_k]

--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -42,6 +42,7 @@ from app.governance import (
 )
 from app.database import async_session_factory, get_db
 from app.embeddings import get_embedding_model
+from app import rerank as _rerank
 from app.models.session import AskSession
 from app.rate_limit import rate_limit_storage
 from app.slo_observer import token_observer
@@ -2240,7 +2241,13 @@ async def _prepare_query(
     vec_str = vec_to_pg(query_embedding)
 
     # 3. pgvector HNSW index scan — O(log N) instead of O(N) Python loop
-    fetch_k = top_k + 10
+    # Reranking (flag-gated, off by default) needs a larger candidate pool to
+    # reorder; otherwise the legacy top_k+10 fetch is preserved exactly.
+    fetch_k = (
+        max(top_k + 10, _rerank.rerank_fetch_n())
+        if _rerank.rerank_enabled()
+        else top_k + 10
+    )
     with _tracer.start_as_current_span("pgvector_search") as search_span:
         result = await db.execute(
             text("""
@@ -2302,6 +2309,17 @@ async def _prepare_query(
 
     # Sort descending by similarity
     scored.sort(key=lambda r: r["similarity"], reverse=True)
+
+    # Flag-gated cross-encoder rerank of the dense candidates. PROVEN (offline
+    # pooled-relevance eval) to significantly improve nDCG@10/MRR on realistic
+    # semantic queries. Skipped for name-lookup ("alternatives to X") queries
+    # where dense ordering wins. OFF by default; failures degrade to dense order.
+    if (_rerank.rerank_enabled() and len(scored) > 1
+            and not _rerank.is_name_lookup_query(question)):
+        try:
+            scored = _rerank.rerank_candidates(question, scored)
+        except Exception as exc:  # never let reranking break the answer path
+            logger.warning("rerank skipped (error): %s", exc)
     top_for_answer = scored[:top_k]
 
     # 4. Build context for Claude — KAN-ask-cache: context hygiene

--- a/tests/test_rerank.py
+++ b/tests/test_rerank.py
@@ -1,0 +1,90 @@
+"""Unit tests for the flag-gated cross-encoder reranking stage (app/rerank.py).
+
+Reranking the dense candidate set is a STATISTICALLY-PROVEN win on realistic
+semantic queries (offline eval: nDCG@10 0.69->0.82, MRR 0.87->0.97, 95% CI
+excludes 0) but it is OFF by default and skipped for name-literal "alternatives
+to X" queries where dense wins. These tests use a fake model (no download).
+"""
+import os
+
+import pytest
+
+from app import rerank
+
+
+class _FakeCE:
+    """Scores a (query, passage) pair 1.0 if passage mentions 'target' else 0.0."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def predict(self, pairs, **kw):
+        self.calls += 1
+        return [1.0 if "target" in p[1].lower() else 0.0 for p in pairs]
+
+
+def test_rerank_reorders_relevant_candidate_to_front():
+    scored = [
+        {"id": "1", "name": "alpha", "description": "unrelated"},
+        {"id": "2", "name": "beta", "description": "the target tool"},
+        {"id": "3", "name": "gamma", "description": "also unrelated"},
+    ]
+    out = rerank.rerank_candidates("q", scored, model=_FakeCE())
+    assert out[0]["id"] == "2"  # the 'target' doc is promoted to the front
+    assert {r["id"] for r in out} == {"1", "2", "3"}  # no docs lost
+
+
+def test_rerank_attaches_score_and_preserves_fields():
+    scored = [{"id": "2", "name": "x", "description": "target", "similarity": 0.3}]
+    # singleton is returned unchanged (no reorder needed) but must keep fields
+    out = rerank.rerank_candidates("q", scored, model=_FakeCE())
+    assert out[0]["id"] == "2" and out[0]["similarity"] == 0.3
+
+
+def test_rerank_multi_attaches_rerank_score():
+    scored = [{"id": "1", "description": "target"}, {"id": "2", "description": "no"}]
+    out = rerank.rerank_candidates("q", scored, model=_FakeCE())
+    assert "rerank_score" in out[0]
+
+
+def test_rerank_empty_and_singleton_unchanged():
+    assert rerank.rerank_candidates("q", [], model=_FakeCE()) == []
+    one = [{"id": "1", "description": "x"}]
+    assert rerank.rerank_candidates("q", one, model=_FakeCE()) == one
+
+
+def test_build_rerank_text_concatenates_and_truncates():
+    repo = {"name": "foo", "forked_from": "up/foo", "description": "d",
+            "readme_summary": "r", "problem_solved": "p"}
+    t = rerank.build_rerank_text(repo)
+    assert "foo" in t and "up/foo" in t and "r" in t
+    assert len(rerank.build_rerank_text({"description": "x" * 9999})) <= 512
+
+
+def test_flags_default_off(monkeypatch):
+    monkeypatch.delenv("RERANK_ENABLED", raising=False)
+    assert rerank.rerank_enabled() is False
+
+
+def test_flag_enabled_when_set(monkeypatch):
+    monkeypatch.setenv("RERANK_ENABLED", "1")
+    assert rerank.rerank_enabled() is True
+
+
+def test_fetch_n_default_and_override(monkeypatch):
+    monkeypatch.delenv("RERANK_FETCH_N", raising=False)
+    assert rerank.rerank_fetch_n() == 50
+    monkeypatch.setenv("RERANK_FETCH_N", "80")
+    assert rerank.rerank_fetch_n() == 80
+
+
+def test_name_lookup_queries_are_detected():
+    assert rerank.is_name_lookup_query("vector database alternatives to pinecone")
+    assert rerank.is_name_lookup_query("something similar to langchain")
+    assert rerank.is_name_lookup_query("replacement for redis")
+
+
+def test_semantic_queries_are_not_name_lookups():
+    assert not rerank.is_name_lookup_query("run large language models locally")
+    assert not rerank.is_name_lookup_query("framework for building agents")
+    assert not rerank.is_name_lookup_query("")

--- a/tests/test_rerank.py
+++ b/tests/test_rerank.py
@@ -78,6 +78,15 @@ def test_fetch_n_default_and_override(monkeypatch):
     assert rerank.rerank_fetch_n() == 80
 
 
+def test_fetch_n_is_clamped_and_bad_value_falls_back(monkeypatch):
+    monkeypatch.setenv("RERANK_FETCH_N", "100000")
+    assert rerank.rerank_fetch_n() == 100  # hard cap
+    monkeypatch.setenv("RERANK_FETCH_N", "0")
+    assert rerank.rerank_fetch_n() == 1     # floor
+    monkeypatch.setenv("RERANK_FETCH_N", "notanint")
+    assert rerank.rerank_fetch_n() == 50    # default on parse error
+
+
 def test_name_lookup_queries_are_detected():
     assert rerank.is_name_lookup_query("vector database alternatives to pinecone")
     assert rerank.is_name_lookup_query("something similar to langchain")


### PR DESCRIPTION
## What & why
Adds an OPTIONAL local cross-encoder reranking stage to the `/ask` dense-retrieval path. This is the one retrieval change that PASSED a rigorous offline gate.

**Evidence (self-owned pooled-relevance eval, paired bootstrap 95% CI):** on realistic developer queries, reranking the dense top-50 lifts **nDCG@10 0.691 -> 0.821 (+0.130, CI [+0.06,+0.20])** and **MRR 0.872 -> 0.965 (+0.094, CI [+0.02,+0.19])** -- both significant. (For comparison, swapping embeddings to bge-small *regressed* and was rejected; a flawed taxonomy-membership eval had *masked* the reranking win until we built LLM-judged qrels.)

## Design (safe, reversible)
- New `app/rerank.py` reusing the sentence-transformers stack the API already ships (no new heavyweight dep).
- **OFF by default** (`RERANK_ENABLED != 1`): the default retrieval path is byte-identical to today (`fetch_k = top_k + 10`, no rerank).
- When enabled: fetch `RERANK_FETCH_N` (default 50) dense candidates, reorder with a local CrossEncoder (`RERANK_MODEL`, default `ms-marco-MiniLM-L-6-v2`), slice `top_k`.
- **Skipped** for name-lookup ("alternatives to X") queries, where the eval showed dense ordering wins.
- Reranking failures **degrade gracefully** to dense order (try/except) -- never breaks the answer path.

## Tests
10 new unit tests (fake model, no download, deterministic); full suite **collects (777)**; ask code-hygiene passes.

## Deploy considerations (GATED -- not for auto-merge/deploy)
- The cross-encoder adds **latency** (scoring ~50 candidates/query on the serving box) -- the `/ask` path is already 1-11s, so A/B + a latency budget check before enabling in prod.
- **Pre-bake** the reranker model into the Docker image to avoid a cold-start download.
- Roll out behind the flag; enable for semantic traffic first.

Per repo policy this PR is for **human review** (no self-merge). Off-by-default makes it safe to merge to `dev` ahead of the deploy decision.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>