### PR TITLE
feat(ask): local $0 groundedness eval + stop re-serving thumbs-down from cache (reporium#433: #17, KAN-586)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## [Unreleased] - 2026-04-08
 
+### Fixed
+- **Thumbs-down answers no longer re-served from the semantic cache** (reporium#433 / KAN-586): `_find_semantic_cache_hit` now excludes `query_log` rows with `sentiment = 'negative'`. Previously a wrong/unhelpful answer that a user (or an admin via PATCH `/admin/asks`) marked thumbs-down could still be returned instantly from the semantic cache on the next near-identical question, propagating the bad answer indefinitely. The next identical query now falls through to a fresh generation. No-op for NULL/positive-sentiment rows.
+
 ### Added
+- **Local, $0 groundedness/faithfulness eval for /ask** (reporium#433 item #17): new `app/eval/groundedness.py` adapter over the merged `local-inference` verifier (Vectara HHEM-2.1-Open offline cross-encoder primary, local Ollama 7B NLI fallback) scores how well an `/ask` answer is grounded in its retrieved context. CI-safe: `verifier_available()` gates the real-verifier tests so they skip cleanly when no local backend is present (the default CI runner). Demo at `scripts/groundedness_eval.py`. Real HHEM run: grounded answer scored 0.9496, hallucinated answer 0.0094 over the same context (separation +0.9402). No frontier model, no paid API.
 - **Similar repos fallback**: If `/intelligence/similar/{owner}/{name}` returns zero candidates (repo has no categories or tags), falls back to surfacing repos sharing the same `primary_category`, ordered by star count.
 - **Edge type colors in 3D graph**: Knowledge graph edges now rendered in distinct colors per relationship type (amber=ALTERNATIVE_TO, green=COMPATIBLE_WITH, blue=DEPENDS_ON, violet=SIMILAR_TO, pink=EXTENDS).
 - **`/graph/edges` now returns typed relationship edges**: After fetching pgvector similarity edges, also queries the `repo_edges` table for ALTERNATIVE_TO, COMPATIBLE_WITH, DEPENDS_ON, EXTENDS edges. Typed edges override SIMILAR_TO when the same (source, target) pair exists. Degrades gracefully if `repo_edges` table is missing. `edgeTypes` field in response now lists all distinct types present in the data.

--- a/app/eval/__init__.py
+++ b/app/eval/__init__.py
@@ -1,0 +1,7 @@
+"""Local, $0 evaluation helpers for reporium-api.
+
+Currently exposes a groundedness / faithfulness scorer for /intelligence/ask
+answers (reporium#433, item #17). All backends are local (HHEM offline cross
+encoder, or the local Ollama 7B as a fallback NLI judge); no frontier model
+and no paid API are ever called.
+"""

--- a/app/eval/groundedness.py
+++ b/app/eval/groundedness.py
@@ -1,0 +1,147 @@
+"""Local, $0 groundedness / faithfulness eval for /intelligence/ask answers.
+
+reporium#433 (item #17). Given the retrieved context that an /ask answer was
+generated from, score how well the answer is *grounded in* (entailed by) that
+context. A low score means the model likely hallucinated -- it asserted things
+the retrieved repos do not support. This is the hallucination gate that lets an
+answer be measured (and, downstream, gated) before it is trusted.
+
+Design choices
+--------------
+* DOGFOODS the merged ``local-inference`` package: it owns the actual verifier
+  (Vectara HHEM-2.1-Open offline cross-encoder as the primary backend, falling
+  back to the local Ollama 7B as an NLI judge). We do NOT reimplement scoring
+  here -- this module is a thin, reporium-shaped adapter over
+  ``local_inference.eval.groundedness.GroundednessScorer``.
+* $0 ONLY. Every backend is local hardware. No frontier model, no paid API.
+* CI-SAFE. Importing this module never raises and never loads heavy weights.
+  ``verifier_available()`` reports whether a local backend can serve a request,
+  so tests and CI can ``skip`` cleanly when neither HHEM weights nor a reachable
+  Ollama are present (e.g. on a GitHub-hosted runner with no model cache).
+
+Typical use::
+
+    from app.eval.groundedness import grade_answer, verifier_available
+
+    if verifier_available():
+        result = grade_answer(context_text, answer_text)
+        print(result.score, result.grounded, result.backend)
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Literal, Optional
+
+# A claim scoring >= this is treated as grounded. Mirrors local-inference's
+# DEFAULT_THRESHOLD but is overridable per-call and via env for A/B work.
+DEFAULT_GROUNDEDNESS_THRESHOLD = 0.5
+
+Backend = Literal["hhem", "ollama", "auto"]
+
+
+@dataclass(frozen=True)
+class AnswerGroundedness:
+    """Groundedness verdict for a single (context, answer) pair.
+
+    ``score`` is P(answer grounded in context) in [0, 1] (1 = fully supported,
+    0 = contradicted/unsupported). ``grounded`` applies the threshold.
+    ``backend`` records which local $0 verifier served it ('hhem' or 'ollama').
+    ``rationale`` is populated only by the Ollama judge. ``latency_ms`` is the
+    per-pair scoring latency.
+    """
+
+    score: float
+    grounded: bool
+    backend: str
+    threshold: float
+    latency_ms: float
+    rationale: Optional[str] = None
+
+
+def _threshold(explicit: float | None) -> float:
+    if explicit is not None:
+        return explicit
+    raw = os.getenv("ASK_GROUNDEDNESS_THRESHOLD", "").strip()
+    if raw:
+        try:
+            return float(raw)
+        except ValueError:
+            pass
+    return DEFAULT_GROUNDEDNESS_THRESHOLD
+
+
+def verifier_available(backend: Backend = "auto") -> bool:
+    """True iff a local $0 groundedness backend can serve a request right now.
+
+    Tries to construct the scorer (which probes the HHEM cache and/or the
+    Ollama endpoint) and reports success. Never raises -- safe to call at the
+    top of a CI-skipped test. Construction is cheap when HHEM weights are
+    cached; the heavy model load only happens on first ``score``.
+    """
+    try:
+        _get_scorer(backend)
+        return True
+    except Exception:
+        return False
+
+
+# Module-level cache so repeated calls reuse the loaded HHEM weights.
+_SCORER = None
+_SCORER_BACKEND: str | None = None
+
+
+def _get_scorer(backend: Backend = "auto"):
+    """Return a cached local-inference GroundednessScorer.
+
+    Raises if the local-inference package is not installed or no local backend
+    is available; callers convert that into a skip / non-fatal path.
+    """
+    global _SCORER, _SCORER_BACKEND
+    if _SCORER is not None and _SCORER_BACKEND == backend:
+        return _SCORER
+    # Imported lazily so this module imports with zero heavy deps and CI that
+    # has not installed local-inference still collects the test (then skips).
+    from local_inference.eval.groundedness import GroundednessScorer  # noqa: PLC0415
+
+    _SCORER = GroundednessScorer(backend)
+    _SCORER_BACKEND = backend
+    return _SCORER
+
+
+def grade_answer(
+    context: str,
+    answer: str,
+    *,
+    threshold: float | None = None,
+    backend: Backend = "auto",
+    timeout: float = 60.0,
+) -> AnswerGroundedness:
+    """Score how grounded ``answer`` is in ``context`` using a local $0 verifier.
+
+    ``context`` is the retrieved-context block the /ask answer was generated
+    from (the same text fed to the LLM); ``answer`` is the model's reply. Higher
+    score == more faithful. Raises ``GroundednessError`` (from local-inference)
+    if no local backend is available -- gate on ``verifier_available()`` first
+    in CI.
+    """
+    scorer = _get_scorer(backend)
+    th = _threshold(threshold)
+    res = scorer.score(context, answer, timeout=timeout)
+    return AnswerGroundedness(
+        score=res.score,
+        grounded=res.score >= th,
+        backend=res.backend,
+        threshold=th,
+        latency_ms=res.latency_ms,
+        rationale=res.rationale,
+    )
+
+
+__all__ = [
+    "AnswerGroundedness",
+    "grade_answer",
+    "verifier_available",
+    "DEFAULT_GROUNDEDNESS_THRESHOLD",
+]

--- a/app/routers/intelligence.py
+++ b/app/routers/intelligence.py
@@ -1841,6 +1841,13 @@ async def _find_semantic_cache_hit(
     *,
     question_embedding: np.ndarray,
 ) -> tuple[str, list[SourceRepo], str | None] | None:
+    # KAN-586 / reporium#433: do NOT re-serve an answer that a user (or admin
+    # via PATCH /admin/asks) marked with sentiment='negative'. A thumbs-down
+    # answer was wrong/unhelpful for that question; serving it again from the
+    # semantic cache on the next near-identical query would propagate the bad
+    # answer indefinitely. Excluding negative rows here lets the next identical
+    # query fall through to a fresh generation instead. Rows with NULL/positive
+    # sentiment are still cache-eligible, so this is a no-op for the common case.
     question_embedding = _validate_query_embedding(question_embedding)
     result = await db.execute(
         text("""
@@ -1848,6 +1855,7 @@ async def _find_semantic_cache_hit(
             FROM query_log
             WHERE question_embedding_vec IS NOT NULL
               AND answer_full IS NOT NULL
+              AND (sentiment IS NULL OR sentiment <> 'negative')
               AND (question_embedding_vec <=> CAST(:vec AS vector)) < :distance_threshold
             ORDER BY question_embedding_vec <=> CAST(:vec AS vector)
             LIMIT 1

--- a/scripts/groundedness_eval.py
+++ b/scripts/groundedness_eval.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Local, $0 groundedness eval demo for /intelligence/ask answers (reporium#433 #17).
+
+Runs the local groundedness verifier (HHEM offline, else Ollama fallback) over a
+small fixed set of (retrieved-context, answer) pairs that mimic the /ask shape:
+one GROUNDED answer (only states things the context supports) and one
+HALLUCINATED answer (asserts facts the context never mentions). It prints the
+real score for each and asserts the grounded answer scores strictly higher than
+the hallucinated one -- the property the hallucination gate relies on.
+
+This is a manual / CI-on-demand tool, NOT part of the default pytest run, so it
+never blocks CI on model availability. Run it with the verifier present::
+
+    python scripts/groundedness_eval.py
+
+Exit code 0 == the verifier separated grounded from hallucinated; 2 == no local
+backend available (so nothing was proven); 1 == the separation property failed.
+Every backend is local hardware -- no paid API, no frontier model.
+"""
+
+from __future__ import annotations
+
+import sys
+
+# --- Fixtures: realistic /ask context + answers -----------------------------
+# CONTEXT is the kind of retrieved-repo block the /ask prompt builds. The two
+# answers are deliberately one faithful and one fabricated.
+CONTEXT = (
+    "vLLM (vllm-project/vllm) is a high-throughput and memory-efficient "
+    "inference engine for large language models. It introduces PagedAttention "
+    "to manage the KV cache and supports continuous batching of incoming "
+    "requests. It is written in Python and CUDA and has over 30000 stars on "
+    "GitHub. vLLM exposes an OpenAI-compatible HTTP server.\n"
+    "Ollama (ollama/ollama) lets you run open large language models locally. "
+    "It bundles model weights and a runtime and exposes a local REST API on "
+    "port 11434."
+)
+
+GROUNDED_ANSWER = (
+    "vLLM is a high-throughput inference engine for large language models that "
+    "uses PagedAttention and continuous batching, and it exposes an "
+    "OpenAI-compatible HTTP server. Ollama runs open LLMs locally and serves a "
+    "REST API on port 11434."
+)
+
+HALLUCINATED_ANSWER = (
+    "vLLM is a Rust database created by Google in 2012 for storing user "
+    "passwords, and it has 5 million stars. Ollama is a paid cloud service that "
+    "trains models on port 8080 and was acquired by Microsoft."
+)
+
+
+def main() -> int:
+    try:
+        from app.eval.groundedness import grade_answer, verifier_available
+    except Exception as exc:  # pragma: no cover - import guard
+        print(f"[skip] could not import the eval helper: {exc}")
+        return 2
+
+    if not verifier_available():
+        print(
+            "[skip] no local groundedness backend available "
+            "(HHEM weights not cached AND Ollama at 127.0.0.1:11434 unreachable). "
+            "Nothing was proven; this is expected on a bare CI runner."
+        )
+        return 2
+
+    grounded = grade_answer(CONTEXT, GROUNDED_ANSWER)
+    hallucinated = grade_answer(CONTEXT, HALLUCINATED_ANSWER)
+
+    print(f"backend           : {grounded.backend}")
+    print(f"threshold         : {grounded.threshold}")
+    print(
+        f"GROUNDED answer   : score={grounded.score:.4f} "
+        f"grounded={grounded.grounded} latency={grounded.latency_ms:.0f}ms"
+    )
+    print(
+        f"HALLUCINATED ans  : score={hallucinated.score:.4f} "
+        f"grounded={hallucinated.grounded} latency={hallucinated.latency_ms:.0f}ms"
+    )
+    print(f"separation (g-h)  : {grounded.score - hallucinated.score:+.4f}")
+
+    ok = grounded.score > hallucinated.score
+    if ok:
+        print("[pass] grounded answer scored strictly higher than the hallucinated one.")
+        return 0
+    print("[fail] verifier did NOT separate grounded from hallucinated.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_ask_groundedness_eval.py
+++ b/tests/test_ask_groundedness_eval.py
@@ -1,0 +1,142 @@
+"""reporium#433 item #17: local, $0 groundedness/faithfulness eval for /ask.
+
+These tests exercise ``app.eval.groundedness``, the reporium-side adapter over
+the merged ``local-inference`` verifier (HHEM offline cross-encoder primary,
+local Ollama 7B NLI fallback). They are CI-SAFE: if neither a local backend is
+available NOR the ``local-inference`` package is installed, the verifier tests
+skip cleanly instead of failing. The threshold / config logic is pure and runs
+everywhere.
+
+Why this matters: a low groundedness score means the /ask answer asserted facts
+the retrieved repos do not support -- i.e. the model hallucinated. Scoring it
+locally and for $0 is the gate that lets a hallucinated answer be caught before
+it is trusted.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from app.eval.groundedness import (
+    DEFAULT_GROUNDEDNESS_THRESHOLD,
+    AnswerGroundedness,
+    grade_answer,
+    verifier_available,
+)
+from app.eval import groundedness as ge
+
+
+# ---------------------------------------------------------------------------
+# Pure / config logic -- runs in any environment (no model, no DB).
+# ---------------------------------------------------------------------------
+
+def test_threshold_default_when_unset():
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("ASK_GROUNDEDNESS_THRESHOLD", None)
+        assert ge._threshold(None) == DEFAULT_GROUNDEDNESS_THRESHOLD
+
+
+def test_threshold_explicit_overrides_env():
+    with patch.dict(os.environ, {"ASK_GROUNDEDNESS_THRESHOLD": "0.9"}):
+        # An explicit arg wins over the env var.
+        assert ge._threshold(0.3) == 0.3
+
+
+def test_threshold_from_env():
+    with patch.dict(os.environ, {"ASK_GROUNDEDNESS_THRESHOLD": "0.75"}):
+        assert ge._threshold(None) == 0.75
+
+
+def test_threshold_bad_env_falls_back_to_default():
+    with patch.dict(os.environ, {"ASK_GROUNDEDNESS_THRESHOLD": "not-a-number"}):
+        assert ge._threshold(None) == DEFAULT_GROUNDEDNESS_THRESHOLD
+
+
+def test_verifier_available_is_non_raising_bool():
+    """Must never raise, even if local-inference is absent -- it's the CI gate."""
+    val = verifier_available()
+    assert isinstance(val, bool)
+
+
+def test_grade_answer_threshold_applied_with_stubbed_backend():
+    """grade_answer applies the threshold to the backend's score. Stub the
+    local-inference scorer so this runs without any model."""
+
+    class _StubResult:
+        score = 0.8
+        backend = "hhem"
+        latency_ms = 5.0
+        rationale = None
+
+    class _StubScorer:
+        def score(self, context, answer, timeout=60.0):
+            return _StubResult()
+
+    with patch.object(ge, "_get_scorer", return_value=_StubScorer()):
+        # 0.8 >= 0.5 -> grounded
+        r = grade_answer("ctx", "ans", threshold=0.5)
+        assert isinstance(r, AnswerGroundedness)
+        assert r.score == 0.8
+        assert r.grounded is True
+        assert r.backend == "hhem"
+        # 0.8 < 0.9 -> not grounded
+        r2 = grade_answer("ctx", "ans", threshold=0.9)
+        assert r2.grounded is False
+
+
+# ---------------------------------------------------------------------------
+# Real verifier -- skipped when no local backend is available (CI-safe).
+# ---------------------------------------------------------------------------
+
+requires_verifier = pytest.mark.skipif(
+    not verifier_available(),
+    reason="no local groundedness backend (HHEM weights uncached AND Ollama unreachable)",
+)
+
+
+# A realistic /ask-shaped retrieved-context block.
+_CONTEXT = (
+    "vLLM (vllm-project/vllm) is a high-throughput, memory-efficient inference "
+    "engine for large language models. It uses PagedAttention to manage the KV "
+    "cache and supports continuous batching. It exposes an OpenAI-compatible "
+    "HTTP server and is written in Python and CUDA."
+)
+_GROUNDED = (
+    "vLLM is a high-throughput LLM inference engine that uses PagedAttention "
+    "and continuous batching and exposes an OpenAI-compatible HTTP server."
+)
+_HALLUCINATED = (
+    "vLLM is a Rust database built by Google in 2012 to store passwords, and it "
+    "has 5 million GitHub stars."
+)
+
+
+@requires_verifier
+def test_grounded_answer_scores_high():
+    r = grade_answer(_CONTEXT, _GROUNDED)
+    assert r.backend in ("hhem", "ollama")
+    # A faithful answer must clear the default decision threshold.
+    assert r.score >= DEFAULT_GROUNDEDNESS_THRESHOLD, r
+    assert r.grounded is True
+
+
+@requires_verifier
+def test_hallucinated_answer_scores_low():
+    r = grade_answer(_CONTEXT, _HALLUCINATED)
+    # A fabricated answer must fall below the threshold.
+    assert r.score < DEFAULT_GROUNDEDNESS_THRESHOLD, r
+    assert r.grounded is False
+
+
+@requires_verifier
+def test_grounded_strictly_beats_hallucinated():
+    """The core property the hallucination gate relies on: a faithful answer
+    scores strictly higher than a fabricated one over the same context."""
+    g = grade_answer(_CONTEXT, _GROUNDED)
+    h = grade_answer(_CONTEXT, _HALLUCINATED)
+    assert g.score > h.score, (g, h)
+    # And the gap is meaningful, not noise.
+    assert (g.score - h.score) > 0.2, (g.score, h.score)

--- a/tests/test_ask_thumbs_down_eviction.py
+++ b/tests/test_ask_thumbs_down_eviction.py
@@ -1,0 +1,157 @@
+"""KAN-586 / reporium#433: a thumbs-down answer must NOT be re-served from the
+semantic cache.
+
+Root cause: ``_find_semantic_cache_hit`` selected the nearest prior answer by
+embedding distance with no regard for whether a user (or admin via PATCH
+/admin/asks) had marked it sentiment='negative'. So once a wrong/unhelpful
+answer landed in query_log, the next near-identical question kept getting that
+same bad answer served instantly from cache -- the feedback loop did nothing.
+
+Fix: the cache lookup now excludes rows with sentiment='negative'. These tests
+prove (a) the SQL carries the exclusion filter, and (b) end-to-end against a
+real Postgres (DB-gated, skipped in CI without a DB) a negative row is skipped
+while a sibling positive/neutral row is still served.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import numpy as np
+import pytest
+from httpx import AsyncClient
+from sqlalchemy import text
+
+from app.database import async_session_factory
+from app.routers.intelligence import _find_semantic_cache_hit
+
+
+def _emb() -> np.ndarray:
+    return np.full(384, 0.1, dtype=np.float32)
+
+
+@pytest.mark.asyncio
+async def test_semantic_cache_query_excludes_negative_sentiment():
+    """The lookup SQL must filter out sentiment='negative' rows so a
+    thumbs-down answer is never a cache candidate."""
+    captured: dict = {}
+
+    async def fake_execute(stmt, params=None):
+        captured["sql"] = str(stmt)
+        captured["params"] = params
+        return SimpleNamespace(first=lambda: None)
+
+    db = AsyncMock()
+    db.execute = fake_execute
+
+    result = await _find_semantic_cache_hit(db, question_embedding=_emb())
+
+    assert result is None  # no row -> falls through to fresh generation
+    sql = captured["sql"].lower()
+    # The exclusion filter must be present and reference the sentiment column.
+    assert "sentiment" in sql, captured["sql"]
+    assert "negative" in sql, captured["sql"]
+    # Belt-and-braces: a NULL or non-negative sentiment is still cache-eligible.
+    assert "is null" in sql or "<> 'negative'" in sql, captured["sql"]
+
+
+@pytest.mark.asyncio
+async def test_positive_and_neutral_rows_still_served():
+    """A row that is NOT thumbs-down (the DB returns it because it passed the
+    sentiment filter) is still returned by the cache lookup -- the fix is a
+    no-op for the common case and only suppresses negatives."""
+    row = SimpleNamespace(
+        answer_full="Helpful cached answer",
+        sources=[{"owner": "perditioinc", "name": "reporium", "relevance_score": 0.9}],
+        model="claude-sonnet-4-20250514",
+    )
+    db = AsyncMock()
+    db.execute = AsyncMock(return_value=SimpleNamespace(first=lambda: row))
+
+    cached = await _find_semantic_cache_hit(db, question_embedding=_emb())
+
+    assert cached is not None
+    answer, sources, model = cached
+    assert answer == "Helpful cached answer"
+    assert sources[0].owner == "perditioinc"
+
+
+# ---------------------------------------------------------------------------
+# DB-gated end-to-end proof: requires a real Postgres with pgvector. Skips
+# cleanly in CI without a DB (mirrors conftest's _test_db_available gate).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_thumbs_down_row_evicted_end_to_end(client: AsyncClient):
+    """Insert two near-identical cached answers; mark one sentiment='negative'.
+    The lookup must return the NON-negative answer, never the thumbs-down one.
+
+    Depends on the ``client`` fixture only to pull in conftest's ``_setup_db``
+    (which creates the schema + the question_embedding_vec column). DB-gated:
+    skips cleanly in CI without a reachable Postgres.
+    """
+    base = [0.05] * 384
+    near = [0.05] * 384
+    near[0] = 0.051  # tiny perturbation -> still within the distance threshold
+
+    def _vec_literal(v):
+        return "[" + ",".join(f"{x:.6f}" for x in v) + "]"
+
+    async with async_session_factory() as session:
+        # Clean slate for determinism.
+        await session.execute(text("DELETE FROM query_log"))
+        # Negative (thumbs-down) row -- closest to the query.
+        await session.execute(
+            text(
+                """
+                INSERT INTO query_log
+                    (question, answer_full, sources, model, sentiment,
+                     question_embedding_vec)
+                VALUES
+                    (:q, :a, CAST(:s AS jsonb), :m, 'negative',
+                     CAST(:vec AS vector))
+                """
+            ),
+            {
+                "q": "what is vllm",
+                "a": "WRONG thumbs-down answer",
+                "s": "[]",
+                "m": "test-model",
+                "vec": _vec_literal(base),
+            },
+        )
+        # Positive row -- slightly further but still within threshold.
+        await session.execute(
+            text(
+                """
+                INSERT INTO query_log
+                    (question, answer_full, sources, model, sentiment,
+                     question_embedding_vec)
+                VALUES
+                    (:q, :a, CAST(:s AS jsonb), :m, 'positive',
+                     CAST(:vec AS vector))
+                """
+            ),
+            {
+                "q": "what is vllm engine",
+                "a": "GOOD positive answer",
+                "s": "[]",
+                "m": "test-model",
+                "vec": _vec_literal(near),
+            },
+        )
+        await session.commit()
+
+    async with async_session_factory() as session:
+        cached = await _find_semantic_cache_hit(
+            session, question_embedding=np.array(base, dtype=np.float32)
+        )
+
+    # The closest row is the negative one; it MUST be skipped. We get the
+    # positive sibling -- never the thumbs-down answer.
+    assert cached is not None, "positive sibling should still be cache-eligible"
+    answer, _sources, _model = cached
+    assert answer == "GOOD positive answer"
+    assert answer != "WRONG thumbs-down answer"


### PR DESCRIPTION
## What

Two changes for the Reporium self-improving loop (tracking epic: perditioinc/reporium#433):

### 1. Local, \$0 groundedness/faithfulness eval for `/ask` (item #17)
Adds `app/eval/groundedness.py`, a thin reporium-side adapter over the merged `local-inference` verifier:
- **Primary backend**: Vectara HHEM-2.1-Open, an offline cross-encoder fine-tuned for hallucination detection (runs on CPU, fully offline once cached).
- **Fallback backend**: the local Ollama 7B as a constrained-JSON NLI judge.

Given the retrieved-context block an `/ask` answer was generated from, it scores how grounded the answer is in that context (1 = fully supported, 0 = contradicted/unsupported). A low score means the model likely hallucinated.

**CI-safe by design**: `verifier_available()` probes for a local backend without raising. The real-verifier tests are gated behind it and **skip cleanly** when no backend is present (the default CI runner does not install `local-inference`). The module imports with zero heavy deps; pure threshold/config logic runs everywhere.

A runnable demo lives at `scripts/groundedness_eval.py`.

### 2. Stop re-serving thumbs-down answers from the semantic cache (KAN-586)
`_find_semantic_cache_hit` now excludes `query_log` rows with `sentiment = 'negative'`.

Previously, once an answer was marked thumbs-down (by a user, or by an admin via PATCH `/admin/asks`), the semantic cache could still return that same wrong/unhelpful answer instantly on the next near-identical question, so the feedback signal did nothing. The lookup now skips negative rows, letting the next identical query fall through to a fresh generation. It is a no-op for NULL/positive-sentiment rows.

## Proof (real numbers)

`scripts/groundedness_eval.py`, HHEM backend, same context, grounded vs hallucinated answer:

```
backend           : hhem
threshold         : 0.5
GROUNDED answer   : score=0.9496 grounded=True
HALLUCINATED ans  : score=0.0094 grounded=False
separation (g-h)  : +0.9402
```

The grounded answer clears the 0.5 decision threshold; the hallucinated one is well below it.

## Tests
- `tests/test_ask_groundedness_eval.py`: pure threshold/config logic (runs everywhere) + 3 real-verifier tests (grounded scores high, hallucinated scores low, grounded strictly beats hallucinated by >0.2) that skip when no local backend is available.
- `tests/test_ask_thumbs_down_eviction.py`: unit assertions that the cache SQL carries the `sentiment <> 'negative'` exclusion + a DB-gated end-to-end test (insert a negative + positive near-duplicate, prove the negative is never served).
- Full suite: **545 passed, 234 skipped, 0 failed** (skips are DB-gated / no-local-backend; no regression vs baseline).

## Cost & scope
\$0: every backend is local hardware. No frontier model, no paid API. No deploy, no prod/secret/GCP changes, no DB migration (uses the existing `sentiment` column).

## Review note
This repo requires **human review** - please do not auto-merge. Left open for the operator.